### PR TITLE
Feature: Add debug output for Get-IcingaWindowsInformation calls to EventLog

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -20,6 +20,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#134](https://github.com/Icinga/icinga-powershell-framework/pull/134) Adds Cmdlet `Test-IcingaWindowsInformation` to check if a WMI class exist and if we can fetch data from it. In addition we add support for binary value comparison with the new Cmdlet `Test-IcingaBinaryOperator`
 * [#142](https://github.com/Icinga/icinga-powershell-framework/pull/142) **Experimental:** Adds feature to cache the Framework code into a single file to speed up the entire loading process, mitigating the impact on performance on systems with few CPU cores. You enable disables this feature by using `Enable-IcingaFrameworkCodeCache` and `Disable-IcingaFrameworkCodeCache`. Updating the cache is done with `Write-IcingaFrameworkCodeCache`
 * [#149](https://github.com/Icinga/icinga-powershell-framework/pull/149) Adds support to add Wmi permissions for a specific user and namespace with `Add-IcingaWmiPermissions`. In addition you can remove users from Wmi namespaces by using `Remove-IcingaWmiPermissions`
+* [#155](https://github.com/Icinga/icinga-powershell-framework/pull/155) Adds support to write all objects collected by `Get-IcingaWindowsInformation` into the Windows EventLog in case the debug output for the Icinga PowerShell Framework is enabled.
 
 ### Bugfixes
 

--- a/lib/wmi/Get-IcingaWindowsInformation.psm1
+++ b/lib/wmi/Get-IcingaWindowsInformation.psm1
@@ -55,7 +55,11 @@ function Get-IcingaWindowsInformation()
 
     if ($ForceWMI -eq $FALSE -And (Get-Command 'Get-CimInstance' -ErrorAction SilentlyContinue)) {
         try {
-            return (Get-CimInstance @Arguments -ErrorAction Stop);
+            $CimData = (Get-CimInstance @Arguments -ErrorAction Stop);
+
+            Write-IcingaDebugMessage 'Debug output for "Get-IcingaWindowsInformation::Get-CimInstance"' -Objects $ClassName, $Filter, $Namespace, ($CimData | Out-String);
+
+            return $CimData;
         } catch {
             $ErrorName    = $_.Exception.NativeErrorCode;
             $ErrorMessage = $_.Exception.Message;
@@ -84,7 +88,11 @@ function Get-IcingaWindowsInformation()
 
     if ((Get-Command 'Get-WmiObject' -ErrorAction SilentlyContinue)) {
         try {
-            return (Get-WmiObject @Arguments -ErrorAction Stop);
+            $WmiData = (Get-WmiObject @Arguments -ErrorAction Stop);
+
+            Write-IcingaDebugMessage 'Debug output for "Get-IcingaWindowsInformation::Get-WmiObject"' -Objects $ClassName, $Filter, $Namespace, ($WmiData | Out-String);
+
+            return $WmiData;
         } catch {
             $ErrorName    = $_.CategoryInfo.Category;
             $ErrorMessage = $_.Exception.Message;


### PR DESCRIPTION
Adds support to write all objects collected by `Get-IcingaWindowsInformation` into the Windows EventLog in case the debug output for the Icinga PowerShell Framework is enabled.