### PR TITLE
Bugfix: Fix crash on background service execution caused by missing Perf Data cache

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -15,6 +15,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#127](https://github.com/Icinga/icinga-powershell-framework/issues/127) Fixes wrong error message on failed MSSQL connection due to database not reachable by using `-IntegratedSecurity`
 * [#128](https://github.com/Icinga/icinga-powershell-framework/issues/128) Fixes unhandled output from loading `System.Reflection.Assembly` which can cause weird side effects for plugin outputs
+* [#130](https://github.com/Icinga/icinga-powershell-framework/issues/130) Fix crash while running services as background task to collect metrics over time by missing Performance Counter cache initialisation
 
 ## 1.2.0 (2020-08-28)
 

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -43,7 +43,6 @@ function Use-Icinga()
                 'DebugMode'                = $DebugMode;
             }
         );
-        New-IcingaPerformanceCounterCache;
     } else {
         # This will fix the debug mode in case we are only using Libs
         # without any other variable content and daemon handling
@@ -57,6 +56,7 @@ function Use-Icinga()
             $global:IcingaDaemonData.FrameworkRunningAsDaemon = $Daemon;
         }
     }
+    New-IcingaPerformanceCounterCache;
 
     # Enable DebugMode in case it is enabled in our config
     if (Get-IcingaFrameworkDebugMode) {


### PR DESCRIPTION
Fix crash while running services as background task to collect metrics over time by missing Performance Counter cache initialisation.

Fixes #129