### PR TITLE
Doc: Updates WMI KB for Winmgmt service restart

### DIFF
--- a/doc/knowledgebase/IWKB000001.md
+++ b/doc/knowledgebase/IWKB000001.md
@@ -39,6 +39,20 @@ Add-IcingaWmiPermissions -User 'icinga' -Namespace 'root\Microsoft\Windows\Stora
 
 The above command will grant the user `icinga` the read and remote access permission for the `root\Microsoft\Windows\Storage` namespace. In addition by using `-Recurse` we will set the permissions for `subnamespaces` in addition.
 
+To fully apply the changes, it might be required to restart the Wmi service `Winmgmt`. How ever, you are running a Hyper-V server for example, the command
+
+```powershell
+Restart-Service Winmgmt;
+```
+
+might return an error, because this service has dependencies for other services. To enforce this, you can run
+
+```powershell
+Restart-Service Winmgmt -Force;
+```
+
+which will restart this and all other depending services. Please ensure that this is done while doing maintenance on the systems to not interrupt production services.
+
 ### Permission Table
 
 | Flag           | Description |


### PR DESCRIPTION
Updates documentation for possible requirement to restart Wmi service `Winmgmt` to apply permission changes.