### PR TITLE
Fixes DSL for building array elements escaped

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -19,6 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#203](https://github.com/Icinga/icinga-powershell-framework/pull/203) Removes experimental state of the Icinga PowerShell Framework code caching and adds docs on how to use the feature
 * [#205](https://github.com/Icinga/icinga-powershell-framework/pull/205) Ensure Icinga for Windows configuration file is opened as read-only for every single task besides actually modifying configuration content
 * [#207](https://github.com/Icinga/icinga-powershell-framework/pull/207) Adds new Argument `-LabelName` to `New-IcingaCheck`, allowing the developer to provide custom label names for checks and override the default based on the check name.
+* [#210](https://github.com/Icinga/icinga-powershell-framework/pull/210) Updates the Icinga DSL for building PowerShell arrays to ensure all string values are properly escaped with `'`. In case the user already wrapped commands with `'` by himself, this will not have an effect as we only add single quotes for escaping if they are not present already
 
 ### Bugfixes
 

--- a/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
+++ b/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
@@ -179,11 +179,12 @@ function Get-IcingaCheckCommandConfig()
                         'value' = @{
                             'type' = 'Function';
                             'body' = [string]::Format(
-                                'var arr = macro("{0}");{1}if (len(arr) == 0) {2}{1}return "@()";{1}{3}{1}return arr.join(",");',
+                                'var arr = macro("{0}");{1}    if (len(arr) == 0) {2}{1}        return "@()";{1}    {3}{1}    return arr.map({1}        x => if (typeof(x) == String) {2}{1}            var argLen = len(x);{1}            if (argLen != 0 && x.substr(0,1) == "{4}" && x.substr(argLen - 1, argLen) == "{4}") {2}{1}                x;{1}            {3} else {2}{1}                "{4}" + x + "{4}";{1}            {3}{1}        {3} else {2}{1}            x;{1}        {3}{1}    ).join(",");',
                                 $IcingaCustomVariable,
                                 "`r`n",
                                 '{',
-                                '}'
+                                '}',
+                                "'"
                             );
                         }
                         'order' = $Order;


### PR DESCRIPTION
Updates the Icinga DSL for building PowerShell arrays to ensure all string values are properly escaped with `'`. In case the user already wrapped commands with `'` by himself, this will not have an effect as we only add single quotes for escaping if they are not present already.