### PR TITLE
Fix: Plugin threshold conversion and adds % unit handling

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -23,6 +23,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#206](https://github.com/Icinga/icinga-powershell-framework/pull/206) Fixes background service check daemon for collecting metrics over time which will no longer share data between configured checks which might cause higher CPU load and a possible memory leak
+* [#208](https://github.com/Icinga/icinga-powershell-framework/pull/208) Fixes `Convert-IcingaPluginThresholds` which sometimes did not return proper numeric usable values for our internal functions, causing issues on plugin calls. In addition the function now also supports the handling for % units.
 
 ## 1.3.1 (2021-02-04)
 

--- a/lib/core/tools/Convert-IcingaPluginThresholds.psm1
+++ b/lib/core/tools/Convert-IcingaPluginThresholds.psm1
@@ -90,7 +90,7 @@ function Convert-IcingaPluginThresholds()
     $Threshold = $Threshold.Replace(',', '.');
 
     [array]$Content    = @();
-    
+
     if ($Threshold.Contains(':')) {
         $Content = $Threshold.Split(':');
     } else {
@@ -128,6 +128,10 @@ function Convert-IcingaPluginThresholds()
             }
             $Value         = (ConvertTo-Seconds -Value $ThresholdValue);
             $RetValue.Unit = $WorkUnit;
+        } elseif (($ThresholdValue -Match "(^[\d\.]*) ?(%)")) {
+            $WorkUnit      = '%';
+            $Value         = ([string]$ThresholdValue).Replace(' ', '').Replace('%', '');
+            $RetValue.Unit = $WorkUnit;
         } else {
             $Value = $ThresholdValue;
         }
@@ -145,11 +149,13 @@ function Convert-IcingaPluginThresholds()
 
     if ([string]::IsNullOrEmpty($Value) -eq $FALSE -And $Value.Contains(':') -eq $FALSE) {
         if ((Test-Numeric $Value)) {
-            $RetValue.Value = [convert]::ToDecimal($Value);
+            $RetValue.Value = $Value;
             return $RetValue;
         }
     }
 
+    # Always ensure we are using correct digits
+    $Value = ([string]$Value).Replace(',', '.');
     $RetValue.Value = $Value;
 
     return $RetValue;


### PR DESCRIPTION
Fixes `Convert-IcingaPluginThresholds` which sometimes did not return proper numeric usable values for our internal functions, causing issues on plugin calls. In addition the function now also supports the handling for % units.