### PR TITLE
Fix: Removes hardcoded global zones

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -15,6 +15,8 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#188](https://github.com/Icinga/icinga-powershell-framework/pull/188) Removes hardcoded zones `director-global` and `global-zones` which were always set regardless of user specification. This fix will ensure the user has the option to add or not add these zones
+
 ## 1.3.0 (2020-12-01)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/10?closed=1)

--- a/lib/core/icingaagent/writers/Write-IcingaAgentZonesConfig.psm1
+++ b/lib/core/icingaagent/writers/Write-IcingaAgentZonesConfig.psm1
@@ -58,13 +58,6 @@ function Write-IcingaAgentZonesConfig()
     $ZonesConf = [string]::Format('{0}    endpoints = [ "{1}" ];{2}', $ZonesConf, $Hostname, "`r`n");
     $ZonesConf = [string]::Format('{0}{1}{2}{2}', $ZonesConf, '}', "`r`n");
 
-    if ($GlobalZones.Contains('director-global') -eq $FALSE) {
-        $GlobalZones += 'director-global';
-    }
-    if ($GlobalZones.Contains('global-templates') -eq $FALSE) {
-        $GlobalZones += 'global-templates';
-    }
-
     foreach ($zone in $GlobalZones) {
         $ZonesConf = [string]::Format('{0}object Zone "{1}" {2}{3}', $ZonesConf, $zone, '{', "`r`n");
         $ZonesConf = [string]::Format('{0}    global = true;{1}', $ZonesConf, "`r`n");


### PR DESCRIPTION
As we ask the questions for adding `director-global` and `global-templates`, we should leave the decision to the user if these zones should be added by default and not enforce them.