### PR TITLE
Feature: Ensure thread results are separated from each other by default

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,12 +7,13 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
-## 1.4.0 (pending)
+## 1.4.0 (2021-03-02)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/11?closed=1)
 
 ### Enhancements
 
+* [#180](https://github.com/Icinga/icinga-powershell-framework/pull/180) Ensure check data are separated from each thread and not accessible from one thread to another to prevent conflicting results
 * [#193](https://github.com/Icinga/icinga-powershell-framework/pull/193) Adds optional support for adding milliseconds to `Get-IcingaUnixTime` with the `-Milliseconds` argument for more detailed time comparison
 * [#198](https://github.com/Icinga/icinga-powershell-framework/pull/198) Adds support to flush the content of the Icinga Agent API directory with a single Cmdlet `Clear-IcingaAgentApiDirectory`
 * [#203](https://github.com/Icinga/icinga-powershell-framework/pull/203) Removes experimental state of the Icinga PowerShell Framework code caching and adds docs on how to use the feature

--- a/lib/core/framework/Get-IcingaCheckSchedulerPerfData.psm1
+++ b/lib/core/framework/Get-IcingaCheckSchedulerPerfData.psm1
@@ -17,24 +17,12 @@
 
 function Get-IcingaCheckSchedulerPerfData()
 {
-    if ($null -eq $IcingaDaemonData) {
+    if ($null -eq $global:Icinga) {
         return $null;
     }
 
-    if ($IcingaDaemonData.ContainsKey('IcingaThreadContent') -eq $FALSE) {
-        return $null;
-    }
-
-    if ($IcingaDaemonData.IcingaThreadContent.ContainsKey('Scheduler') -eq $FALSE) {
-        return $null;
-    }
-
-    if ($IcingaDaemonData.IcingaThreadContent.Scheduler.ContainsKey('PluginPerfData') -eq $FALSE) {
-        return $null;
-    }
-
-    $PerfData = $IcingaDaemonData.IcingaThreadContent.Scheduler.PluginPerfData;
-    $IcingaDaemonData.IcingaThreadContent.Scheduler.PluginPerfData = @();
+    $PerfData               = $global:Icinga.PerfData;
+    $global:Icinga.PerfData = @();
 
     return $PerfData;
 }

--- a/lib/core/framework/Get-IcingaCheckSchedulerPluginOutput.psm1
+++ b/lib/core/framework/Get-IcingaCheckSchedulerPluginOutput.psm1
@@ -17,24 +17,12 @@
 
 function Get-IcingaCheckSchedulerPluginOutput()
 {
-    if ($null -eq $IcingaDaemonData) {
+    if ($null -eq $global:Icinga) {
         return $null;
     }
 
-    if ($IcingaDaemonData.ContainsKey('IcingaThreadContent') -eq $FALSE) {
-        return $null;
-    }
-
-    if ($IcingaDaemonData.IcingaThreadContent.ContainsKey('Scheduler') -eq $FALSE) {
-        return $null;
-    }
-
-    if ($IcingaDaemonData.IcingaThreadContent.Scheduler.ContainsKey('PluginCache') -eq $FALSE) {
-        return $null;
-    }
-
-    $CheckResult = [string]::Join("`r`n", $IcingaDaemonData.IcingaThreadContent.Scheduler.PluginCache);
-    $IcingaDaemonData.IcingaThreadContent.Scheduler.PluginCache = @();
+    $CheckResult = [string]::Join("`r`n", $global:Icinga.CheckResults);
+    $global:Icinga.CheckResults = @();
 
     return $CheckResult;
 }

--- a/lib/core/framework/New-IcingaCheckSchedulerEnvironment.psm1
+++ b/lib/core/framework/New-IcingaCheckSchedulerEnvironment.psm1
@@ -1,8 +1,12 @@
 function New-IcingaCheckSchedulerEnvironment()
 {
+    # Legacy code
     $IcingaDaemonData.IcingaThreadContent.Add('Scheduler', @{ });
-    if ($IcingaDaemonData.IcingaThreadContent['Scheduler'].ContainsKey('PluginCache') -eq $FALSE) {
-        $IcingaDaemonData.IcingaThreadContent['Scheduler'].Add('PluginCache', @());
-        $IcingaDaemonData.IcingaThreadContent['Scheduler'].Add('PluginPerfData', @());
+
+    if ($null -eq $global:Icinga) {
+        $global:Icinga = @{};
     }
+
+    $global:Icinga.Add('CheckResults', @());
+    $global:Icinga.Add('PerfData', @());
 }

--- a/lib/daemons/ServiceCheckDaemon/Start-IcingaServiceCheckDaemon.psm1
+++ b/lib/daemons/ServiceCheckDaemon/Start-IcingaServiceCheckDaemon.psm1
@@ -101,6 +101,9 @@ function Start-IcingaServiceCheckTask()
                 try {
                     & $CheckCommand @Arguments | Out-Null;
 
+                    Get-IcingaCheckSchedulerPerfData | Out-Null;
+                    Get-IcingaCheckSchedulerPluginOutput | Out-Null;
+
                     $UnixTime = Get-IcingaUnixTime;
 
                     foreach ($result in $IcingaDaemonData.BackgroundDaemon.ServiceCheckScheduler[$CheckCommand]['results'].Keys) {

--- a/lib/icinga/plugin/Write-IcingaPluginOutput.psm1
+++ b/lib/icinga/plugin/Write-IcingaPluginOutput.psm1
@@ -7,8 +7,7 @@ function Write-IcingaPluginOutput()
     if ($global:IcingaDaemonData.FrameworkRunningAsDaemon -eq $FALSE) {
         Write-IcingaConsolePlain $Output;
     } else {
-        if ($global:IcingaDaemonData.IcingaThreadContent.ContainsKey('Scheduler')) {
-            $global:IcingaDaemonData.IcingaThreadContent['Scheduler']['PluginCache'] += $Output;
-        }
+        # New behavior with local thread separated results
+        $global:Icinga.CheckResults += $Output;
     }
 }

--- a/lib/icinga/plugin/Write-IcingaPluginPerfData.psm1
+++ b/lib/icinga/plugin/Write-IcingaPluginPerfData.psm1
@@ -45,9 +45,8 @@ function Get-IcingaPluginPerfDataContent()
                     $cachedresult = (New-IcingaPerformanceDataEntry -PerfDataObject $data -Label $SearchEntry -Value $checkresult.Value);
 
                     if ($AsObject) {
-                        if ($global:IcingaDaemonData.IcingaThreadContent.ContainsKey('Scheduler')) {
-                            $global:IcingaDaemonData.IcingaThreadContent['Scheduler']['PluginPerfData'] += $cachedresult;
-                        }
+                        # New behavior with local thread separated results
+                        $global:Icinga.PerfData += $cachedresult;
                     }
                     $PerfDataOutput += $cachedresult;
                 }
@@ -56,9 +55,8 @@ function Get-IcingaPluginPerfDataContent()
             $compiledPerfData = (New-IcingaPerformanceDataEntry $data);
 
             if ($AsObject) {
-                if ($global:IcingaDaemonData.IcingaThreadContent.ContainsKey('Scheduler')) {
-                    $global:IcingaDaemonData.IcingaThreadContent['Scheduler']['PluginPerfData'] += $compiledPerfData;
-                }
+                # New behavior with local thread separated results
+                $global:Icinga.PerfData += $compiledPerfData;
             }
             $PerfDataOutput += $compiledPerfData;
         }


### PR DESCRIPTION
In case multitple background daemons are running and executing check plugins, it can happen that results overlap from one thread to another. A CPU check might then include information from another service check for example.

We fix this by locking each check result data into an own thread, preventing other threads from accessing the data.