### PR TITLE
Fix: Array handling for ValidateSet and array rendering for config generator

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -31,6 +31,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#138](https://github.com/Icinga/icinga-powershell-framework/issues/138) Fixes possible value overflow on `Convert-Bytes` while converting from anything larger than MB to Bytes
 * [#140](https://github.com/Icinga/icinga-powershell-framework/issues/140) Fixes version fetching for not loaded modules during upgrades/plugin calls with `Get-IcingaPowerShellModuleVersion`
 * [#143](https://github.com/Icinga/icinga-powershell-framework/issues/143) Fixes the annoying hint from the analyzer to check space before open brace
+* [#152](https://github.com/Icinga/icinga-powershell-framework/issues/152) Fixes incorrect rendering for empty arrays which used `$null` incorrectly instead of `@()` and fixed ValidateSet which now also supports arrays as data type
 
 ## 1.2.0 (2020-08-28)
 

--- a/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
+++ b/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
@@ -165,7 +165,7 @@ function Get-IcingaCheckCommandConfig()
                         'value' = @{
                             'type' = 'Function';
                             'body' = [string]::Format(
-                                'var arr = macro("{0}");{1}if (len(arr) == 0) {2}{1}return "$null";{1}{3}{1}return arr.join(",");',
+                                'var arr = macro("{0}");{1}if (len(arr) == 0) {2}{1}return "@()";{1}{3}{1}return arr.join(",");',
                                 $IcingaCustomVariable,
                                 "`r`n",
                                 '{',
@@ -259,10 +259,16 @@ function Get-IcingaCheckCommandConfig()
                 );
 
                 if ($IsDataList) {
+                    [string]$DataListDataType = 'string';
+
+                    if ($parameter.type.name -eq 'Array') {
+                        $DataListDataType = 'array';
+                    }
+
                     $Basket.Datafield[[string]$FieldID].Add(
                         'settings', @{
                             'datalist'  = $DataListName;
-                            'data_type' = 'string';
+                            'data_type' = $DataListDataType;
                             'behavior'  = 'strict';
                         }
                     );


### PR DESCRIPTION
Empty arrays will now properly be rendered as empty array with `@()`instead of `$null`. In addition the config renderer now also supports ValidateSet for array entries