### PR TITLE
Fix: Disables PowerShell Progress bar while using Icinga for Windows

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -21,6 +21,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#188](https://github.com/Icinga/icinga-powershell-framework/pull/188) Removes hardcoded zones `director-global` and `global-zones` which were always set regardless of user specification. This fix will ensure the user has the option to add or not add these zones
 * [#189](https://github.com/Icinga/icinga-powershell-framework/pull/189) Fixes wrong documented user group for accessing Performance Counter objects which should be `Performance Monitor Users`
 * [#195](https://github.com/Icinga/icinga-powershell-framework/pull/195) Fix Agent installer crash on package lookup with different files in directory
+* [#197](https://github.com/Icinga/icinga-powershell-framework/pull/197) Fixes progress bar appearance on check outputs for certain plugins, by disabling the entire PowerShell progress bar during the usage of Icinga for Windows
 
 ## 1.3.0 (2020-12-01)
 

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -61,6 +61,7 @@ function Use-Icinga()
         }
     }
     New-IcingaPerformanceCounterCache;
+    Disable-IcingaProgressPreference;
 
     # Enable DebugMode in case it is enabled in our config
     if (Get-IcingaFrameworkDebugMode) {


### PR DESCRIPTION
In some cases progress bar output for certain activities might be printed into the plugin output. The best option is to disable it entirely while using Icinga for Windows, as we have no use for it.

Fixes #185 