### PR TITLE
Fixes MSSQL error handling on Integrated Security

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -11,6 +11,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/10?closed=1)
 
+### Bugfixes
+
+* [#127](https://github.com/Icinga/icinga-powershell-framework/issues/127) Fixes wrong error message on failed MSSQL connection due to database not reachable by using `-IntegratedSecurity`
+
 ## 1.2.0 (2020-08-28)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/7?closed=1)

--- a/lib/mssql/Open-IcingaMSSQLConnection.psm1
+++ b/lib/mssql/Open-IcingaMSSQLConnection.psm1
@@ -89,11 +89,13 @@ function Open-IcingaMSSQLConnection()
             return $null;
         }
 
-        Exit-IcingaThrowException `
-            -InputString $_.Exception.Message `
-            -StringPattern $Username `
-            -ExceptionType 'Input' `
-            -ExceptionThrown $IcingaExceptions.Inputs.MSSQLCredentialHandling;
+        if ([string]::IsNullOrEmpty($Username) -eq $FALSE) {
+            Exit-IcingaThrowException `
+                -InputString $_.Exception.Message `
+                -StringPattern $Username `
+                -ExceptionType 'Input' `
+                -ExceptionThrown $IcingaExceptions.Inputs.MSSQLCredentialHandling;
+        }
 
         Exit-IcingaThrowException `
             -InputString $_.Exception.Message `


### PR DESCRIPTION
While using `IntegratedSecurity` for authentication, the error message printed in case the connection is not possible is stating invalid credentials instead of connection not possible