### PR TITLE
Fix: Icinga API being disabled after successfull certificate installation

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -22,6 +22,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#059](https://github.com/Icinga/icinga-powershell-framework/issues/059), [#060](https://github.com/Icinga/icinga-powershell-framework/pull/060) Fixes interface handling for multiple interfaces and returns only the main interface by fallback to routing table and adds support for Windows 2008 R2
+* [#114](https://github.com/Icinga/icinga-powershell-framework/issues/114)[#146](https://github.com/Icinga/icinga-powershell-framework/pull/146) Fixes Icinga Agent API being wrongly disabled after successful certificate configuration and installation
 * [#127](https://github.com/Icinga/icinga-powershell-framework/issues/127) Fixes wrong error message on failed MSSQL connection due to database not reachable by using `-IntegratedSecurity`
 * [#128](https://github.com/Icinga/icinga-powershell-framework/issues/128) Fixes unhandled output from loading `System.Reflection.Assembly` which can cause weird side effects for plugin outputs
 * [#130](https://github.com/Icinga/icinga-powershell-framework/issues/130) Fix crash while running services as background task to collect metrics over time by missing Performance Counter cache initialisation

--- a/lib/core/icingaagent/misc/Start-IcingaAgentInstallWizard.psm1
+++ b/lib/core/icingaagent/misc/Start-IcingaAgentInstallWizard.psm1
@@ -561,7 +561,7 @@ function Start-IcingaAgentInstallWizard()
             Install-IcingaAgentBaseFeatures;
             $CertsInstalled = Install-IcingaAgentCertificates -Hostname $Hostname -Endpoint $CAEndpoint -Port $CAPort -CACert $CAFile -Ticket $Ticket;
             Write-IcingaAgentApiConfig -Port $CAPort;
-            if ($EmptyCA -eq $TRUE -Or $CertsInstalled -eq $FALSE) {
+            if ($EmptyCA -eq $TRUE -And $CertsInstalled -eq $FALSE) {
                 Disable-IcingaAgentFeature 'api';
                 Write-IcingaConsoleWarning `
                     -Message '{0}{1}{2}{3}{4}' `


### PR DESCRIPTION
Fixes Icinga Agent API being wrongly disabled after successful certificate configuration and installation

Fixes #114 