### PR TITLE
Feature: Add optional support for adding milliseconds to Get-IcingaUnixTime

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,6 +13,8 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Enhancements
 
+* [#193](https://github.com/Icinga/icinga-powershell-framework/pull/193) Adds optional support for adding milliseconds to `Get-IcingaUnixTime` with the `-Milliseconds` argument for more detailed time comparison
+
 ### Bugfixes
 
 * [#188](https://github.com/Icinga/icinga-powershell-framework/pull/188) Removes hardcoded zones `director-global` and `global-zones` which were always set regardless of user specification. This fix will ensure the user has the option to add or not add these zones

--- a/lib/core/tools/Get-IcingaUnixTime.psm1
+++ b/lib/core/tools/Get-IcingaUnixTime.psm1
@@ -1,5 +1,13 @@
 function Get-IcingaUnixTime()
 {
+    param(
+        [switch]$Milliseconds = $FALSE
+    );
+
+    if ($Milliseconds) {
+        return ([int64](([DateTime]::UtcNow) - (Get-Date '1/1/1970')).TotalMilliseconds / 1000);
+    }
+
     return [int][double]::Parse(
         (Get-Date -UFormat %s -Date (Get-Date).ToUniversalTime())
     );


### PR DESCRIPTION
Adds support to add milliseconds to the result of `Get-IcingaUnixTime` which might come in handy for more time depending tasks.