### PR TITLE
Bugfix: Handle multiple network interfaces on discovery and add support for Windows 2008 R2

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#059](https://github.com/Icinga/icinga-powershell-framework/issues/059), [#060](https://github.com/Icinga/icinga-powershell-framework/pull/060) Fixes interface handling for multiple interfaces and returns only the main interface by fallback to routing table and adds support for Windows 2008 R2
 * [#127](https://github.com/Icinga/icinga-powershell-framework/issues/127) Fixes wrong error message on failed MSSQL connection due to database not reachable by using `-IntegratedSecurity`
 * [#128](https://github.com/Icinga/icinga-powershell-framework/issues/128) Fixes unhandled output from loading `System.Reflection.Assembly` which can cause weird side effects for plugin outputs
 * [#130](https://github.com/Icinga/icinga-powershell-framework/issues/130) Fix crash while running services as background task to collect metrics over time by missing Performance Counter cache initialisation

--- a/lib/core/tools/Get-IcingaNetworkRoute.psm1
+++ b/lib/core/tools/Get-IcingaNetworkRoute.psm1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+   Fetch the used interface for our Windows System
+.DESCRIPTION
+   Newer Windows systems provide a Cmdlet 'Get-NetRoute' for fetching the
+   network route configurations. Older systems however do not provide this
+   and to ensure some sort of backwards compatibility, we will have a look
+   on our route configuration and return the first valid interface found
+.FUNCTIONALITY
+   This Cmdlet will return first valid IP for our interface
+.EXAMPLE
+   PS>Get-IcingaNetworkRoute
+.OUTPUTS
+   System.Array
+.LINK
+   https://github.com/Icinga/icinga-powershell-framework
+.NOTES
+#>
+
+function Get-IcingaNetworkRoute()
+{
+    $RouteConfig = (&route print | Where-Object {
+        $_.TrimStart() -Like "0.0.0.0*";
+    }).Split() | Where-Object {
+        return $_;
+    };
+
+    $Interface   = @{
+        'Destination' = $RouteConfig[0];
+        'Netmask'     = $RouteConfig[1];
+        'Gateway'     = $RouteConfig[2];
+        'Interface'   = $RouteConfig[3];
+        'Metric'      = $RouteConfig[4];
+    }
+
+    return $Interface;
+}


### PR DESCRIPTION
Author: @LordHepipud

Tasks @LordHepipud:
- [x] Add solution to fetch network routes on Windows systems not providing `Get-NetRoute`
- [x] Testing
- [x] User Feedback

Testing:

```powershell
powershell -C { Use-Icinga; Get-IcingaNetworkInterface <icinga_server> }
```

Replace `<icinga_server>` with the IP / FQDN of your Icinga 2 Master / Satellite and check if the correct IP of your local interface is returned which should be added to Icinga 2 for monitoring and connecting.