### PR TITLE
Disable OnSameLine & don't check space before open brace

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -34,7 +34,7 @@
         };
         PSPlaceOpenBrace           = @{
             Enable             = $true
-            OnSameLine         = $true
+            OnSameLine         = $false
             NewLineAfter       = $true
             IgnoreOneLineBlock = $true
         };
@@ -52,7 +52,7 @@
         };
         PSUseConsistentWhitespace  = @{
             Enable         = $true
-            CheckOpenBrace = $true
+            CheckOpenBrace = $false
             CheckOpenParen = $true
             CheckOperator  = $false
             CheckSeparator = $true

--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -25,6 +25,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#130](https://github.com/Icinga/icinga-powershell-framework/issues/130) Fix crash while running services as background task to collect metrics over time by missing Performance Counter cache initialisation
 * [#138](https://github.com/Icinga/icinga-powershell-framework/issues/138) Fixes possible value overflow on `Convert-Bytes` while converting from anything larger than MB to Bytes
 * [#140](https://github.com/Icinga/icinga-powershell-framework/issues/140) Fixes version fetching for not loaded modules during upgrades/plugin calls with `Get-IcingaPowerShellModuleVersion`
+* [#143](https://github.com/Icinga/icinga-powershell-framework/issues/143) Fixes the annoying hint from the analyzer to check space before open brace
 
 ## 1.2.0 (2020-08-28)
 


### PR DESCRIPTION
Because the script analyzer often complains that we can always use the
function open brace on the same line as the function name, which is not
the case, I finally decided to correct this today. I set the attribute
OnSameLine to False and disabled the check for space before open Brace.