### PR TITLE
Fixed: ServiceUser can't be changed on Server 2008

### DIFF
--- a/lib/core/icingaagent/setters/Set-IcingaAgentServiceUser.psm1
+++ b/lib/core/icingaagent/setters/Set-IcingaAgentServiceUser.psm1
@@ -16,7 +16,7 @@ function Set-IcingaAgentServiceUser()
         $User = [string]::Format('.\{0}', $User);
     }
 
-    $ArgString = 'config {0} obj= "{1}" password="{2}"';
+    $ArgString = 'config {0} obj= "{1}" password= "{2}"';
     if($null -eq $Password) {
         $ArgString = 'config {0} obj= "{1}"{2}';
     }


### PR DESCRIPTION
Added a space to fix sc.exe not changing user on Windows Server 2008 because it expects a space between 'password=' and '"{2}"'