### PR TITLE
Feature: Ensure config.json is opened as read-only

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -17,6 +17,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#193](https://github.com/Icinga/icinga-powershell-framework/pull/193) Adds optional support for adding milliseconds to `Get-IcingaUnixTime` with the `-Milliseconds` argument for more detailed time comparison
 * [#198](https://github.com/Icinga/icinga-powershell-framework/pull/198) Adds support to flush the content of the Icinga Agent API directory with a single Cmdlet `Clear-IcingaAgentApiDirectory`
 * [#203](https://github.com/Icinga/icinga-powershell-framework/pull/203) Removes experimental state of the Icinga PowerShell Framework code caching and adds docs on how to use the feature
+* [#205](https://github.com/Icinga/icinga-powershell-framework/pull/205) Ensure Icinga for Windows configuration file is opened as read-only for every single task besides actually modifying configuration content
 
 ## 1.3.1 (2021-02-04)
 

--- a/icinga-powershell-framework.psd1
+++ b/icinga-powershell-framework.psd1
@@ -14,7 +14,8 @@
         '.\lib\config\Test-IcingaPowerShellConfigItem.psm1',
         '.\lib\core\logging\Write-IcingaConsoleOutput.psm1',
         '.\lib\core\logging\Write-IcingaConsoleNotice.psm1',
-        '.\lib\core\logging\Write-IcingaConsoleWarning.psm1'
+        '.\lib\core\logging\Write-IcingaConsoleWarning.psm1',
+        '.\lib\core\tools\Read-IcingaFileContent.psm1'
     )
     FunctionsToExport = @(
         'Use-Icinga',
@@ -37,7 +38,8 @@
         'Test-IcingaPowerShellConfigItem',
         'Write-IcingaConsoleOutput',
         'Write-IcingaConsoleNotice',
-        'Write-IcingaConsoleWarning'
+        'Write-IcingaConsoleWarning',
+        'Read-IcingaFileContent'
     )
     CmdletsToExport   = @('*')
     VariablesToExport = '*'

--- a/lib/config/Read-IcingaPowerShellConfig.psm1
+++ b/lib/config/Read-IcingaPowerShellConfig.psm1
@@ -28,7 +28,7 @@ function Read-IcingaPowerShellConfig()
         return (New-Object -TypeName PSObject);
     }
 
-    [string]$Content = Get-Content -Path $ConfigFile;
+    [string]$Content = Read-IcingaFileContent -File $ConfigFile;
 
     if ([string]::IsNullOrEmpty($Content)) {
         return (New-Object -TypeName PSObject);

--- a/lib/core/tools/Read-IcingaFileContent.psm1
+++ b/lib/core/tools/Read-IcingaFileContent.psm1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+   Reads content of a file in read-only mode, ensuring no data corruption is happening
+.DESCRIPTION
+   Reads content of a file in read-only mode, ensuring no data corruption is happening
+.FUNCTIONALITY
+   Reads content of a file in read-only mode, ensuring no data corruption is happening
+.EXAMPLE
+   PS>Read-IcingaFileContent -File 'config.json';
+.OUTPUTS
+   System.Object
+.LINK
+   https://github.com/Icinga/icinga-powershell-framework
+#>
+
+function Read-IcingaFileContent()
+{
+    param (
+        [string]$File
+    );
+
+    if ((Test-Path $File) -eq $FALSE) {
+        return $null;
+    }
+
+    [System.IO.FileStream]$FileStream = [System.IO.File]::Open(
+        $File,
+        [System.IO.FileMode]::Open,
+        [System.IO.FileAccess]::Read,
+        [System.IO.FileShare]::Read
+    );
+
+    $ReadArray    = New-Object Byte[] $FileStream.Length;
+    $UTF8Encoding = New-Object System.Text.UTF8Encoding $TRUE;
+    $FileContent  = '';
+
+    while ($FileStream.Read($ReadArray, 0 , $ReadArray.Length)) {
+        $FileContent = [System.String]::Concat($FileContent, $UTF8Encoding.GetString($ReadArray));
+    }
+
+    $FileStream.Dispose();
+
+    return $FileContent;
+}


### PR DESCRIPTION
In some cases it can happen that multiple processes access our config file. By default `Get-Content` is not thread save and might result in errors while reading the file content.

In general we should use a read-only attempt for the config.json and write it only if required.