### PR TITLE
Bugfix: Fixing value overflow on Convert-Bytes Cmdlet

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -22,6 +22,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#127](https://github.com/Icinga/icinga-powershell-framework/issues/127) Fixes wrong error message on failed MSSQL connection due to database not reachable by using `-IntegratedSecurity`
 * [#128](https://github.com/Icinga/icinga-powershell-framework/issues/128) Fixes unhandled output from loading `System.Reflection.Assembly` which can cause weird side effects for plugin outputs
 * [#130](https://github.com/Icinga/icinga-powershell-framework/issues/130) Fix crash while running services as background task to collect metrics over time by missing Performance Counter cache initialisation
+* [#138](https://github.com/Icinga/icinga-powershell-framework/issues/138) Fixes possible value overflow on `Convert-Bytes` while converting from anything larger than MB to Bytes
 
 ## 1.2.0 (2020-08-28)
 

--- a/lib/core/tools/Convert-Bytes.psm1
+++ b/lib/core/tools/Convert-Bytes.psm1
@@ -33,7 +33,7 @@ function Convert-Bytes()
                 }
             }
         }
-        return @{'value' = $FinalValue; 'pastunit' = $CurrentUnit; 'endunit' = $Unit };
+        return @{'value' = ([decimal]$FinalValue); 'pastunit' = $CurrentUnit; 'endunit' = $Unit };
     }
 
     Exit-IcingaThrowException -ExceptionType 'Input' -ExceptionThrown $IcingaExceptions.Inputs.ConversionUnitMissing -Force;


### PR DESCRIPTION
Fixes an issue while converting data size values from any other datatype to bytes which will cause an overflow and might result in issues during comparison.