### PR TITLE
Fix: Fixes error while writing EventLog entries with too large message size

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -43,6 +43,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#159](https://github.com/Icinga/icinga-powershell-framework/pull/159) Fixes crash during update of the Icinga Framework, caused by the newly introduced experimental feature for code caching
 * [#165](https://github.com/Icinga/icinga-powershell-framework/pull/165) Fixes fetching for Icinga Agent certificate for REST-Api daemon on upper/lower case hostname mismatch
 * [#166](https://github.com/Icinga/icinga-powershell-framework/pull/166) Fixes fetching of Icinga Agent MSI packages by correctly comparing versions to ensure we always use the latest version and fixes `release` usage for local/network drive sources
+* [#167](https://github.com/Icinga/icinga-powershell-framework/pull/167) Fixes error while writing EventLog entries with too large message size
 
 ## 1.2.0 (2020-08-28)
 

--- a/lib/core/logging/Write-IcingaEventMessage.psm1
+++ b/lib/core/logging/Write-IcingaEventMessage.psm1
@@ -51,6 +51,25 @@ function Write-IcingaEventMessage()
         return;
     }
 
+    [int]$MaxEventLogMessageSize = 30000;
+
+    if ($EventLogMessage.Length -ge $MaxEventLogMessageSize) {
+        while ($EventLogMessage.Length -ge $MaxEventLogMessageSize) {
+            $CutMessage = $EventLogMessage.Substring(0, $MaxEventLogMessageSize);
+            Write-EventLog -LogName Application `
+                -Source 'Icinga for Windows' `
+                -EntryType $EntryType `
+                -EventId $EventId `
+                -Message $CutMessage;
+
+            $EventLogMessage = $EventLogMessage.Substring($MaxEventLogMessageSize, $EventLogMessage.Length - $MaxEventLogMessageSize);
+        }
+    }
+
+    if ([string]::IsNullOrEmpty($EventLogMessage)) {
+        return;
+    }
+
     Write-EventLog -LogName Application `
         -Source 'Icinga for Windows' `
         -EntryType $EntryType `


### PR DESCRIPTION
In rare cases it can happen that the EventLog writer will throw an error in case the message size for EventLog entries is too large. This mostly happens in case the debug mode is enabled which is writing plenty of content into the EventLog.

This fix will now split such message into multiple messages to resolve the issue and keeping the data.