### PR TITLE
Fixes uncatched invisible output on Start-IcingaTimer

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#127](https://github.com/Icinga/icinga-powershell-framework/issues/127) Fixes wrong error message on failed MSSQL connection due to database not reachable by using `-IntegratedSecurity`
+* [#128](https://github.com/Icinga/icinga-powershell-framework/issues/128) Fixes unhandled output from loading `System.Reflection.Assembly` which can cause weird side effects for plugin outputs
 
 ## 1.2.0 (2020-08-28)
 

--- a/lib/core/framework/Start-IcingaTimer.psm1
+++ b/lib/core/framework/Start-IcingaTimer.psm1
@@ -32,7 +32,7 @@ function Start-IcingaTimer()
     }
 
     # Load the library first
-    [System.Reflection.Assembly]::LoadWithPartialName("System.Diagnostics");
+    [System.Reflection.Assembly]::LoadWithPartialName("System.Diagnostics") | Out-Null;
     $TimerObject = New-Object System.Diagnostics.Stopwatch;
     $TimerObject.Start();
 


### PR DESCRIPTION
`Start-IcingaTiemer` is using `System.Reflection.Assembly` which creates an yet uncatched return value.