### PR TITLE
Feature: Adds exit to Windows Terminal integration to close shell on exit

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -24,6 +24,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#149](https://github.com/Icinga/icinga-powershell-framework/pull/149) Adds support to add Wmi permissions for a specific user and namespace with `Add-IcingaWmiPermissions`. In addition you can remove users from Wmi namespaces by using `Remove-IcingaWmiPermissions`
 * [#155](https://github.com/Icinga/icinga-powershell-framework/pull/155) Adds support to write all objects collected by `Get-IcingaWindowsInformation` into the Windows EventLog in case the debug output for the Icinga PowerShell Framework is enabled.
 * [#162](https://github.com/Icinga/icinga-powershell-framework/pull/162) Adds feature to test the length of plugin custom variables during config generation and throws error in case the total length is bigger than 64 digits, as imports into the Icinga Director by using baskets is not possible otherwise
+* [#164](https://github.com/Icinga/icinga-powershell-framework/pull/164) Adds `exit` after calling `icinga` on Windows Terminal integration to ensure the shell will close in case the Icinga shell is closed
 
 ### Bugfixes
 

--- a/doc/icingaintegration/50-Windows-Terminal.md
+++ b/doc/icingaintegration/50-Windows-Terminal.md
@@ -16,7 +16,7 @@ To install the Icinga Shell as native shell in your Windows Terminal dropdown, s
 
     "guid": "{fcd7a805-a41b-49f9-afee-9d17a2b76d42}",
     "name": "Icinga",
-    "commandline" : "powershell.exe -noe -c \"&{ icinga }\"",
+    "commandline" : "powershell.exe -noe -c \"&{ icinga; exit }\"",
     "hidden": false,
     "icon" : "ms-appdata:///roaming/icingawhite.png",
 


### PR DESCRIPTION
Adds `exit` after calling `icinga` on Windows Terminal integration to ensure the shell will close in case the Icinga shell is closed.