### PR TITLE
fix Problem with existing 'InstallDir' while running Install-IcingaAgent

### DIFF
--- a/lib/core/icingaagent/installer/Install-IcingaAgent.psm1
+++ b/lib/core/icingaagent/installer/Install-IcingaAgent.psm1
@@ -46,8 +46,8 @@ function Install-IcingaAgent()
     if ([string]::IsNullOrEmpty($InstallDir) -eq $FALSE) {
         if ((Test-Path $InstallDir) -eq $FALSE) {
             New-Item -Path $InstallDir -Force | Out-Null;
-            $InstallTarget = $InstallDir;
         }
+        $InstallTarget = $InstallDir;
     }
 
     [string]$InstallFolderMsg = $InstallTarget;


### PR DESCRIPTION
If the check ((Test-Path $InstallDir) -eq $FALSE) is negative, i.e. the directory 'InstallDir' already exists, 'InstallDir' is not taken.

There are several reasons, for example a new installation, which require that the directory exists. Provided that custom checks were previously installed in 'InstallDir'.

Moving the setting of 'InstallTarget' outside the path check / directory creation ensures that 'InstallDir' is taken care of if the check is negative.