### PR TITLE
Adds feature to customize label for checks

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#198](https://github.com/Icinga/icinga-powershell-framework/pull/198) Adds support to flush the content of the Icinga Agent API directory with a single Cmdlet `Clear-IcingaAgentApiDirectory`
 * [#203](https://github.com/Icinga/icinga-powershell-framework/pull/203) Removes experimental state of the Icinga PowerShell Framework code caching and adds docs on how to use the feature
 * [#205](https://github.com/Icinga/icinga-powershell-framework/pull/205) Ensure Icinga for Windows configuration file is opened as read-only for every single task besides actually modifying configuration content
+* [#207](https://github.com/Icinga/icinga-powershell-framework/pull/207) Adds new Argument `-LabelName` to `New-IcingaCheck`, allowing the developer to provide custom label names for checks and override the default based on the check name.
 
 ### Bugfixes
 

--- a/doc/developerguide/01-New-IcingaCheck.md
+++ b/doc/developerguide/01-New-IcingaCheck.md
@@ -31,13 +31,14 @@ For performance metrics you can provide a `Unit` to ensure your graphing is disp
 | Maximum      | String    |           | The maximum value which is displayed on your graphs |
 | ObjectExists | Bool      |           | If you are using values coming from objects, like Services, you can use this argument to determin if the object itself exist or not. In case it doesn't, you will receive a proper output on the check result |
 | Translation  | Hashtable |           | In case you want to map values to certain descriptions, you can place a hashtable at this argument which will then map the value to the description on the check result. For example this would apply to service running states |
+| LabelName    | String    |           | Allows to override the default label name generated based on the `-Name` argument to a custom name. Please ensure to remove any special characters manually, as the name set here is the exact name for the label |
 | NoPerfData   | Switch    |           | Disables Performance Data output for this check object |
 
 ## Units
 
 | Unit | Name         | Description                                     |
 | ---  | ---          | ---                                             |
-| %    | Percentage   | The input value is a percentual value           |
+| %    | Percentage   | The input value is a percentage value           |
 | s    | Seconds      | The input is indicated as time seconds          |
 | ms   | Milliseconds | The input is indicated as time in milliseconds  |
 | us   | Microseconds | The input is indicated as time in microseconds  |

--- a/lib/icinga/plugin/New-IcingaCheck.psm1
+++ b/lib/icinga/plugin/New-IcingaCheck.psm1
@@ -11,6 +11,7 @@ function New-IcingaCheck()
         [string]$Maximum    = '',
         $ObjectExists       = -1,
         $Translation        = $null,
+        [string]$LabelName  = $null,
         [switch]$NoPerfData
     );
 
@@ -38,6 +39,7 @@ function New-IcingaCheck()
     $Check | Add-Member -MemberType NoteProperty -Name 'maximum'        -Value $Maximum;
     $Check | Add-Member -MemberType NoteProperty -Name 'objectexists'   -Value $ObjectExists;
     $Check | Add-Member -MemberType NoteProperty -Name 'translation'    -Value $Translation;
+    $Check | Add-Member -MemberType NoteProperty -Name 'labelname'      -Value $LabelName;
     $Check | Add-Member -MemberType NoteProperty -Name 'checks'         -Value $null;
     $Check | Add-Member -MemberType NoteProperty -Name 'completed'      -Value $FALSE;
     $Check | Add-Member -MemberType NoteProperty -Name 'checkcommand'   -Value '';
@@ -802,6 +804,10 @@ function New-IcingaCheck()
         $value             = ConvertTo-Integer -Value $this.value -NullAsEmpty;
         $warning           = ConvertTo-Integer -Value $this.warning -NullAsEmpty;
         $critical          = ConvertTo-Integer -Value $this.critical -NullAsEmpty;
+
+        if ([string]::IsNullOrEmpty($this.labelname) -eq $FALSE) {
+            $LabelName = $this.labelname;
+        }
 
         $perfdata = @{
             'label'    = $LabelName;


### PR DESCRIPTION
Adds new Argument `-LabelName` to `New-IcingaCheck`, allowing the developer to provide custom label names for checks and override the default based on the check name.