### PR TITLE
Fix: Prefer startup type of services fetching over WMI instead of Get-Services

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -20,6 +20,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#186](https://github.com/Icinga/icinga-powershell-framework/issues/186) Fixes path handling for custom local/web path sources for service binary installation
 * [#188](https://github.com/Icinga/icinga-powershell-framework/pull/188) Removes hardcoded zones `director-global` and `global-zones` which were always set regardless of user specification. This fix will ensure the user has the option to add or not add these zones
 * [#189](https://github.com/Icinga/icinga-powershell-framework/pull/189) Fixes wrong documented user group for accessing Performance Counter objects which should be `Performance Monitor Users`
+* [#192](https://github.com/Icinga/icinga-powershell-framework/pull/192) Fixes code base for `Invoke-IcingaCheckService` by preferring to fetch the startup type of services by using WMI instead of `Get-Services`, as the result of `Get-Services` might be empty in some cases
 * [#195](https://github.com/Icinga/icinga-powershell-framework/pull/195) Fix Agent installer crash on package lookup with different files in directory
 * [#197](https://github.com/Icinga/icinga-powershell-framework/pull/197) Fixes progress bar appearance on check outputs for certain plugins, by disabling the entire PowerShell progress bar during the usage of Icinga for Windows
 

--- a/lib/core/tools/Get-IcingaServices.psm1
+++ b/lib/core/tools/Get-IcingaServices.psm1
@@ -26,6 +26,8 @@ function Get-IcingaServices()
         [array]$DependingServices = $null;
         $ServiceExitCode          = 0;
         [string]$ServiceUser      = '';
+        [int]$StartModeId         = 5;
+        [string]$StartMode        = 'Unknown';
 
         if ($Exclude -contains $service.ServiceName) {
             continue;
@@ -35,6 +37,10 @@ function Get-IcingaServices()
             if ($wmiService.Name -eq $service.ServiceName) {
                 $ServiceUser     = $wmiService.StartName;
                 $ServiceExitCode = $wmiService.ExitCode;
+                if ([string]::IsNullOrEmpty($wmiService.StartMode) -eq $FALSE) {
+                    $StartModeId = ([int]$IcingaEnums.ServiceWmiStartupType[$wmiService.StartMode]);
+                    $StartMode   = $IcingaEnums.ServiceStartupTypeName[$StartModeId];
+                }
                 break;
             }
         }
@@ -80,8 +86,8 @@ function Get-IcingaServices()
                     };
                     'ServiceHandle'       = $service.ServiceHandle;
                     'StartType'           = @{
-                        'raw'   = [int]$service.StartType;
-                        'value' = $service.StartType;
+                        'raw'   = $StartModeId;
+                        'value' = $StartMode;
                     };
                     'ServiceUser'         = $ServiceUser;
                     'ExitCode'            = $ServiceExitCode;

--- a/lib/icinga/enums/Icinga_IcingaEnums.psm1
+++ b/lib/icinga/enums/Icinga_IcingaEnums.psm1
@@ -38,6 +38,28 @@
     'c'  = 'counter';
 };
 
+<##################################################################################################
+################# Service Enums ##################################################################
+##################################################################################################>
+
+[hashtable]$ServiceStartupTypeName = @{
+    0 = 'Boot';
+    1 = 'System';
+    2 = 'Automatic';
+    3 = 'Manual';
+    4 = 'Disabled';
+    5 = 'Unknown'; # Custom
+}
+
+[hashtable]$ServiceWmiStartupType = @{
+    'Boot'     = 0;
+    'System'   = 1;
+    'Auto'     = 2;
+    'Manual'   = 3;
+    'Disabled' = 4;
+    'Unknown'  = 5; # Custom
+}
+
 <#
  # Once we defined a new enum hashtable above, simply add it to this list
  # to make it available within the entire module.
@@ -50,6 +72,9 @@
     IcingaExitCodeText     = $IcingaExitCodeText;
     IcingaExitCodeColor    = $IcingaExitCodeColor;
     IcingaMeasurementUnits = $IcingaMeasurementUnits;
+     #services
+    ServiceStartupTypeName = $ServiceStartupTypeName;
+    ServiceWmiStartupType  = $ServiceWmiStartupType;
 }
 
 Export-ModuleMember -Variable @( 'IcingaEnums' );


### PR DESCRIPTION
In some cases, it can happen that `Get-Service` which is used primarily to fetch most of the service data, is not providing any results of the startup type of the service. This results in an error on the plugin, as the monitoring of all services which should be running `Automatic` and throw a critical if not exited properly is no longer possible. The result is simply "Ok" with no services checked as the status code is always 0 for all services and not matching the actual comparison value of 2 (Automatic)