### PR TITLE
Feature: Adds experimental Feature "Management Console"

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -21,6 +21,14 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#207](https://github.com/Icinga/icinga-powershell-framework/pull/207) Adds new Argument `-LabelName` to `New-IcingaCheck`, allowing the developer to provide custom label names for checks and override the default based on the check name.
 * [#210](https://github.com/Icinga/icinga-powershell-framework/pull/210) Updates the Icinga DSL for building PowerShell arrays to ensure all string values are properly escaped with `'`. In case the user already wrapped commands with `'` by himself, this will not have an effect as we only add single quotes for escaping if they are not present already
 * [#211](https://github.com/Icinga/icinga-powershell-framework/pull/211) Adds feature to uninstall single components for Icinga for Windows or to uninstall everything and start entirely from new
+* [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Added support to fetch network interface for `Register-IcingaDirectorSelfServiceHost` directly from provided director url
+* [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Added support for Icinga Framework Code Cache file being deleted once the feature is disabled
+* [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Added support to suppress any console output for the current PowerShell session by using `Disable-IcingaFrameworkConsoleOutput` and to enable it again by using `Enable-IcingaFrameworkConsoleOutput`
+* [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Added support for `-Release` argument for `Get-IcingaFrameworkServiceBinary` suppressing questions and using GitHub as source directly if set
+* [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Added support to color console output by using `Write-IcingaConsolePlain` with the new argument `-ForeColor`
+* [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Added new feature to write Icinga for Windows console headers more easily, better structured and formatted with `Write-IcingaConsoleHeader` by adding line content as array elements
+* [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Fixed possible crash on `Get-IcingaAgentFeatures` if PowerShell is not running as administrator and therefor the command `icinga2 feature list` can not be processed
+* [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Fixed `ConvertTo-IcingaSecureString` to return `$null` for empty strings instead of throwing an exception
 
 ### Bugfixes
 
@@ -30,6 +38,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Experimental
 
 * [#204](https://github.com/Icinga/icinga-powershell-framework/pull/204) Adds experimental feature to forward checks executed by the Icinga Agent to an internal REST-Api, to reduce the performance impact on systems with lower resources available
+* [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Adds new experimental feature `Management Console` for better and easier management for Icinga for Windows and improved automation and deployed.
 
 ## 1.3.1 (2021-02-04)
 

--- a/icinga-powershell-framework.psd1
+++ b/icinga-powershell-framework.psd1
@@ -4,7 +4,7 @@
     GUID              = 'fcd7a805-a41b-49f9-afee-9d17a2b76d42'
     Author            = 'Lord Hepipud'
     CompanyName       = 'Icinga GmbH'
-    Copyright         = '(c) 2020 Icinga GmbH | MIT'
+    Copyright         = '(c) 2021 Icinga GmbH | MIT'
     Description       = 'Icinga for Windows module which allows to entirely monitor the Windows Host system.'
     PowerShellVersion = '4.0'
     NestedModules     = @(
@@ -27,7 +27,9 @@
         '.\lib\web\Disable-IcingaProgressPreference.psm1',
         '.\lib\core\tools\New-IcingaNewLine.psm1',
         '.\lib\core\logging\Write-IcingaConsolePlain.psm1',
-        '.\lib\core\tools\Test-IcingaFunction.psm1'
+        '.\lib\core\tools\Test-IcingaFunction.psm1',
+        '.\lib\core\tools\Write-IcingaConsoleHeader.psm1',
+        '.\lib\core\framework\Test-IcingaFrameworkConsoleOutput.psm1'
     )
     FunctionsToExport = @(
         'Use-Icinga',
@@ -63,7 +65,9 @@
         'Disable-IcingaProgressPreference',
         'New-IcingaNewLine',
         'Write-IcingaConsolePlain',
-        'Test-IcingaFunction'
+        'Test-IcingaFunction',
+        'Write-IcingaConsoleHeader',
+        'Test-IcingaFrameworkConsoleOutput'
     )
     CmdletsToExport   = @('*')
     VariablesToExport = '*'

--- a/lib/apis/Register-IcingaDirectorSelfServiceHost.psm1
+++ b/lib/apis/Register-IcingaDirectorSelfServiceHost.psm1
@@ -53,10 +53,16 @@ function Register-IcingaDirectorSelfServiceHost()
     $ProgressPreference = "SilentlyContinue";
     $DirectorConfigJson = $null;
 
-    if ([string]::IsNullOrEmpty($Endpoint) -eq $FALSE) {
-        $Interface          = Get-IcingaNetworkInterface $Endpoint;
-        $DirectorConfigJson = [string]::Format('{0} "address":"{2}" {1}', '{', '}', $Interface);
+    if ([string]::IsNullOrEmpty($Endpoint)) {
+        if ($DirectorUrl.Contains('https://') -Or $DirectorUrl.Contains('http://')) {
+            $Endpoint = $DirectorUrl.Split('/')[2];
+        } else {
+            $Endpoint = $DirectorUrl.Split('/')[0];
+        }
     }
+
+    $Interface          = Get-IcingaNetworkInterface $Endpoint;
+    $DirectorConfigJson = [string]::Format('{0} "address":"{2}" {1}', '{', '}', $Interface);
 
     $EndpointUrl = Join-WebPath -Path $DirectorUrl -ChildPath ([string]::Format('/self-service/register-host?name={0}&key={1}', $Hostname, $ApiKey));
 

--- a/lib/core/framework/Disable-IcingaFrameworkCodeCache.psm1
+++ b/lib/core/framework/Disable-IcingaFrameworkCodeCache.psm1
@@ -16,4 +16,9 @@
 function Disable-IcingaFrameworkCodeCache()
 {
     Set-IcingaPowerShellConfig -Path 'Framework.CodeCaching' -Value $FALSE;
+
+    # Remove the cache file in case it exists and the feature is disabled
+    if (Test-Path -Path (Get-IcingaFrameworkCodeCacheFile)) {
+        Remove-ItemSecure -Path (Get-IcingaFrameworkCodeCacheFile) -Force | Out-Null;
+    }
 }

--- a/lib/core/framework/Disable-IcingaFrameworkConsoleOutput.psm1
+++ b/lib/core/framework/Disable-IcingaFrameworkConsoleOutput.psm1
@@ -1,0 +1,25 @@
+<#
+.SYNOPSIS
+   Allows to disable any console output for this PowerShell session
+.DESCRIPTION
+   Allows to disable any console output for this PowerShell session
+.FUNCTIONALITY
+   Allows to disable any console output for this PowerShell session
+.EXAMPLE
+   PS>Disable-IcingaFrameworkConsoleOutput;
+.LINK
+   https://github.com/Icinga/icinga-powershell-framework
+#>
+
+function Disable-IcingaFrameworkConsoleOutput()
+{
+    if ($null -eq $global:Icinga) {
+        $global:Icinga = @{ };
+    }
+
+    if ($global:Icinga.ContainsKey('DisableConsoleOutput') -eq $FALSE) {
+        $global:Icinga.Add('DisableConsoleOutput', $TRUE);
+    } else {
+        $global:Icinga.DisableConsoleOutput = $TRUE;
+    }
+}

--- a/lib/core/framework/Enable-IcingaFrameworkConsoleOutput.psm1
+++ b/lib/core/framework/Enable-IcingaFrameworkConsoleOutput.psm1
@@ -1,0 +1,25 @@
+<#
+.SYNOPSIS
+   Allows to enable any console output for this PowerShell session
+.DESCRIPTION
+   Allows to enable any console output for this PowerShell session
+.FUNCTIONALITY
+   Allows to enable any console output for this PowerShell session
+.EXAMPLE
+   PS>Enable-IcingaFrameworkConsoleOutput;
+.LINK
+   https://github.com/Icinga/icinga-powershell-framework
+#>
+
+function Enable-IcingaFrameworkConsoleOutput()
+{
+    if ($null -eq $global:Icinga) {
+        $global:Icinga = @{ };
+    }
+
+    if ($global:Icinga.ContainsKey('DisableConsoleOutput') -eq $FALSE) {
+        $global:Icinga.Add('DisableConsoleOutput', $FALSE);
+    } else {
+        $global:Icinga.DisableConsoleOutput = $FALSE;
+    }
+}

--- a/lib/core/framework/Get-IcingaFrameworkServiceBinary.psm1
+++ b/lib/core/framework/Get-IcingaFrameworkServiceBinary.psm1
@@ -28,14 +28,15 @@ function Get-IcingaFrameworkServiceBinary()
 {
     param(
         [string]$FrameworkServiceUrl,
-        [string]$ServiceDirectory
+        [string]$ServiceDirectory,
+        [switch]$Release             = $FALSE
     );
 
     Set-IcingaTLSVersion;
     $ProgressPreference = "SilentlyContinue";
 
-    if ([string]::IsNullOrEmpty($FrameworkServiceUrl)) {
-        if ((Get-IcingaAgentInstallerAnswerInput -Prompt 'Do you provide a custom source of the service binary?' -Default 'n').result -eq 1) {
+    if ([string]::IsNullOrEmpty($FrameworkServiceUrl) -Or $Release) {
+        if ($Release -Or (Get-IcingaAgentInstallerAnswerInput -Prompt 'Do you provide a custom source of the service binary?' -Default 'n').result -eq 1) {
             $LatestRelease       = (Invoke-IcingaWebRequest -Uri 'https://github.com/Icinga/icinga-powershell-service/releases/latest' -UseBasicParsing).BaseResponse.ResponseUri.AbsoluteUri;
             $FrameworkServiceUrl = $LatestRelease.Replace('/tag/', '/download/');
             $Tag                 = $FrameworkServiceUrl.Split('/')[-1];

--- a/lib/core/framework/Test-IcingaFrameworkConsoleOutput.psm1
+++ b/lib/core/framework/Test-IcingaFrameworkConsoleOutput.psm1
@@ -1,0 +1,25 @@
+<#
+.SYNOPSIS
+   Allows to test if console output can be written or not for this PowerShell session
+.DESCRIPTION
+   Allows to test if console output can be written or not for this PowerShell session
+.FUNCTIONALITY
+   Allows to test if console output can be written or not for this PowerShell session
+.EXAMPLE
+   PS>Enable-IcingaFrameworkConsoleOutput;
+.LINK
+   https://github.com/Icinga/icinga-powershell-framework
+#>
+
+function Test-IcingaFrameworkConsoleOutput()
+{
+    if ($null -eq $global:Icinga) {
+        return $TRUE;
+    }
+
+    if ($global:Icinga.ContainsKey('DisableConsoleOutput') -eq $FALSE) {
+        return $TRUE;
+    }
+
+    return (-Not ($global:Icinga.DisableConsoleOutput));
+}

--- a/lib/core/icingaagent/getters/Get-IcingaAgentFeatures.psm1
+++ b/lib/core/icingaagent/getters/Get-IcingaAgentFeatures.psm1
@@ -3,6 +3,13 @@ function Get-IcingaAgentFeatures()
     $Binary       = Get-IcingaAgentBinary;
     $ConfigResult = Start-IcingaProcess -Executable $Binary -Arguments 'feature list';
 
+    if ($ConfigResult.ExitCode -ne 0) {
+        return @{
+            'Enabled'  = @();
+            'Disabled' = @();
+        }
+    }
+
     $DisabledFeatures = (
         $ConfigResult.Message.SubString(
             0,

--- a/lib/core/installer/Install-Icinga.psm1
+++ b/lib/core/installer/Install-Icinga.psm1
@@ -1,0 +1,149 @@
+function Install-Icinga()
+{
+    param (
+        [string]$InstallCommand = $null,
+        [string]$InstallFile    = ''
+    );
+
+    if ($null -eq $global:Icinga) {
+        $global:Icinga = @{ };
+    }
+
+    if ($global:Icinga.ContainsKey('InstallWizard') -eq $FALSE) {
+        $global:Icinga.Add(
+            'InstallWizard', @{
+                'AdminShell'      = (Test-AdministrativeShell);
+                'LastInput'       = '';
+                'LastNotice'      = '';
+                'LastError'       = '';
+                'HeaderPreview'   = '';
+                'LastParent'      = [System.Collections.ArrayList]@();
+                'LastValues'      = @();
+                'Config'          = @{ };
+                'ConfigSwap'      = @{ };
+                'ParentConfig'    = $null;
+                'Menu'            = 'Install-Icinga';
+                'NextCommand'     = '';
+                'NextArguments'   = $null;
+                'HeaderSelection' = $null;
+                'DisplayAdvanced' = $FALSE;
+                'ShowAdvanced'    = $FALSE;
+                'ShowHelp'        = $FALSE;
+                'DeleteValues'    = $FALSE;
+                'HeaderPrint'     = $FALSE;
+                'JumpToSummary'   = $FALSE;
+                'Closing'         = $FALSE;
+            }
+        );
+    }
+
+    if ([string]::IsNullOrEmpty($InstallFile) -eq $FALSE) {
+        $InstallCommand = Read-IcingaFileContent -File $InstallFile;
+    }
+
+    # Use our install command to configure everything
+    if ([string]::IsNullOrEmpty($InstallCommand) -eq $FALSE) {
+
+        Disable-IcingaFrameworkConsoleOutput;
+
+        # Add our "old" swap internally
+        $OldConfigSwap = Get-IcingaPowerShellConfig -Path 'Framework.Config.Swap';
+
+        [hashtable]$IcingaConfiguration = Convert-IcingaForwindowsManagementConsoleJSONConfig -Config (ConvertFrom-Json -InputObject $InstallCommand);
+
+        # First run our configuration values
+        Invoke-IcingaForWindowsManagementConsoleCustomConfig -IcingaConfiguration $IcingaConfiguration;
+
+        # In case we use the director, we require to first fetch all basic values from the Self-Service API then
+        # require to register the host to fet the remaining content
+        if ($IcingaConfiguration.ContainsKey('IfW-DirectorSelfServiceKey') -And $IcingaConfiguration.ContainsKey('IfW-DirectorUrl')) {
+            Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate;
+            Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate -Register;
+            Disable-IcingaFrameworkConsoleOutput;
+        } else {
+            # Now load all remaining values we haven't set and define the defaults
+            Add-IcingaForWindowsInstallationAdvancedEntries;
+        }
+
+        # Now apply our configuration again to ensure the defaults are overwritten again
+        # Suite a mess, but we can improve this later
+        Invoke-IcingaForWindowsManagementConsoleCustomConfig -IcingaConfiguration $IcingaConfiguration;
+
+        Enable-IcingaFrameworkConsoleOutput;
+
+        Start-IcingaForWindowsInstallation -Automated;
+
+        # Set our "old" swap live again. By doing so, we can still continue our old
+        # configuration
+        Set-IcingaPowerShellConfig -Path 'Framework.Config.Swap' -Value $OldConfigSwap;
+
+        return;
+    }
+
+    while ($TRUE) {
+
+        # Do nothing else anymore in case we are closing the management console
+        if ($global:Icinga.InstallWizard.Closing) {
+            break;
+        }
+
+        $FrameworkInstalled = Get-IcingaPowerShellConfig -Path 'Framework.Installed';
+
+        if ($null -eq $FrameworkInstalled) {
+            $FrameworkInstalled = $FALSE;
+        }
+
+        if ([string]::IsNullOrEmpty($global:Icinga.InstallWizard.NextCommand) -Or $global:Icinga.InstallWizard.NextCommand -eq 'Install-Icinga') {
+            Show-IcingaForWindowsInstallerMenu `
+                -Header 'What do you want to do?' `
+                -Entries @(
+                    @{
+                        'Caption' = 'Installation';
+                        'Command' = 'Show-IcingaForWindowsInstallerMenuInstallWindows';
+                        'Help'    = 'Allows you to install Icinga for Windows with all required components and options.'
+                    },
+                    @{
+                        'Caption'  = 'Update environment';
+                        'Command'  = '';
+                        'Help'     = 'Allows you to modify your current Icinga for Windows installation.';
+                        'Disabled' = $TRUE;
+                    },
+                    @{
+                        'Caption' = 'Manage environment';
+                        'Command' = 'Show-IcingaForWindowsMenuManage';
+                        'Help'    = 'Allows you to modify your current Icinga for Windows installation.';
+                    },
+                    @{
+                        'Caption'  = 'Remove components';
+                        'Command'  = 'Show-IcingaForWindowsMenuRemoveComponents';
+                        'Help'     = 'Allows you to modify your current Icinga for Windows installation.';
+                        'Disabled' = (-Not ($global:Icinga.InstallWizard.AdminShell));
+                    }
+                ) `
+                -DefaultIndex 0;
+        } else {
+            $NextArguments = $global:Icinga.InstallWizard.NextArguments;
+
+            if ($global:Icinga.InstallWizard.NextCommand.Contains(':')) {
+                $NextArguments = @{
+                    'Value' = ($global:Icinga.InstallWizard.NextCommand.Split(':')[1]);
+                };
+                $global:Icinga.InstallWizard.NextCommand = $global:Icinga.InstallWizard.NextCommand.Split(':')[0];
+            }
+
+            try {
+                if ($null -ne $NextArguments -And $NextArguments.Count -ne 0) {
+                    & $global:Icinga.InstallWizard.NextCommand @NextArguments;
+                } else {
+                    & $global:Icinga.InstallWizard.NextCommand;
+                }
+            } catch {
+                $ErrMsg = $_.Exception.Message;
+
+                $global:Icinga.InstallWizard.LastError     = [string]::Format('Failed to enter menu "{0}". Error "{1}', $global:Icinga.InstallWizard.NextCommand, $ErrMsg);
+                $global:Icinga.InstallWizard.NextCommand   = 'Install-Icinga';
+                $global:Icinga.InstallWizard.NextArguments = @{ };
+            }
+        }
+    }
+}

--- a/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
+++ b/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
@@ -1,0 +1,266 @@
+function Start-IcingaForWindowsInstallation()
+{
+    param (
+        [switch]$Automated
+    );
+
+    if ((Get-IcingaFrameworkDebugMode) -eq $FALSE) {
+        Clear-Host;
+    }
+
+    Write-IcingaConsoleNotice 'Starting Icinga for Windows installation';
+
+    $ConnectionType        = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectConnection';
+    $HostnameType          = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectHostname';
+    $FirewallType          = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectOpenWindowsFirewall';
+
+    # Certificate handler
+    $CertificateType       = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectCertificate';
+    $CertificateTicket     = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaTicket';
+    $CertificateCAFile     = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile';
+
+    # Icinga Agent
+    $AgentVersion          = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentVersion';
+    $AgentPackageType      = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectIcingaAgentSource';
+    $AgentInstallDir       = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentDirectory';
+    $ServiceUser           = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentUser';
+    $ServicePassword       = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentServicePassword';
+
+    # Icinga for Windows Service
+    $WindowsServiceType    = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectWindowsServiceSource';
+    $WindowsServiceDir     = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallationMenuEnterWindowsServiceDirectory';
+
+    # Icinga for Windows Plugins
+    $WindowsPluginsType    = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectIcingaPluginsSource';
+    $WindowsPluginsPackage = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterPluginsPackageSource';
+
+    # Global Zones
+    $GlobalZonesType       = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectGlobalZones';
+    $GlobalZonesCustom     = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallationMenuEnterCustomGlobalZones';
+
+    # Icinga Endpoint Configuration
+    $IcingaZone            = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone';
+    $IcingaEndpoints       = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes';
+    $IcingaPort            = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallationMenuEnterIcingaPort';
+
+    # Icinga for Windows PowerShell Framework
+    $CodeCacheType         = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsManagementConsoleEnableCodeCache';
+
+    $Hostname              = '';
+    $GlobalZones           = @();
+    $IcingaParentAddresses = @();
+    $AgentPackageSource    = ''
+    $ServicePackageSource  = ''
+    $ServiceSourceGitHub   = $FALSE;
+    $InstallAgent          = $TRUE;
+    $InstallService        = $TRUE;
+    $InstallPlugins        = $TRUE;
+    $PluginPackageRelease  = $FALSE;
+    $PluginPackageSnapshot = $FALSE;
+
+    foreach ($endpoint in $IcingaEndpoints) {
+        $EndpointAddress = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses' -Parent $endpoint;
+
+        $IcingaParentAddresses += $EndpointAddress;
+    }
+
+    switch ($HostnameType) {
+        '0' {
+            $Hostname = (Get-IcingaHostname -AutoUseFQDN 1);
+            break;
+        };
+        '1' {
+            $Hostname = (Get-IcingaHostname -AutoUseFQDN 1 -LowerCase 1);
+            break;
+        };
+        '2' {
+            $Hostname = (Get-IcingaHostname -AutoUseFQDN 1 -UpperCase 1);
+            break;
+        };
+        '3' {
+            $Hostname = (Get-IcingaHostname -AutoUseHostname 1);
+            break;
+        };
+        '4' {
+            $Hostname = (Get-IcingaHostname -AutoUseHostname 1 -LowerCase 1);
+            break;
+        };
+        '5' {
+            $Hostname = (Get-IcingaHostname -AutoUseHostname 1 -UpperCase 1);
+            break;
+        };
+    }
+
+    switch ($GlobalZonesType) {
+        '0' {
+            $GlobalZones += 'director-global';
+            $GlobalZones += 'global-templates';
+            break;
+        };
+        '1' {
+            $GlobalZones += 'director-global';
+            break;
+        }
+        '2' {
+            $GlobalZones += 'global-templates';
+            break;
+        }
+    }
+
+    foreach ($zone in $GlobalZonesCustom) {
+        if ([string]::IsNullOrEmpty($zone) -eq $FALSE) {
+            if ($GlobalZones -Contains $zone) {
+                continue;
+            }
+
+            $GlobalZones += $zone;
+        }
+    }
+
+    switch ($AgentPackageType) {
+        '0' {
+            # Install Icinga Agent from packages.icinga.com
+            $AgentPackageSource = ' https://packages.icinga.com/windows';
+            break;
+        };
+        '1' {
+            # Install Icinga Agent from custom source
+            $AgentPackageSource = (Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaAgentPackageSource');
+            break;
+        };
+        '2' {
+            # Do not install Icinga Agent
+            $InstallAgent = $FALSE;
+            break;
+        }
+    }
+
+    switch ($WindowsServiceType) {
+        '0' {
+            #GitHub
+            $ServiceSourceGitHub = $TRUE;
+            break;
+        };
+        '1' {
+            # Custom location
+            $ServicePackageSource = (Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterWindowsServicePackageSource');
+            break;
+        };
+        '2' {
+            # Do not install Icinga for Windows service
+            $InstallService = $FALSE;
+            break;
+        }
+    }
+
+    switch ($WindowsPluginsType) {
+        '0' {
+            # Download Release from GitHub
+            $PluginPackageRelease = $TRUE;
+            break;
+        };
+        '1' {
+            # Download Snapshot (master) from GitHub
+            $PluginPackageSnapshot = $TRUE;
+            break;
+        };
+        '2' {
+            # Use custom package source
+            break;
+        };
+        '3' {
+            # Do not install plugins
+            $InstallPlugins = $FALSE;
+            break;
+        }
+    }
+
+    if ($InstallAgent) {
+        Install-IcingaAgent -Version $AgentVersion -Source $AgentPackageSource -InstallDir $AgentInstallDir -AllowUpdates $TRUE | Out-Null;
+        Reset-IcingaAgentConfigFile;
+        Move-IcingaAgentDefaultConfig;
+        Set-IcingaAgentNodeName -Hostname $Hostname;
+        Set-IcingaAgentServiceUser -User $ServiceUser -Password (ConvertTo-IcingaSecureString $ServicePassword) -SetPermission | Out-Null;
+        Install-IcingaAgentBaseFeatures;
+        Write-IcingaAgentApiConfig -Port $IcingaPort;
+    }
+
+    if ((Install-IcingaAgentCertificates -Hostname $Hostname -Endpoint $IcingaParentAddresses[0] -Port $IcingaPort -CACert $CertificateCAFile -Ticket $CertificateTicket) -eq $FALSE) {
+        Disable-IcingaAgentFeature 'api';
+        Write-IcingaConsoleWarning `
+            -Message '{0}{1}{2}{3}{4}' `
+            -Objects (
+                'Your Icinga Agent API feature has been disabled. Please provide either your ca.crt ',
+                'or connect to a parent node for certificate requests. You can run "Install-IcingaAgentCertificates" ',
+                'with your configuration to properly create the host certificate and a valid certificate request. ',
+                'After this you can enable the API feature by using "Enable-IcingaAgentFeature api" and restart the ',
+                'Icinga Agent service "Restart-IcingaService icinga2"'
+            );
+    }
+
+    Write-IcingaAgentZonesConfig -Endpoints $IcingaEndpoints -EndpointConnections $IcingaParentAddresses -ParentZone $IcingaZone -GlobalZones $GlobalZones -Hostname $Hostname;
+
+    if ($InstallService) {
+        $ServiceData = Get-IcingaFrameworkServiceBinary -FrameworkServiceUrl $ServicePackageSource -Release:$ServiceSourceGitHub -ServiceDirectory $WindowsServiceDir;
+
+        Install-IcingaFrameworkService -Path $ServiceData.ServiceBin -User $ServiceUser -Password (ConvertTo-IcingaSecureString $ServicePassword) | Out-Null;
+        Register-IcingaBackgroundDaemon -Command 'Start-IcingaServiceCheckDaemon';
+    }
+
+    if ($InstallPlugins) {
+        Install-IcingaFrameworkComponent -Name 'plugins' -Release:$PluginPackageRelease -Snapshot:$PluginPackageSnapshot -Url $WindowsPluginsPackage | Out-Null;
+    }
+
+    switch ($FirewallType) {
+        '0' {
+            # Open Windows Firewall
+            Enable-IcingaFirewall -IcingaPort $IcingaPort -Force;
+            break;
+        };
+        '1' {
+            # Close Windows Firewall
+            Disable-IcingaFirewall;
+            break;
+        }
+    }
+
+    switch ($CodeCacheType) {
+        '0' {
+            # Enable Code Cache
+            Enable-IcingaFrameworkCodeCache;
+            Write-IcingaConsoleNotice 'Writing Icinga Framework Code Cache file';
+            Write-IcingaFrameworkCodeCache;
+            break;
+        };
+        '1' {
+            # Disable Code Cache
+            Disable-IcingaFrameworkCodeCache;
+            break;
+        }
+    }
+
+    Test-IcingaAgent;
+
+    if ($InstallAgent) {
+        Restart-IcingaService 'icinga2';
+    }
+
+    if ($InstallService) {
+        Restart-IcingaService 'icingapowershell';
+    }
+
+    # Update configuration and clear swap
+    $ConfigSwap = Get-IcingaPowerShellConfig -Path 'Framework.Config.Swap';
+    Set-IcingaPowerShellConfig -Path 'Framework.Config.Swap' -Value $null;
+    Set-IcingaPowerShellConfig -Path 'Framework.Config.Live' -Value $ConfigSwap;
+    $global:Icinga.InstallWizard.Config = @{ };
+    Set-IcingaPowerShellConfig -Path 'Framework.Installed' -Value $TRUE;
+
+    if ($Automated -eq $FALSE) {
+        Write-IcingaConsoleNotice 'Icinga for Windows is installed. Returning to main menu in 5 seconds'
+        Start-Sleep -Seconds 5;
+    }
+
+    $global:Icinga.InstallWizard.NextCommand   = 'Install-Icinga';
+    $global:Icinga.InstallWizard.NextArguments = @{ };
+}

--- a/lib/core/installer/menu/installation/Add-IcingaForWindowsInstallationAdvancedEntries.psm1
+++ b/lib/core/installer/menu/installation/Add-IcingaForWindowsInstallationAdvancedEntries.psm1
@@ -1,0 +1,29 @@
+function Add-IcingaForWindowsInstallationAdvancedEntries()
+{
+    $ConnectionConfiguration = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectConnection';
+
+    $OpenFirewall = '1'; # Do not open firewall
+    if ($ConnectionConfiguration -ne '0') {
+        $OpenFirewall = '0';
+    }
+
+    Disable-IcingaFrameworkConsoleOutput;
+
+    Show-IcingaForWindowsInstallationMenuEnterIcingaPort -Automated -Advanced;
+    Show-IcingaForWindowsInstallerMenuSelectOpenWindowsFirewall -DefaultInput $OpenFirewall -Automated -Advanced;
+    Show-IcingaForWindowsInstallerMenuSelectCertificate -Automated -Advanced;
+    Show-IcingaForWindowsInstallerMenuSelectGlobalZones -Automated -Advanced;
+    Show-IcingaForWindowsInstallationMenuEnterCustomGlobalZones -Automated -Advanced;
+    Show-IcingaForWindowsInstallationMenuEnterIcingaAgentVersion -Automated -Advanced;
+    Show-IcingaForWindowsInstallerMenuSelectIcingaAgentSource -Automated -Advanced;
+    Show-IcingaForWindowsInstallationMenuEnterIcingaAgentDirectory -Automated -Advanced;
+    Show-IcingaForWindowsInstallationMenuEnterIcingaAgentUser -Automated -Advanced;
+    Show-IcingaForWindowsInstallerMenuSelectIcingaPluginsSource -Automated -Advanced;
+    Show-IcingaForWindowsInstallerMenuSelectWindowsServiceSource -Automated -Advanced;
+    Show-IcingaForWindowsInstallationMenuEnterWindowsServiceDirectory -Automated -Advanced;
+    Show-IcingaForWindowsManagementConsoleEnableCodeCache -Automated -Advanced;
+
+    Enable-IcingaFrameworkConsoleOutput;
+
+    $global:Icinga.InstallWizard.NextCommand = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+}

--- a/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallationMenuEnterIcingaAgentDirectory.psm1
+++ b/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallationMenuEnterIcingaAgentDirectory.psm1
@@ -1,0 +1,30 @@
+function Show-IcingaForWindowsInstallationMenuEnterIcingaAgentDirectory()
+{
+    param (
+        [array]$Value          = @( (Join-Path -Path $Env:ProgramFiles -ChildPath 'ICINGA2') ),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Enter the path where to install the Icinga Agent into:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Allows you to override the location on where the Icinga Agent will be installed into';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues @( $Value ) `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-AgentDirectory' -Value 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentDirectory';

--- a/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallationMenuEnterIcingaAgentServicePassword.psm1
+++ b/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallationMenuEnterIcingaAgentServicePassword.psm1
@@ -1,0 +1,31 @@
+function Show-IcingaForWindowsInstallationMenuEnterIcingaAgentServicePassword()
+{
+    param (
+        [array]$Value          = @( ),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please enter the password for your service. Not required for system users!' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Allows you to provide a password for a service user account. This is only required for custom users, like a local or domain user. The default user does not require a password and should be left empty in this case';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -PasswordInput `
+        -DefaultValues @( $Value ) `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-ServicePassword' -Value 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentServicePassword';

--- a/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallationMenuEnterIcingaAgentUser.psm1
+++ b/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallationMenuEnterIcingaAgentUser.psm1
@@ -1,0 +1,48 @@
+function Show-IcingaForWindowsInstallationMenuEnterIcingaAgentUser()
+{
+    param (
+        [array]$Value          = @( 'NT Authority\NetworkService' ),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please define the user the Icinga Agent service should run with:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentServicePassword';
+                'Help'    = 'Allows you to override the default user the Icinga Agent is running with as service. In case a password is required, you can add it in the next step';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues @( $Value ) `
+        -MandatoryValue `
+        -JumpToSummary:$FALSE `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+
+    # Remove a defined password in case we are running system services
+    [string]$ServiceUser = Get-IcingaForWindowsInstallerValuesFromStep;
+
+    if ([string]::IsNullOrEmpty($ServiceUser) -eq $FALSE) {
+        $ServiceUser = $ServiceUser.ToLower();
+    } else {
+        $global:Icinga.InstallWizard.NextCommand   = 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentUser';
+        return;
+    }
+
+    if ($ServiceUser -eq 'networkservice' -Or $ServiceUser -eq 'nt authority\networkservice' -Or $ServiceUser -eq 'localsystem' -Or $ServiceUser -eq 'nt authority\localservice' -Or $ServiceUser -eq 'localservice') {
+        Remove-IcingaForWindowsInstallerConfigEntry -Menu 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentServicePassword';
+        $global:Icinga.InstallWizard.NextCommand   = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+        $global:Icinga.InstallWizard.NextArguments = @{ };
+    } else {
+        $global:Icinga.InstallWizard.NextCommand   = 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentServicePassword';
+    }
+}
+
+Set-Alias -Name 'IfW-AgentUser' -Value 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentUser';

--- a/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallationMenuEnterIcingaAgentVersion.psm1
+++ b/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallationMenuEnterIcingaAgentVersion.psm1
@@ -1,0 +1,30 @@
+function Show-IcingaForWindowsInstallationMenuEnterIcingaAgentVersion()
+{
+    param (
+        [array]$Value          = @( 'release' ),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please specify the version of the Icinga Agent you want to install:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Allows you to define which Icinga Agent version is installed on this system. The installer will search for the .MSI package for the specified version on the source location. You can either use "release" to install the highest version found, use "snapshot" to install snapshot packages or specify a direct version like "2.12.3"';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues @( $Value ) `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-AgentVersion' -Value 'Show-IcingaForWindowsInstallationMenuEnterIcingaAgentVersion';

--- a/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallerMenuEnterIcingaAgentPackageSource.psm1
+++ b/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallerMenuEnterIcingaAgentPackageSource.psm1
@@ -1,0 +1,31 @@
+function Show-IcingaForWindowsInstallerMenuEnterIcingaAgentPackageSource()
+{
+    param (
+        [array]$Value          = @( 'https://packages.icinga.com/windows/' ),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please enter the location on where to find your Icinga Agent installation package:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'The location on where to find your Icinga Agent .MSI packages. You can specify a local path "C:\icinga\msi", a network path "\\example.com\software\icinga\" or a web path "https://example.com/icinga/windows". For the last variant it is required that the web server is printing the directory file list.';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues $Value `
+        -ContinueFirstValue `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-AgentPackageSource' -Value 'Show-IcingaForWindowsInstallerMenuEnterIcingaAgentPackageSource';

--- a/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallerMenuSelectIcingaAgentSource.psm1
+++ b/lib/core/installer/menu/installation/agent/Show-IcingaForWindowsInstallerMenuSelectIcingaAgentSource.psm1
@@ -1,0 +1,42 @@
+function Show-IcingaForWindowsInstallerMenuSelectIcingaAgentSource()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '0',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please select where your Icinga Agent .MSI package is downloaded from:' `
+        -Entries @(
+            @{
+                'Caption' = 'Download from "https://packages.icinga.com"';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Download the Icinga Agent directly from "https://packages.icinga.com" for the specified version';
+            },
+            @{
+                'Caption' = 'Use custom source';
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterIcingaAgentPackageSource';
+                'Help'    = 'Specify the path on where the .MSI installer packages for the Icinga Agent can be found in your environment';
+            },
+            @{
+                'Caption' = 'Do not install Icinga Agent';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Do not install the Icinga Agent on this system';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$FALSE `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+
+    # In case we use the default location, delete our custom location entry
+    if (Get-IcingaForWindowsManagementConsoleLastInput -ne '1') {
+        Remove-IcingaForWindowsInstallerConfigEntry -Menu 'Show-IcingaForWindowsInstallerMenuEnterIcingaAgentPackageSource';
+    }
+}
+
+Set-Alias -Name 'IfW-AgentSource' -Value 'Show-IcingaForWindowsInstallerMenuSelectIcingaAgentSource';

--- a/lib/core/installer/menu/installation/certificate/Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile.psm1
+++ b/lib/core/installer/menu/installation/certificate/Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile.psm1
@@ -1,0 +1,32 @@
+function Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    $Advanced = $TRUE;
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please enter the path to your ca.crt file. This can be a local, network share or web address:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'To sign certificates locally you can copy the Icinga CA master "ca.crt" file (normally located at "/var/lib/icinga2/ca") to a location you can access from this host. Enter the full path on where you stored the "ca.crt" file. You can provide a local path "C:\users\public\ca.crt", a network share "\\share.example.com\icinga\ca.crt" or a web address "https://example.com/icinga/ca.crt"';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues @( $Value ) `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-CAFile' -Value 'Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile';

--- a/lib/core/installer/menu/installation/certificate/Show-IcingaForWindowsInstallerMenuEnterIcingaTicket.psm1
+++ b/lib/core/installer/menu/installation/certificate/Show-IcingaForWindowsInstallerMenuEnterIcingaTicket.psm1
@@ -1,0 +1,32 @@
+function Show-IcingaForWindowsInstallerMenuEnterIcingaTicket()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    $Advanced = $TRUE;
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please enter your ticket for signing the Icinga certificate:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'The ticket required for signing your local Icinga certificate. You can get the ticket from the Icinga Director for this host or from your Icinga CA master by running "icinga2 pki ticket --cn <hostname as selected before>"';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues @( $Value ) `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-Ticket' -Value 'Show-IcingaForWindowsInstallerMenuEnterIcingaTicket';

--- a/lib/core/installer/menu/installation/certificate/Show-IcingaForWindowsInstallerMenuSelectCertificate.psm1
+++ b/lib/core/installer/menu/installation/certificate/Show-IcingaForWindowsInstallerMenuSelectCertificate.psm1
@@ -1,0 +1,54 @@
+function Show-IcingaForWindowsInstallerMenuSelectCertificate()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '0',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'How do you want to create the Icinga certificate?' `
+        -Entries @(
+            @{
+                'Caption' = 'Sign certificate manually on the Icinga CA master';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'This option will not require you to provide additional details for certificate generation and only require a connection to/from this host. You will have to sign the certificate manually on the Icinga CA master with "icinga2 ca sign <request>"';
+            },
+            @{
+                'Caption' = 'Sign certificate with a ticket';
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterIcingaTicket';
+                'Help'    = 'By selecting this option, this host will connect to a parent Icinga node and sign the certificate with a ticket you have to provide in the next step';
+            },
+            @{
+                'Caption' = 'Sign certificate with local ca.crt';
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile';
+                'Help'    = 'This will allow you to sign the certificate for this host directly on this machine. For this you will have to store your Icinga ca.crt somewhere accessible to this system. In the next step you are asked to provide the path to the location of your ca.crt';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$FALSE `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+
+    # Make sure we delete configuration no longer required
+    switch (Get-IcingaForWindowsManagementConsoleLastInput) {
+        '0' {
+            Remove-IcingaForWindowsInstallerConfigEntry -Menu 'Show-IcingaForWindowsInstallerMenuEnterIcingaTicket';
+            Remove-IcingaForWindowsInstallerConfigEntry -Menu 'Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile';
+            break;
+        };
+        '1' {
+            Remove-IcingaForWindowsInstallerConfigEntry -Menu 'Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile';
+            break;
+        };
+        '2' {
+            Remove-IcingaForWindowsInstallerConfigEntry -Menu 'Show-IcingaForWindowsInstallerMenuEnterIcingaTicket';
+            break;
+        };
+    }
+}
+
+Set-Alias -Name 'IfW-Certificate' -Value 'Show-IcingaForWindowsInstallerMenuSelectCertificate';

--- a/lib/core/installer/menu/installation/director/Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate.psm1
+++ b/lib/core/installer/menu/installation/director/Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate.psm1
@@ -1,0 +1,192 @@
+function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
+{
+    param (
+        [switch]$Register = $FALSE
+    );
+
+    $DirectorUrl    = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorUrl';
+    $SelfServiceKey = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceKey';
+
+    # Once we run this menu, we require to reset everything to have a proper state
+    if ($Register -eq $FALSE) {
+        $global:Icinga.InstallWizard.Config = @{ };
+
+        Add-IcingaForWindowsInstallerConfigEntry -Selection 'c' -Values $DirectorUrl -OverwriteValues -OverwriteMenu 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorUrl';
+        Add-IcingaForWindowsInstallerConfigEntry -Selection 'c' -Values $SelfServiceKey -OverwriteValues -OverwriteMenu 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceKey';
+    } else {
+        $HostnameType = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectHostname';
+        $Hostname     = '';
+
+        switch ($HostnameType) {
+            '0' {
+                $Hostname = (Get-IcingaHostname -AutoUseFQDN 1);
+                break;
+            };
+            '1' {
+                $Hostname = (Get-IcingaHostname -AutoUseFQDN 1 -LowerCase 1);
+                break;
+            };
+            '2' {
+                $Hostname = (Get-IcingaHostname -AutoUseFQDN 1 -UpperCase 1);
+                break;
+            };
+            '3' {
+                $Hostname = (Get-IcingaHostname -AutoUseHostname 1);
+                break;
+            };
+            '4' {
+                $Hostname = (Get-IcingaHostname -AutoUseHostname 1 -LowerCase 1);
+                break;
+            };
+            '5' {
+                $Hostname = (Get-IcingaHostname -AutoUseHostname 1 -UpperCase 1);
+                break;
+            };
+        }
+
+        try {
+            $SelfServiceKey = Register-IcingaDirectorSelfServiceHost -DirectorUrl $DirectorUrl -ApiKey $SelfServiceKey -Hostname $Hostname;
+        } catch {
+            Write-IcingaConsoleNotice 'Host seems already to be registered within Icinga Director. Trying local Api key if present'
+            $SelfServiceKey = Get-IcingaPowerShellConfig -Path 'IcingaDirector.SelfService.ApiKey';
+
+            if ([string]::IsNullOrEmpty($SelfServiceKey)) {
+                Write-IcingaConsoleNotice 'No local Api key was found and using your provided template key failed. Please ensure the host is not already registered and drop the set Self-Service key within the Icinga Director for this host.'
+            }
+        }
+        Add-IcingaForWindowsInstallerConfigEntry -Selection 'c' -Values $SelfServiceKey -OverwriteValues -OverwriteMenu 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceKey';
+    }
+
+    try {
+        $DirectorConfig = Get-IcingaDirectorSelfServiceConfig -DirectorUrl $DirectorUrl -ApiKey $SelfServiceKey;
+    } catch {
+        Set-IcingaForWindowsManagementConsoleMenu 'Show-IcingaForWindowsInstallerConfigurationSummary';
+        $global:Icinga.InstallWizard.LastError = 'Failed to fetch host configuration with the given Director Url and Self-Service key. Please ensure the template key is correct and in case a previous host key was used, that it matches the one configured within the Icinga Director. In case this form was loaded previously with a key, it might be that the host key is no longer valid and requires to be dropped. In addition please ensure that this host can connect to the Icinga Director and the SSL certificate is trusted. Otherwise run "Enable-IcingaUntrustedCertificateValidation" before starting the management console. Otherwise modify the "DirectorSelfServiceKey" configuration element above with the correct key and try again.';
+        return;
+    }
+
+    # No we need to identify which host selection is matching our config
+    $HostnameSelection        = -1;
+    $InstallPluginsSelection  = -1;
+    $InstallServiceSelection  = -1;
+    $WindowsFirewallSelection = 1;
+
+    $ServiceUserName          = $DirectorConfig.icinga_service_user;
+    $AgentPackageSelection    = 1; #Always use custom source
+    $AgentPackageSource       = $DirectorConfig.download_url;
+    $AgentVersion             = $DirectorConfig.release;
+    $IcingaPort               = $DirectorConfig.agent_listen_port;
+    $GlobalZones              = @();
+    $IcingaParents            = @();
+    $IcingaParentAddresses    = New-Object PSCustomObject;
+    $ParentZone               = '';
+    $MasterAddress            = '';
+
+    if ($DirectorUrl.ToLower().Contains('https://') -Or $DirectorUrl.ToLower().Contains('http://')) {
+        $MasterAddress = $DirectorUrl.Split('/')[2];
+    } else {
+        $MasterAddress = $DirectorUrl.Split('/')[0];
+    }
+
+    if ($Register) {
+        if ($null -ne $DirectorConfig.agent_add_firewall_rule -And $DirectorConfig.agent_add_firewall_rule) {
+            # Open Windows Firewall
+            $WindowsFirewallSelection = 0;
+        }
+
+        if ($null -ne $DirectorConfig.global_zones) {
+            $GlobalZones = $DirectorConfig.global_zones;
+        }
+
+        if ($null -ne $DirectorConfig.parent_endpoints) {
+            $IcingaParents = $DirectorConfig.parent_endpoints;
+        }
+
+        if ($null -ne $DirectorConfig.endpoints_config) {
+            [int]$Index = 0;
+            foreach ($entry in $DirectorConfig.endpoints_config) {
+                $IcingaParentAddresses | Add-Member -MemberType NoteProperty -Name ($IcingaParents[$Index]) -Value (($entry.Split(';')[0]));
+                $Index += 1;
+            }
+        }
+
+        if ($null -ne $DirectorConfig.parent_zone) {
+            $ParentZone = $DirectorConfig.parent_zone;
+        }
+    }
+
+    if ($DirectorConfig.fetch_agent_fqdn) {
+        switch ($DirectorConfig.transform_hostname) {
+            '0' {
+                # FQDN as it is
+                $HostnameSelection = 0;
+                break;
+            };
+            '1' {
+                # FQDN to lowercase
+                $HostnameSelection = 1;
+                break;
+            };
+            '2' {
+                # FQDN to uppercase
+                $HostnameSelection = 2;
+                break;
+            }
+        }
+    } elseif ($DirectorConfig.fetch_agent_name) {
+        switch ($DirectorConfig.transform_hostname) {
+            '0' {
+                # Hostname as it is
+                $HostnameSelection = 3;
+                break;
+            };
+            '1' {
+                # Hostname to lowercase
+                $HostnameSelection = 4;
+                break;
+            };
+            '2' {
+                # Hostname to uppercase
+                $HostnameSelection = 5;
+                break;
+            }
+        }
+    }
+
+    if ($DirectorConfig.install_framework_service -eq 0) {
+        # Do not install
+        $InstallServiceSelection = 2;
+    } else {
+        # TODO: This is currently not supported. We use the "default" config for installing from GitHub by now
+        $InstallServiceSelection = 0;
+    }
+
+    if ($DirectorConfig.install_framework_plugins -eq 0) {
+        # Do not install
+        $InstallPluginsSelection = 3;
+    } else {
+        # TODO: This is currently not supported. We use the "default" config for installing from GitHub by now
+        $InstallPluginsSelection = 0;
+    }
+
+    Disable-IcingaFrameworkConsoleOutput;
+    Show-IcingaForWindowsInstallerMenuSelectHostname -DefaultInput $HostnameSelection -Automated;
+    Add-IcingaForWindowsInstallationAdvancedEntries;
+    Disable-IcingaFrameworkConsoleOutput;
+
+    Show-IcingaForWindowsInstallerMenuSelectIcingaPluginsSource -DefaultInput $InstallPluginsSelection -Value @() -Automated;
+    Show-IcingaForWindowsInstallerMenuSelectWindowsServiceSource -DefaultInput $InstallServiceSelection -Value @() -Automated;
+    Show-IcingaForWindowsInstallerMenuSelectOpenWindowsFirewall -DefaultInput $WindowsFirewallSelection -Value @() -Automated;
+
+    if ($Register) {
+        Show-IcingaForWindowsInstallationMenuEnterCustomGlobalZones -Value $GlobalZones -Automated;
+        Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes -Value $IcingaParents -Automated;
+        Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses -Value $IcingaParentAddresses -Automated;
+        Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone -Value $ParentZone -Automated;
+    }
+
+    Show-IcingaForWindowsManagementConsoleInstallationDirectorRegisterHost -Automated;
+
+    Enable-IcingaFrameworkConsoleOutput;
+    Reset-IcingaForWindowsManagementConsoleInstallationDirectorConfigModifyState;
+}

--- a/lib/core/installer/menu/installation/director/Show-IcingaForWindowsManagementConsoleInstallationDirectorRegisterHost.psm1
+++ b/lib/core/installer/menu/installation/director/Show-IcingaForWindowsManagementConsoleInstallationDirectorRegisterHost.psm1
@@ -1,0 +1,40 @@
+function Show-IcingaForWindowsManagementConsoleInstallationDirectorRegisterHost()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '0',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    $Advanced = $TRUE;
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Do you want to register the host right now inside the Icinga Director? This will show missing configurations.' `
+        -Entries @(
+            @{
+                'Caption' = 'Do not register host inside Icinga Director';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'If you do not want to modify extended properties for this host and use default values from the Icinga Director, based on the Self-Service API configuration, use this option and complete the installation process afterwards.';
+            },
+            @{
+                'Caption' = 'Register host inside Icinga Director';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'You can select this option to register the host within the Icinga Director right now, unlocking more advanced configurations for this host like "Parent Zone", "Parent Nodes" and "Parent Node Addresses"';
+                'Action'  = @{
+                    'Command'   = 'Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate';
+                    'Arguments' = @{
+                        '-Register' = $TRUE;
+                    }
+                }
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$FALSE `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-DirectorRegisterHost' -Value 'Show-IcingaForWindowsManagementConsoleInstallationDirectorRegisterHost';

--- a/lib/core/installer/menu/installation/director/Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceKey.psm1
+++ b/lib/core/installer/menu/installation/director/Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceKey.psm1
@@ -1,0 +1,43 @@
+function Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceKey()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    if ($null -eq $Value -or $Value.Count -eq 0) {
+        $LocalApiKey = Get-IcingaPowerShellConfig -Path 'IcingaDirector.SelfService.ApiKey';
+        if ([string]::IsNullOrEmpty($LocalApiKey) -eq $FALSE) {
+            $Value += $LocalApiKey;
+        }
+    }
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please enter the Self-Service API key for the Host-Template to use:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'This is the Self-Service API for the host template to use. To get this, you will have to set the host template to be an "Icinga 2 Agent" template inside the Icinga Director. Afterwards you see an "Agent" tab on the top right navigation, providing you with the key. In case you entered this menu for the first time and see a key already present, this means the installer already run once and therefor you will be presented with your host key. If a host is already present within the Icinga Director, you can also use the "Agent" tab to get the key of this host directly to enter here';
+                'Action'  = @{
+                    'Command'   = 'Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate';
+                    'Arguments' = @{
+                        '-Register' = $FALSE;
+                    }
+                }
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues $Value `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-DirectorSelfServiceKey' -Value 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceKey';

--- a/lib/core/installer/menu/installation/director/Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorUrl.psm1
+++ b/lib/core/installer/menu/installation/director/Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorUrl.psm1
@@ -1,0 +1,30 @@
+function Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorUrl()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please enter the URL pointing to your Icinga Director module:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceKey';
+                'Help'    = 'The Icinga Web 2 url pointing directly to the root of the Icinga Director module. Example: "https://example.com/icingaweb2/director" or "https://icinga.example.com/director"';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues $Value `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-DirectorUrl' -Value 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorUrl';

--- a/lib/core/installer/menu/installation/firewall/Show-IcingaForWindowsInstallerMenuSelectOpenWindowsFirewall.psm1
+++ b/lib/core/installer/menu/installation/firewall/Show-IcingaForWindowsInstallerMenuSelectOpenWindowsFirewall.psm1
@@ -1,0 +1,32 @@
+function Show-IcingaForWindowsInstallerMenuSelectOpenWindowsFirewall()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '1',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please select if your Windows Firewall should be opened for the Icinga port:' `
+        -Entries @(
+            @{
+                'Caption' = 'Open Windows Firewall for incoming Icinga connections';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'This will open the Windows Firewall for the configured Icinga Port, to allow incoming communication from Icinga parent node(s)';
+            },
+            @{
+                'Caption' = 'Do not open Windows Firewall for incoming Icinga connections';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Do not open the Windows firewall for any incoming Icinga connections. Please note that in case your Icinga Agent is configured for "Connecting from parent system" you will not be able to establish a communication unless the connection type is changed or the port is opened';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$FALSE `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-WindowsFirewall' -Value 'Show-IcingaForWindowsInstallerMenuSelectOpenWindowsFirewall';

--- a/lib/core/installer/menu/installation/framework/Show-IcingaForWindowsManagementConsoleEnableCodeCache.psm1
+++ b/lib/core/installer/menu/installation/framework/Show-IcingaForWindowsManagementConsoleEnableCodeCache.psm1
@@ -1,0 +1,32 @@
+function Show-IcingaForWindowsManagementConsoleEnableCodeCache()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '0',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Do you want to enable the Icinga Framework Code Cache?' `
+        -Entries @(
+            @{
+                'Caption' = 'Enable Icinga Framework Code Cache ';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Enables the Icinga Framework Code Cache feature during installation to decrease the loading time of the Icinga Framework. Please note that for each custom modification you do on the Icinga Framework afterwards, you will have to call "Write-IcingaFrameworkCodeCache" to rebuild the cache';
+            },
+            @{
+                'Caption' = 'Disable Icinga Framework Code Cache';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Does not enable the Icinga Framework Code Cache and disables it during the installation process';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$FALSE `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-CodeCache' -Value 'Show-IcingaForWindowsManagementConsoleEnableCodeCache';

--- a/lib/core/installer/menu/installation/general/Export-IcingaForWindowsManagementConsoleInstallationAnswerFile.psm1
+++ b/lib/core/installer/menu/installation/general/Export-IcingaForWindowsManagementConsoleInstallationAnswerFile.psm1
@@ -1,0 +1,19 @@
+function Export-IcingaForWindowsManagementConsoleInstallationAnswerFile()
+{
+    $FilePath = '';
+    $Value    = $global:Icinga.InstallWizard.LastValues;
+
+    if ($null -ne $Value -And $Value.Count -ne 0) {
+        $FilePath = $Value[0]
+    }
+
+    if (Test-Path ($FilePath)) {
+        Set-Content -Path (Join-Path -Path $FilePath -ChildPath 'IfW_answer.json') -Value (Get-IcingaForWindowsManagementConsoleConfigurationString);
+        $global:Icinga.InstallWizard.NextCommand = 'Install-Icinga';
+        $global:Icinga.InstallWizard.LastNotice  = ([string]::Format('Answer file "IfW_answer.json" successfully exported into "{0}"', $FilePath));
+        Clear-IcingaForWindowsManagementConsolePaginationCache;
+    } else {
+        $global:Icinga.InstallWizard.LastError   = ([string]::Format('The provided path to store the answer file is invalid: "{0}"', $FilePath));
+        $global:Icinga.InstallWizard.NextCommand = 'Show-IcingaForWindowsManagementConsoleInstallationFileExport';
+    }
+}

--- a/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerConfigurationSummary.psm1
+++ b/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerConfigurationSummary.psm1
@@ -1,0 +1,103 @@
+function Show-IcingaForWindowsInstallerConfigurationSummary()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    [array]$Entries    = @();
+    [int]$CurrentIndex = 0
+
+    Enable-IcingaForWindowsInstallationHeaderPrint;
+
+    while ($TRUE) {
+        if ($CurrentIndex -gt $global:Icinga.InstallWizard.Config.Count) {
+            break;
+        }
+
+        foreach ($entry in $global:Icinga.InstallWizard.Config.Keys) {
+            $ConfigEntry = $global:Icinga.InstallWizard.Config[$entry];
+
+            if ($ConfigEntry.Index -ne $CurrentIndex) {
+                continue;
+            }
+
+            if ($ConfigEntry.Hidden) {
+                continue;
+            }
+
+            if ($ConfigEntry.Advanced -And $global:Icinga.InstallWizard.ShowAdvanced -eq $FALSE) {
+                continue;
+            }
+
+            $EntryValue = $ConfigEntry.Selection;
+            if ($null -ne $ConfigEntry.Values -And $ConfigEntry.Count -ne 0) {
+                if ($ConfigEntry.Password) {
+                    $EntryValue = ConvertFrom-IcingaArrayToString -Array $ConfigEntry.Values -AddQuotes -SecureContent;
+                } else {
+                    $EntryValue = ConvertFrom-IcingaArrayToString -Array $ConfigEntry.Values -AddQuotes;
+                }
+            }
+
+            [string]$Caption = ''
+            $PrintName       = $entry;
+            $RealCommand     = $entry;
+            $ChildElement    = '';
+
+            if ($RealCommand.Contains(':')) {
+                $RealCommand  = $entry.Split(':')[0];
+                $ChildElement = $entry.Split(':')[1];
+            }
+
+            if ($entry.Contains(':')) {
+                $PrintName = [string]::Format('{0} for "{1}"', $RealCommand, $ChildElement);
+            } else {
+                $PrintName = $RealCommand;
+            }
+
+            $PrintName = $PrintName.Replace('IfW-', '');
+
+            if (Test-Numeric ($ConfigEntry.Selection)) {
+                Set-IcingaForWindowsInstallationHeaderSelection -Selection $ConfigEntry.Selection;
+
+                &$RealCommand;
+
+                $Caption = ([string]::Format('{0}: {1}', $PrintName, $global:Icinga.InstallWizard.HeaderPreview));
+            } else {
+                $Caption = ([string]::Format('{0}: {1}', $PrintName, $EntryValue));
+            }
+
+            $Entries += @{
+                'Caption'   = $Caption;
+                'Command'   = $entry;
+                'Arguments' = @{ '-JumpToSummary' = $TRUE };
+                'Help'      = ''
+            }
+
+            $global:Icinga.InstallWizard.HeaderPreview = '';
+        }
+
+        $CurrentIndex += 1;
+    }
+
+    Disable-IcingaForWindowsInstallationHeaderPrint;
+    Enable-IcingaForWindowsInstallationJumpToSummary;
+
+    $global:Icinga.InstallWizard.DisplayAdvanced = $TRUE;
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please validate your configuration. Installation starts on continue:' `
+        -Entries $Entries `
+        -DefaultIndex 'c' `
+        -ContinueFunction 'Show-IcingaForWindowsInstallerMenuFinishInstaller' `
+        -ConfigElement `
+        -Hidden;
+
+    Disable-IcingaForWindowsInstallationJumpToSummary;
+    $global:Icinga.InstallWizard.DisplayAdvanced = $FALSE;
+}
+
+Set-Alias -Name 'IfW-ConfigurationSummary' -Value 'Show-IcingaForWindowsInstallerConfigurationSummary';

--- a/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerMenuContinueConfiguration.psm1
+++ b/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerMenuContinueConfiguration.psm1
@@ -1,0 +1,16 @@
+function Show-IcingaForWindowsInstallerMenuContinueConfiguration()
+{
+    $SwapConfig                         = Get-IcingaPowerShellConfig -Path 'Framework.Config.Swap';
+    $global:Icinga.InstallWizard.Config = Convert-IcingaForwindowsManagementConsoleJSONConfig -Config $SwapConfig;
+    [string]$Menu                       = Get-IcingaForWindowsInstallerLastParent;
+
+    # We don't need the last entry, as this will be added anyways because we are
+    # starting right from there and it will be added anyway
+    Remove-IcingaForWindowsInstallerLastParent;
+
+    if ($Menu.Contains(':')) {
+        $Menu = Get-IcingaForWindowsInstallerLastParent;
+    }
+
+    $global:Icinga.InstallWizard.NextCommand = $Menu;
+}

--- a/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerMenuFinishInstaller.psm1
+++ b/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerMenuFinishInstaller.psm1
@@ -1,0 +1,38 @@
+function Show-IcingaForWindowsInstallerMenuFinishInstaller()
+{
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'How you do want to proceed:' `
+        -Entries @(
+            @{
+                'Caption'  = 'Start installation';
+                'Command'  = 'Start-IcingaForWindowsInstallation';
+                'Help'     = 'Apply the just configured configuration and install components as selected';
+                'Disabled' = (-Not ($global:Icinga.InstallWizard.AdminShell));
+                'Action'   = @{
+                    'Command' = 'Clear-IcingaForWindowsManagementConsolePaginationCache';
+                }
+            },
+            @{
+                'Caption' = 'Export answer file';
+                'Command' = 'Show-IcingaForWindowsManagementConsoleInstallationFileExport';
+                'Help'    = 'Allows you to export a JSON file containing all settings configured during this step and use it on another system';
+            },
+            @{
+                'Caption' = 'Print installation command';
+                'Command' = 'Show-IcingaForWindowsManagementConsoleInstallationConfigString';
+                'Help'    = 'Allows you to export a simple configuration command you can run on another system. Similar to the "Export answer file" option, but does not require to distribute files';
+            },
+            @{
+                'Caption' = 'Save current configuration and go to main menu';
+                'Command' = 'Install-Icinga';
+                'Help'    = 'Keep the current configuration as "swap" and exit to the main menu';
+                'Action'  = @{
+                    'Command' = 'Clear-IcingaForWindowsManagementConsolePaginationCache';
+                }
+            }
+        ) `
+        -DefaultIndex 0 `
+        -Hidden;
+}
+
+Set-Alias -Name 'IfW-FinishInstaller' -Value 'Show-IcingaForWindowsInstallerMenuFinishInstaller';

--- a/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerMenuInstallWindows.psm1
+++ b/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerMenuInstallWindows.psm1
@@ -1,0 +1,33 @@
+function Show-IcingaForWindowsInstallerMenuInstallWindows()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '0',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    if ($null -eq (Get-IcingaPowerShellConfig -Path 'Framework.Config.Swap')) {
+        Show-IcingaForWindowsInstallerMenuSelectConnection;
+        return;
+    }
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Choose the configuration type:' `
+        -Entries @(
+            @{
+                'Caption' = 'New configuration';
+                'Command' = 'Show-IcingaForWindowsInstallerMenuNewConfiguration';
+                'Help'    = 'Start a new configuration and truncate all information stored on the current swap file. This will only modify your production if you hit "Start installation" at the end';
+            },
+            @{
+                'Caption' = 'Continue configuration';
+                'Command' = 'Show-IcingaForWindowsInstallerMenuContinueConfiguration';
+                'Help'    = 'Continue with the previous configuration swap file.';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}

--- a/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerMenuNewConfiguration.psm1
+++ b/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerMenuNewConfiguration.psm1
@@ -1,0 +1,5 @@
+function Show-IcingaForWindowsInstallerMenuNewConfiguration()
+{
+    $global:Icinga.InstallWizard.Config = @{ };
+    Show-IcingaForWindowsInstallerMenuSelectConnection;
+}

--- a/lib/core/installer/menu/installation/general/Show-IcingaForWindowsManagementConsoleInstallationConfigString.psm1
+++ b/lib/core/installer/menu/installation/general/Show-IcingaForWindowsManagementConsoleInstallationConfigString.psm1
@@ -1,0 +1,27 @@
+function Show-IcingaForWindowsManagementConsoleInstallationConfigString()
+{
+    [string]$ConfigurationString = [string]::Format(
+        "{0}Install-Icinga -InstallCommand '{1}'{0}",
+        (New-IcingaNewLine),
+        (Get-IcingaForWindowsManagementConsoleConfigurationString -Compress)
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Here is your configuration command for Icinga for Windows:' `
+        -Entries @(
+            @{
+                'Caption' = '';
+                'Command' = 'Install-Icinga';
+                'Help'    = 'This command provides a list of settings you entered or modified during the process. In case values are not modified, they do not show up here and are left as default. You can run this entire command on a different Windows host to apply the same configuration';
+                'Action'  = @{
+                    'Command' = 'Clear-IcingaForWindowsManagementConsolePaginationCache';
+                }
+            }
+        ) `
+        -AddConfig `
+        -DefaultValues @( $ConfigurationString ) `
+        -ConfigLimit 1 `
+        -DefaultIndex 'c' `
+        -ReadOnly `
+        -Hidden;
+}

--- a/lib/core/installer/menu/installation/general/Show-IcingaForWindowsManagementConsoleInstallationFileExport.psm1
+++ b/lib/core/installer/menu/installation/general/Show-IcingaForWindowsManagementConsoleInstallationFileExport.psm1
@@ -1,0 +1,24 @@
+function Show-IcingaForWindowsManagementConsoleInstallationFileExport()
+{
+    $FilePath = $ENV:USERPROFILE;
+
+    if ($null -ne $global:Icinga.InstallWizard.LastValues -And $global:Icinga.InstallWizard.LastValues.Count -ne 0) {
+        $FilePath = $global:Icinga.InstallWizard.LastValues[0];
+    }
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Where do you want to export the answer file to? The filename "IfW_answer.json" is added automatically.' `
+        -Entries @(
+            @{
+                'Caption' = '';
+                'Command' = 'Export-IcingaForWindowsManagementConsoleInstallationAnswerFile';
+                'Help'    = 'This will all you to export the answer file with the given configuration. You can install Icinga for Windows with this file by using the command "Install-Icinga -AnswerFile <path to the file>".';
+            }
+        ) `
+        -AddConfig `
+        -DefaultValues @( $FilePath ) `
+        -ConfigLimit 1 `
+        -DefaultIndex 'c' `
+        -MandatoryValue `
+        -Hidden;
+}

--- a/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallationMenuEnterIcingaPort.psm1
+++ b/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallationMenuEnterIcingaPort.psm1
@@ -1,0 +1,30 @@
+function Show-IcingaForWindowsInstallationMenuEnterIcingaPort()
+{
+    param (
+        [array]$Value          = @( 5665 ),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please enter your parent Icinga communication port:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'This is the port Icinga will use for communicating with all parent nodes and for which the firewall must be opened, depending on your communication configuration. Defaults to 5665';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues @( $Value ) `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-Port' -Value 'Show-IcingaForWindowsInstallationMenuEnterIcingaPort';

--- a/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses.psm1
+++ b/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses.psm1
@@ -1,0 +1,152 @@
+function Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = $null,
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    if ($Value.Count -ne 0) {
+
+        while ($TRUE) {
+            # Use the installer file/command for automation
+            if ($Value[0].GetType().Name.ToLower() -eq 'pscustomobject') {
+
+                # This is just to handle automated installation by using a file or the install command
+                # We use a hashtable here as well, but reduce complexity and remove network checks
+
+                foreach ($endpoint in  $Value[0].PSObject.Properties) {
+                    Add-IcingaForWindowsInstallerConfigEntry -Selection 'c' -Values $endpoint.Value `
+                        -OverwriteValues `
+                        -OverwriteMenu 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses' `
+                        -OverwriteParent ([string]::Format('Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes:{0}', $endpoint.Name));
+                }
+
+                return;
+
+            } elseif ($Value[0].GetType().Name.ToLower() -eq 'hashtable') { # We will be forwarded this from Test-IcingaForWindowsInstallerParentEndpoints
+
+                $NetworkMap        = $Value[0];
+                [int]$AddressIndex = 0;
+
+                foreach ($entry in $NetworkMap.Keys) {
+                    $EndpointConfig = $NetworkMap[$entry];
+
+                    if ($EndpointConfig.Error -eq $FALSE) {
+                        $AddressIndex += 1;
+                        continue;
+                    }
+
+                    $global:Icinga.InstallWizard.LastError = ([string]::Format('Failed to resolve the address for the following endpoint: {0}', $EndpointConfig.Endpoint));
+
+                    $Address = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses' -Parent $EndpointConfig.Endpoint;
+
+                    if ($null -eq $Address -Or $Address.Count -eq 0) {
+                        $Address = @( $EndpointConfig.Address );
+                    }
+
+                    Show-IcingaForWindowsInstallerMenu `
+                        -Header ([string]::Format('Please enter the connection data for endpoint: "{0}"', $EndpointConfig.Endpoint)) `
+                        -Entries @(
+                            @{
+                                'Command' = 'break';
+                                'Help'    = 'The address to communicate with your parent Icinga node. It is highly recommended to use an IP address instead of a FQDN';
+                            }
+                        ) `
+                        -AddConfig `
+                        -ConfigLimit 1 `
+                        -DefaultValues $Address `
+                        -MandatoryValue `
+                        -ParentConfig ([string]::Format('Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes:{0}', $EndpointConfig.Endpoint)) `
+                        -JumpToSummary:$JumpToSummary `
+                        -ConfigElement `
+                        -Automated:$Automated `
+                        -Advanced:$Advanced;
+
+                    $NewAddress = $Address;
+                    $NewValue   = $Value;
+
+                    if ((Test-IcingaForWindowsManagementConsoleContinue)) {
+                        $ParentAddress = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses' -Parent $EndpointConfig.Endpoint;
+                        $NetworkTest   = Convert-IcingaEndpointsToIPv4 -NetworkConfig $ParentAddress;
+                        $NewAddress    = $ParentAddress;
+
+                        if ($NetworkTest.HasErrors -eq $FALSE) {
+                            Add-IcingaForWindowsInstallerConfigEntry -Selection 'c' -Values ($NetworkTest.Network[0]) -OverwriteValues -OverwriteMenu 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses';
+                            $AddressIndex += 1;
+                            $NewValue[0][$entry].Error = $FALSE;
+                            continue;
+                        }
+                    }
+
+                    Set-IcingaForWindowsManagementConsoleMenu -Menu 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses';
+
+                    $NewValue[0][$entry].Address = $NewAddress;
+
+                    $global:Icinga.InstallWizard.NextArguments = @{
+                        'Value'         = $NewValue;
+                        'DefaultInput'  = $DefaultInput;
+                        'JumpToSummary' = $JumpToSummary;
+                        'Automated'     = $Automated;
+                        'Advanced'      = $Advanced;
+                    };
+
+                    return;
+                }
+
+                $global:Icinga.InstallWizard.NextCommand = 'Add-IcingaForWindowsInstallationAdvancedEntries';
+                return;
+            } elseif ($Value[0].GetType().Name.ToLower() -eq 'string') {
+                $Address = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses' -Parent $Value[0];
+
+                Show-IcingaForWindowsInstallerMenu `
+                    -Header ([string]::Format('Please enter the connection data for endpoint: "{0}"', $Value[0])) `
+                    -Entries @(
+                        @{
+                            'Command' = 'break';
+                            'Help'    = 'The address to communicate with your parent Icinga node. It is highly recommended to use an IP address instead of a FQDN';
+                        }
+                    ) `
+                    -AddConfig `
+                    -ConfigLimit 1 `
+                    -DefaultValues $Address `
+                    -MandatoryValue `
+                    -ParentConfig ([string]::Format('Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes:{0}', $Value[0])) `
+                    -JumpToSummary:$JumpToSummary `
+                    -ConfigElement `
+                    -Automated:$Automated `
+                    -Advanced:$Advanced;
+
+                if ((Test-IcingaForWindowsManagementConsoleContinue)) {
+                    $ParentAddress = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses' -Parent $Value[0];
+                    $NetworkTest   = Convert-IcingaEndpointsToIPv4 -NetworkConfig $ParentAddress;
+
+                    if ($NetworkTest.HasErrors -eq $FALSE) {
+                        Add-IcingaForWindowsInstallerConfigEntry -Selection 'c' -Values ($NetworkTest.Network[0]) -OverwriteValues -OverwriteMenu 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses';
+                        $global:Icinga.InstallWizard.NextCommand = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                        return;
+                    }
+                }
+            }
+
+            if ((Test-IcingaForWindowsManagementConsoleExit) -Or (Test-IcingaForWindowsManagementConsoleMenu) -Or (Test-IcingaForWindowsManagementConsolePrevious)) {
+                return;
+            }
+
+            if ((Test-IcingaForWindowsManagementConsoleDelete)) {
+                continue;
+            }
+        }
+
+        # Just to ensure we never are "trapped" in a endless loop
+        if ($Automated) {
+            break;
+        }
+    }
+
+    $global:Icinga.InstallWizard.NextCommand = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+}
+
+Set-Alias -Name 'IfW-ParentAddress' -Value 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses';

--- a/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes.psm1
+++ b/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes.psm1
@@ -1,0 +1,39 @@
+function Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    $Endpoints = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes';
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please enter your parent Icinga node name(s):' `
+        -Entries @(
+            @{
+                'Command' = 'Test-IcingaForWindowsInstallerParentEndpoints';
+                'Help'    = 'These are the object names for your parent Icinga endpoints as defined within the zones.conf. If you are running multiple Icinga instances within the same zone, you require to add both of them';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 2 `
+        -DefaultValues $Value `
+        -ContinueFirstValue `
+        -MandatoryValue `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+
+    # In case we delete our parent config, ensure we also delete our endpoint addresses
+    if (Test-IcingaForWindowsManagementConsoleDelete) {
+        foreach ($endpoint in $Endpoints) {
+            Remove-IcingaForWindowsInstallerConfigEntry -Menu 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses' -Parent $endpoint;
+        }
+    }
+}
+
+Set-Alias -Name 'IfW-ParentNodes' -Value 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes';

--- a/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone.psm1
+++ b/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone.psm1
@@ -1,0 +1,30 @@
+function Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone()
+{
+    param (
+        [array]$Value          = @( 'master' ),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please enter your parent Icinga zone:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes';
+                'Help'    = 'The object name of the zone of the parent Icinga node(s) you want to communicate with, as defined within the zones.conf';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues $Value `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-ParentZone' -Value 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone';

--- a/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallerMenuSelectConnection.psm1
+++ b/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallerMenuSelectConnection.psm1
@@ -1,0 +1,42 @@
+function Show-IcingaForWindowsInstallerMenuSelectConnection()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '0',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'How do you want to configure your local Icinga Agent?' `
+        -Entries @(
+            @{
+                'Caption' = 'Connecting from this system';
+                'Command' = 'Show-IcingaForWindowsInstallerMenuSelectHostname';
+                'Help'    = 'Choose this option if your Icinga Agent should only connect to a parent Icinga node. This is the easiest configuration as certificate generation is done automatically.'
+            },
+            @{
+                'Caption' = 'Connecting from parent system';
+                'Command' = 'Show-IcingaForWindowsInstallerMenuSelectHostname';
+                'Help'    = 'Choose this option if the Icinga Agent should not or cannot connect to a parent Icinga node and only connections from a Master/Satellite are possible. This will open the Windows firewall for the chosen Icinga protocol port (default 5665). Certificate generation might require additional steps.';
+            },
+            @{
+                'Caption' = 'Connecting from both systems';
+                'Command' = 'Show-IcingaForWindowsInstallerMenuSelectHostname';
+                'Help'    = 'Choose this if connections from a parent Icinga node are possible and the Icinga Agent should connect to a parent node. This will open the Windows firewall for the chosen Icinga protocol port (default 5665).';
+            },
+            @{
+                'Caption' = 'Icinga Director Self-Service API';
+                'Command' = 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorUrl';
+                'Help'    = 'Choose this option if you can connect to the Icinga Director from this host. You will be asked for the Icinga Director Url and a Self-Service API key. The entire configuration for this host is then fetched from the Icinga Director.';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-Connection' -Value 'Show-IcingaForWindowsInstallerMenuSelectConnection';

--- a/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallerMenuSelectHostname.psm1
+++ b/lib/core/installer/menu/installation/icinga/Show-IcingaForWindowsInstallerMenuSelectHostname.psm1
@@ -1,0 +1,52 @@
+function Show-IcingaForWindowsInstallerMenuSelectHostname()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '1',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'How is your host object named in Icinga?' `
+        -Entries @(
+            @{
+                'Caption' = ([string]::Format('"{0}": FQDN (current)', (Get-IcingaHostname -AutoUseFQDN 1)));
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone';
+                'Help'    = 'This will use the current FQDN of your host and not modify the name at all';
+            },
+            @{
+                'Caption' = ([string]::Format('"{0}": FQDN (lowercase)', (Get-IcingaHostname -AutoUseFQDN 1 -LowerCase 1)));
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone';
+                'Help'    = 'This will use the current FQDN of your host and modify all characters to lowercase';
+            },
+            @{
+                'Caption' = ([string]::Format('"{0}": FQDN (uppercase)', (Get-IcingaHostname -AutoUseFQDN 1 -UpperCase 1)));
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone';
+                'Help'    = 'This will use the current FQDN of your host and modify all characters to uppercase';
+            },
+            @{
+                'Caption' = ([string]::Format('"{0}": Hostname (current)', (Get-IcingaHostname -AutoUseHostname 1)));
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone';
+                'Help'    = 'This will use the hostname only without FQDN extension without modification';
+            },
+            @{
+                'Caption' = ([string]::Format('"{0}": Hostname (lowercase)', (Get-IcingaHostname -AutoUseHostname 1 -LowerCase 1)));
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone';
+                'Help'    = 'This will use the hostname only without FQDN extension and modify all characters to lowercase';
+            },
+            @{
+                'Caption' = ([string]::Format('"{0}": Hostname (uppercase)', (Get-IcingaHostname -AutoUseHostname 1 -UpperCase 1)));
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentZone';
+                'Help'    = 'This will use the hostname only without FQDN extension and modify all characters to uppercase';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-Hostname' -Value 'Show-IcingaForWindowsInstallerMenuSelectHostname';

--- a/lib/core/installer/menu/installation/icingaforwindowservice/Show-IcingaForWindowsInstallationMenuEnterWindowsServiceDirectory.psm1
+++ b/lib/core/installer/menu/installation/icingaforwindowservice/Show-IcingaForWindowsInstallationMenuEnterWindowsServiceDirectory.psm1
@@ -1,0 +1,30 @@
+function Show-IcingaForWindowsInstallationMenuEnterWindowsServiceDirectory()
+{
+    param (
+        [array]$Value          = @( (Join-Path -Path $Env:ProgramFiles -ChildPath 'icinga-framework-service') ),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Enter the path where to install the Icinga for Windows service binary into:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'If you want to run a background PowerShell daemon, you will require a binary starting the shell as service. This is the permanent location for the binary, as the Icinga for Windows service is registered with this binary to run PowerShell as background daemon';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues @( $Value ) `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-WindowsServiceDirectory' -Value 'Show-IcingaForWindowsInstallationMenuEnterWindowsServiceDirectory';

--- a/lib/core/installer/menu/installation/icingaforwindowservice/Show-IcingaForWindowsInstallerMenuEnterWindowsServicePackageSource.psm1
+++ b/lib/core/installer/menu/installation/icingaforwindowservice/Show-IcingaForWindowsInstallerMenuEnterWindowsServicePackageSource.psm1
@@ -1,0 +1,30 @@
+function Show-IcingaForWindowsInstallerMenuEnterWindowsServicePackageSource()
+{
+    param (
+        [array]$Value          = @( ),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please enter the full path to the Icinga PowerShell Service .zip file:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Allows you to specify a full custom path on where your Icinga service package .zip file is located at. You can specify a local path "C:\icinga\service\icinga-service.zip", a network path "\\example.com\software\icinga\service\icinga-service.zip" or a web path "https://example.com/icinga/windows/service/icinga-service.zip". Please note that only the custom release .zip packages downloaded from "https://github.com/Icinga/icinga-powershell-service/releases" will work. You can get the packages from there and place them on your custom location';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues $Value `
+        -ContinueFirstValue `
+        -MandatoryValue `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-WindowsServicePackageSource' -Value 'Show-IcingaForWindowsInstallerMenuEnterWindowsServicePackageSource';

--- a/lib/core/installer/menu/installation/icingaforwindowservice/Show-IcingaForWindowsInstallerMenuSelectWindowsServiceSource.psm1
+++ b/lib/core/installer/menu/installation/icingaforwindowservice/Show-IcingaForWindowsInstallerMenuSelectWindowsServiceSource.psm1
@@ -1,0 +1,42 @@
+function Show-IcingaForWindowsInstallerMenuSelectWindowsServiceSource()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '0',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please select where the Icinga for Windows service binary is downloaded from:' `
+        -Entries @(
+            @{
+                'Caption' = 'Download latest release from GitHub';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Download the latest stable release of the service binary directly from "https://github.com/Icinga/icinga-powershell-service/releases"';
+            },
+            @{
+                'Caption' = 'Use custom source';
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterWindowsServicePackageSource';
+                'Help'    = 'Specify a custom location from where to get the Icinga for Windows service package';
+            },
+            @{
+                'Caption' = 'Do not install service';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Select this if you do not want to install the Icinga for Windows service';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$FALSE `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+
+    # In case we use the default location, delete our custom location entry
+    if (Get-IcingaForWindowsManagementConsoleLastInput -ne '1') {
+        Remove-IcingaForWindowsInstallerConfigEntry -Menu 'Show-IcingaForWindowsInstallerMenuEnterWindowsServicePackageSource';
+    }
+}
+
+Set-Alias -Name 'IfW-WindowsServiceSource' -Value 'Show-IcingaForWindowsInstallerMenuSelectWindowsServiceSource';

--- a/lib/core/installer/menu/installation/plugins/Show-IcingaForWindowsInstallerMenuEnterPluginsPackageSource.psm1
+++ b/lib/core/installer/menu/installation/plugins/Show-IcingaForWindowsInstallerMenuEnterPluginsPackageSource.psm1
@@ -1,0 +1,30 @@
+function Show-IcingaForWindowsInstallerMenuEnterPluginsPackageSource()
+{
+    param (
+        [array]$Value          = @( ),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please enter the full path to the Icinga PowerShell Plugins .zip file:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Allows you to specify a full custom path on where your Icinga plugins .zip file is located at. You can specify a local path "C:\icinga\plugins\icinga-powershell-plugins.zip", a network path "\\example.com\software\icinga\plugins\icinga-powershell-plugins.zip" or a web path "https://example.com/icinga/windows/plugins/icinga-powershell-plugins.zip". Please note that only .zip packages downloaded from "https://github.com/icinga/icinga-powershell-plugins/releases" will work. You can get the packages from there and place them on your custom location';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues $Value `
+        -ContinueFirstValue `
+        -MandatoryValue `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-PluginPackageSource' -Value 'Show-IcingaForWindowsInstallerMenuEnterPluginsPackageSource';

--- a/lib/core/installer/menu/installation/plugins/Show-IcingaForWindowsInstallerMenuSelectIcingaPluginsSource.psm1
+++ b/lib/core/installer/menu/installation/plugins/Show-IcingaForWindowsInstallerMenuSelectIcingaPluginsSource.psm1
@@ -1,0 +1,47 @@
+function Show-IcingaForWindowsInstallerMenuSelectIcingaPluginsSource()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '0',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please select where your Icinga plugins are downloaded from:' `
+        -Entries @(
+            @{
+                'Caption' = 'Download latest release from GitHub';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Downloads the latest stable release directly from "https://github.com/icinga/icinga-powershell-plugins/releases"';
+            },
+            @{
+                'Caption' = 'Download snapshot from GitHub';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Uses the master branch of the plugin repository for checkout. Not recommended in production';
+            },
+            @{
+                'Caption' = 'Use custom source';
+                'Command' = 'Show-IcingaForWindowsInstallerMenuEnterPluginsPackageSource';
+                'Help'    = 'Specify a custom location from where to get your plugins from';
+            },
+            @{
+                'Caption' = 'Do not install plugins';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Select this if you do not want to install the plugins for the moment';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$FALSE `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+
+    # In case we use the default location, delete our custom location entry
+    if (Get-IcingaForWindowsManagementConsoleLastInput -ne '2') {
+        Remove-IcingaForWindowsInstallerConfigEntry -Menu 'Show-IcingaForWindowsInstallerMenuEnterPluginsPackageSource';
+    }
+}
+
+Set-Alias -Name 'IfW-PluginSource' -Value 'Show-IcingaForWindowsInstallerMenuSelectIcingaPluginsSource';

--- a/lib/core/installer/menu/installation/zones/Show-IcingaForWindowsInstallationMenuEnterCustomGlobalZones.psm1
+++ b/lib/core/installer/menu/installation/zones/Show-IcingaForWindowsInstallationMenuEnterCustomGlobalZones.psm1
@@ -1,0 +1,28 @@
+function Show-IcingaForWindowsInstallationMenuEnterCustomGlobalZones()
+{
+    param (
+        [array]$Value          = @( '' ),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Please add all your global zones you want to add:' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'If you have configured custom global zones you require on this Windows host, please add all of them in this list. Default zones like "director-global" and "global-templates" should not be configured here';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -DefaultValues @( $Value ) `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-CustomZones' -Value 'Show-IcingaForWindowsInstallationMenuEnterCustomGlobalZones';

--- a/lib/core/installer/menu/installation/zones/Show-IcingaForWindowsInstallerMenuSelectGlobalZones.psm1
+++ b/lib/core/installer/menu/installation/zones/Show-IcingaForWindowsInstallerMenuSelectGlobalZones.psm1
@@ -1,0 +1,42 @@
+function Show-IcingaForWindowsInstallerMenuSelectGlobalZones()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '0',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Which default Icinga global zones do you want to add?' `
+        -Entries @(
+            @{
+                'Caption' = 'Add "director-global" and "global-templates" zones';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Adds both global zones, "director-global" and "global-templates" as the default installer would. Depending on your environment these might be mandatory.';
+            },
+            @{
+                'Caption' = 'Add "director-global" zone';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Only add the global zone "director-global" to your configuration which might be required if you are using the Icinga Director, depending on your configuration.';
+            },
+            @{
+                'Caption' = 'Add "global-templates" zone';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Only add the global zone "global-templates" to your configuration';
+            },
+            @{
+                'Caption' = 'Add no default global zone';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'Do not add any default global zones to your configuration';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-GlobalZones' -Value 'Show-IcingaForWindowsInstallerMenuSelectGlobalZones';

--- a/lib/core/installer/menu/manage/agent/Invoke-IcingaForWindowsManagementConsoleReconfigureAgent.psm1
+++ b/lib/core/installer/menu/manage/agent/Invoke-IcingaForWindowsManagementConsoleReconfigureAgent.psm1
@@ -1,0 +1,13 @@
+function Invoke-IcingaForWindowsManagementConsoleReconfigureAgent()
+{
+    $LiveConfig = Get-IcingaPowerShellConfig -Path 'Framework.Config.Live';
+
+    if ($null -eq $LiveConfig) {
+        $global:Icinga.InstallWizard.NextCommand = 'Show-IcingaForWindowsMenuManageIcingaAgent';
+        $global:Icinga.InstallWizard.LastError   = 'Unable to load any previous live configuration. Reconfiguring not possible.';
+        return;
+    }
+
+    $global:Icinga.InstallWizard.Config      = Convert-IcingaForwindowsManagementConsoleJSONConfig -Config $LiveConfig;
+    $global:Icinga.InstallWizard.NextCommand = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+}

--- a/lib/core/installer/menu/manage/agent/Show-IcingaForWindowsMenuManageIcingaAgent.psm1
+++ b/lib/core/installer/menu/manage/agent/Show-IcingaForWindowsMenuManageIcingaAgent.psm1
@@ -1,0 +1,87 @@
+function Show-IcingaForWindowsMenuManageIcingaAgent()
+{
+    $IcingaService = Get-Service 'icinga2' -ErrorAction SilentlyContinue;
+    $AdminShell    = $global:Icinga.InstallWizard.AdminShell;
+    $ServiceStatus = $null;
+
+    if ($null -ne $IcingaService) {
+        $ServiceStatus = $IcingaService.Status;
+    }
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Manage Icinga Agent:' `
+        -Entries @(
+            @{
+                'Caption'  = 'Manage Features';
+                'Command'  = 'Show-IcingaForWindowsMenuManageIcingaAgentFeatures';
+                'Help'     = 'Allows you to install Icinga for Windows with all required components and options';
+                'Disabled' = ($null -eq $IcingaService -Or (-Not $AdminShell));
+            },
+            @{
+                'Caption'  = 'Reconfigure Installation';
+                'Command'  = 'Invoke-IcingaForWindowsManagementConsoleReconfigureAgent';
+                'Help'     = 'Load the current applied configuration for your Icinga Agent and modify the values';
+                'Disabled' = ($null -eq (Get-IcingaPowerShellConfig -Path 'Framework.Config.Live'));
+            },
+            @{
+                'Caption'  = 'Read Icinga Agent Log File';
+                'Command'  = 'Show-IcingaForWindowsMenuManageIcingaAgent';
+                'Help'     = 'Allows to read the Icinga Agent log file in case the "mainlog" feature of the Icinga Agent is enabled';
+                'Disabled' = ((-Not $AdminShell) -Or -Not (Test-IcingaAgentFeatureEnabled -Feature 'mainlog'));
+                'Action'   = @{
+                    'Command'   = 'Start-Process';
+                    'Arguments' = @{ '-FilePath' = 'powershell.exe'; '-ArgumentList' = "-Command  `"&{ icinga { Read-IcingaAgentLogFile; }; }`"" };
+                }
+            },
+            @{
+                'Caption'  = 'Read Icinga Debug Log File';
+                'Command'  = 'Show-IcingaForWindowsMenuManageIcingaAgent';
+                'Help'     = 'Allows to read the Icinga Agent debug log file in case the "debuglog" feature of the Icinga Agent is enabled';
+                'Disabled' = ((-Not $AdminShell) -Or -Not (Test-IcingaAgentFeatureEnabled -Feature 'debuglog'));
+                'Action'   = @{
+                    'Command'   = 'Start-Process';
+                    'Arguments' = @{ '-FilePath' = 'powershell.exe'; '-ArgumentList' = "-Command  `"&{ icinga { Read-IcingaAgentDebugLogFile; }; }`"" };
+                }
+            },
+            @{
+                'Caption'  = 'Flush API directory (will restart Agent)';
+                'Command'  = 'Show-IcingaForWindowsMenuManageIcingaAgent';
+                'Help'     = 'Allows you to flush the Icinga Agent API directory for cleanup. This will restart the Icinga Agent';
+                'Disabled' = ($null -eq $IcingaService -Or (-Not $AdminShell));
+                'Action'   = @{
+                    'Command'   = 'Clear-IcingaAgentApiDirectory';
+                    'Arguments' = @{ '-Force' = $TRUE };
+                }
+            },
+            @{
+                'Caption'  = 'Start Icinga Agent';
+                'Command'  = 'Show-IcingaForWindowsMenuManageIcingaAgent';
+                'Help'     = 'Allows you to start the Icinga Agent if the service is not running';
+                'Disabled' = ($null -eq $IcingaService -Or $ServiceStatus -eq 'Running' -Or (-Not $AdminShell));
+                'Action'   = @{
+                    'Command'   = 'Start-Service';
+                    'Arguments' = @{ '-Name' = 'icinga2'; };
+                }
+            },
+            @{
+                'Caption'  = 'Stop Icinga Agent';
+                'Command'  = 'Show-IcingaForWindowsMenuManageIcingaAgent';
+                'Help'     = 'Allows you to stop the Icinga Agent if the service is not running';
+                'Disabled' = ($null -eq $IcingaService -Or $ServiceStatus -ne 'Running' -Or (-Not $AdminShell));
+                'Action'   = @{
+                    'Command'   = 'Stop-Service';
+                    'Arguments' = @{ '-Name' = 'icinga2'; };
+                }
+            },
+            @{
+                'Caption'  = 'Restart Icinga Agent';
+                'Command'  = 'Show-IcingaForWindowsMenuManageIcingaAgent';
+                'Help'     = 'Allows you to restart the Icinga Agent if the service is installed';
+                'Disabled' = ($null -eq $IcingaService -Or (-Not $AdminShell));
+                'Action'   = @{
+                    'Command'   = 'Restart-Service';
+                    'Arguments' = @{ '-Name' = 'icinga2'; };
+                }
+            }
+        );
+}

--- a/lib/core/installer/menu/manage/agent/Show-IcingaForWindowsMenuManageIcingaAgentFeatures.psm1
+++ b/lib/core/installer/menu/manage/agent/Show-IcingaForWindowsMenuManageIcingaAgentFeatures.psm1
@@ -1,0 +1,54 @@
+function Show-IcingaForWindowsMenuManageIcingaAgentFeatures()
+{
+    $Features = Get-IcingaAgentFeatures;
+
+    [array]$FeatureList = @();
+
+    foreach ($entry in $Features.Enabled) {
+
+        if ([string]::IsNullOrEmpty($entry)) {
+            continue;
+        }
+
+        [string]$Caption = [string]::Format('{0}: Enabled', $entry);
+
+        $FeatureList += @{
+            'Caption'  = $Caption;
+            'Command'  = 'Show-IcingaForWindowsMenuManageIcingaAgentFeatures';
+            'Help'     = ([string]::Format('The feature "{0}" is currently enabled. Select this entry to disable it.', $entry));
+            'Disabled' = $FALSE;
+            'Action'   = @{
+                'Command'   = 'Disable-IcingaAgentFeature';
+                'Arguments' = @{
+                    '-Feature' = $entry;
+                }
+            }
+        }
+    }
+
+    foreach ($entry in $Features.Disabled) {
+
+        if ([string]::IsNullOrEmpty($entry)) {
+            continue;
+        }
+
+        [string]$Caption = [string]::Format('{0}: Disabled', $entry);
+
+        $FeatureList += @{
+            'Caption'  = $Caption;
+            'Command'  = 'Show-IcingaForWindowsMenuManageIcingaAgentFeatures';
+            'Help'     = ([string]::Format('The feature "{0}" is currently disabled. Select this entry to enable it.', $entry));
+            'Disabled' = $FALSE;
+            'Action'   = @{
+                'Command'   = 'Enable-IcingaAgentFeature';
+                'Arguments' = @{
+                    '-Feature' = $entry;
+                }
+            }
+        }
+    }
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Manage Icinga Agent Features. Select an entry and hit enter to Disable/Enable them:' `
+        -Entries $FeatureList;
+}

--- a/lib/core/installer/menu/manage/framework/Invoke-IcingaForWindowsMangementConsoleToogleFrameworkApiChecks.psm1
+++ b/lib/core/installer/menu/manage/framework/Invoke-IcingaForWindowsMangementConsoleToogleFrameworkApiChecks.psm1
@@ -1,0 +1,8 @@
+function Invoke-IcingaForWindowsMangementConsoleToogleFrameworkApiChecks()
+{
+    if (Get-IcingaFrameworkApiChecks) {
+        Disable-IcingaFrameworkApiChecks;
+    } else {
+        Enable-IcingaFrameworkApiChecks;
+    }
+}

--- a/lib/core/installer/menu/manage/framework/Invoke-IcingaForWindowsMangementConsoleToogleFrameworkCodeCache.psm1
+++ b/lib/core/installer/menu/manage/framework/Invoke-IcingaForWindowsMangementConsoleToogleFrameworkCodeCache.psm1
@@ -1,0 +1,9 @@
+function Invoke-IcingaForWindowsMangementConsoleToogleFrameworkCodeCache()
+{
+    if (Get-IcingaFrameworkCodeCache) {
+        Disable-IcingaFrameworkCodeCache;
+    } else {
+        Enable-IcingaFrameworkCodeCache;
+        Write-IcingaFrameworkCodeCache;
+    }
+}

--- a/lib/core/installer/menu/manage/framework/Invoke-IcingaForWindowsMangementConsoleToogleFrameworkDebug.psm1
+++ b/lib/core/installer/menu/manage/framework/Invoke-IcingaForWindowsMangementConsoleToogleFrameworkDebug.psm1
@@ -1,0 +1,8 @@
+function Invoke-IcingaForWindowsMangementConsoleToogleFrameworkDebug()
+{
+    if (Get-IcingaFrameworkDebugMode) {
+        Disable-IcingaFrameworkDebugMode;
+    } else {
+        Enable-IcingaFrameworkDebugMode;
+    }
+}

--- a/lib/core/installer/menu/manage/framework/Show-IcingaForWindowsManagementConsoleFrameworkExperimental.psm1
+++ b/lib/core/installer/menu/manage/framework/Show-IcingaForWindowsManagementConsoleFrameworkExperimental.psm1
@@ -1,0 +1,19 @@
+function Show-IcingaForWindowsManagementConsoleFrameworkExperimental()
+{
+    $ApiChecks = Get-IcingaFrameworkApiChecks;
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Manage Icinga for Windows experimental features. Not recommended for production!' `
+        -Entries @(
+            @{
+                'Caption'  = ([string]::Format('Forward checks to Api: {0}', (& { if ($ApiChecks) { 'Enabled' } else { 'Disabled' } } )));
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleFrameworkExperimental';
+                'Help'     = 'In case enabled, all check commands executed by "Exit-IcingaExecutePlugin" are forwarded to an internal REST-Api and executed from within the Icinga for Windows background daemon. Requires the Icinga for Windows background daemon and the modules "icinga-powershell-restapi" and "icinga-powershell-apichecks"';
+                'Disabled' = $FALSE;
+                'Action'   = @{
+                    'Command'   = 'Invoke-IcingaForWindowsMangementConsoleToogleFrameworkApiChecks';
+                    'Arguments' = @{ };
+                }
+            }
+        );
+}

--- a/lib/core/installer/menu/manage/framework/Show-IcingaForWindowsManagementConsoleManageFramework.psm1
+++ b/lib/core/installer/menu/manage/framework/Show-IcingaForWindowsManagementConsoleManageFramework.psm1
@@ -1,0 +1,99 @@
+function Show-IcingaForWindowsManagementConsoleManageFramework()
+{
+    $FrameworkDebug     = Get-IcingaFrameworkDebugMode;
+    $FrameworkCodeCache = Get-IcingaFrameworkCodeCache;
+    $IcingaService      = Get-Service 'icingapowershell' -ErrorAction SilentlyContinue;
+    $AdminShell         = $global:Icinga.InstallWizard.AdminShell;
+    $ServiceStatus      = $null;
+
+    if ($null -ne $IcingaService) {
+        $ServiceStatus = $IcingaService.Status;
+    }
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Manage Icinga for Windows:' `
+        -Entries @(
+            @{
+                'Caption'  = 'Manage background daemons';
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleManageBackgroundDaemons';
+                'Help'     = 'Allows you to manage Icinga for Windows background daemons';
+                'Disabled' = ($null -eq (Get-Service 'icingapowershell' -ErrorAction SilentlyContinue));
+            },
+            @{
+                'Caption'  = ([string]::Format('Framework Debug Mode: {0}', (& { if ($FrameworkDebug) { 'Enabled' } else { 'Disabled' } } )));
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleManageFramework';
+                'Help'     = 'Disable or enable the Icinga PowerShell Framework debug mode';
+                'Disabled' = $FALSE;
+                'Action'   = @{
+                    'Command'   = 'Invoke-IcingaForWindowsMangementConsoleToogleFrameworkDebug';
+                    'Arguments' = @{ };
+                }
+            },
+            @{
+                'Caption'  = ([string]::Format('Framework Code Cache: {0}', (& { if ($FrameworkCodeCache) { 'Enabled' } else { 'Disabled' } } )));
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleManageFramework';
+                'Help'     = 'Disable or enable the Icinga PowerShell Framework Code cache feature. The code cache is written automatically once it is enabled';
+                'Disabled' = $FALSE;
+                'Action'   = @{
+                    'Command'   = 'Invoke-IcingaForWindowsMangementConsoleToogleFrameworkCodeCache';
+                    'Arguments' = @{ };
+                }
+            },
+            @{
+                'Caption'  = 'Update Framework Code Cache';
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleManageFramework';
+                'Help'     = 'Updates the Icinga PowerShell Framework Code Cache';
+                'Disabled' = (-Not ($FrameworkCodeCache));
+                'Action'   = @{
+                    'Command'   = 'Write-IcingaFrameworkCodeCache';
+                    'Arguments' = @{ };
+                }
+            },
+            @{
+                'Caption'  = 'Allow untrusted certificate communication (this session only)';
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleManageFramework';
+                'Help'     = 'Enables the Icinga untrusted certificate validation, allowing you to communicate with web servers which ships with a self-signed certificate not installed on this system. This applies only to this PowerShell session and is not permanent. Might be helpful in case you want to connect to the Icinga Director and the SSL is not trusted by this host';
+                'Disabled' = $FALSE
+                'Action'   = @{
+                    'Command'   = 'Enable-IcingaUntrustedCertificateValidation';
+                    'Arguments' = @{ };
+                }
+            },
+            @{
+                'Caption'  = 'Configure experimental features';
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleFrameworkExperimental';
+                'Help'     = 'Allows you to manage experimental features for Icinga for Windows';
+                'Disabled' = $FALSE
+            },
+            @{
+                'Caption'  = 'Start Icinga for Windows Service';
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleManageFramework';
+                'Help'     = 'Allows you to start the Icinga for Windows Service if the service is not running';
+                'Disabled' = ($null -eq $IcingaService -Or $ServiceStatus -eq 'Running' -Or (-Not $AdminShell));
+                'Action'   = @{
+                    'Command'   = 'Start-Service';
+                    'Arguments' = @{ '-Name' = 'icingapowershell'; };
+                }
+            },
+            @{
+                'Caption'  = 'Stop Icinga for Windows Service';
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleManageFramework';
+                'Help'     = 'Allows you to stop the Icinga for Windows Service if the service is not running';
+                'Disabled' = ($null -eq $IcingaService -Or $ServiceStatus -ne 'Running' -Or (-Not $AdminShell));
+                'Action'   = @{
+                    'Command'   = 'Stop-Service';
+                    'Arguments' = @{ '-Name' = 'icingapowershell'; };
+                }
+            },
+            @{
+                'Caption'  = 'Restart Icinga for Windows Service';
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleManageFramework';
+                'Help'     = 'Allows you to restart the Icinga for Windows Service if the service is installed';
+                'Disabled' = ($null -eq $IcingaService -Or (-Not $AdminShell));
+                'Action'   = @{
+                    'Command'   = 'Restart-Service';
+                    'Arguments' = @{ '-Name' = 'icingapowershell'; };
+                }
+            }
+        );
+}

--- a/lib/core/installer/menu/manage/framework/backgrounddaemons/Show-IcingaForWindowsManagementConsoleManageBackgroundDaemons.psm1
+++ b/lib/core/installer/menu/manage/framework/backgrounddaemons/Show-IcingaForWindowsManagementConsoleManageBackgroundDaemons.psm1
@@ -1,0 +1,19 @@
+function Show-IcingaForWindowsManagementConsoleManageBackgroundDaemons()
+{
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Manage the Icinga for Windows background daemons:' `
+        -Entries @(
+            @{
+                'Caption'  = 'Register background daemon';
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleRegisterBackgroundDaemons';
+                'Help'     = 'Allows you to register a new background daemon for Icinga for Windows';
+                'Disabled' = $FALSE;
+            },
+            @{
+                'Caption'  = 'Unregister background daemon';
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleUnregisterBackgroundDaemons';
+                'Help'     = 'Remove registered Icinga for Windows background daemons';
+                'Disabled' = $FALSE;
+            }
+        );
+}

--- a/lib/core/installer/menu/manage/framework/backgrounddaemons/Show-IcingaForWindowsManagementConsoleRegisterBackgroundDaemons.psm1
+++ b/lib/core/installer/menu/manage/framework/backgrounddaemons/Show-IcingaForWindowsManagementConsoleRegisterBackgroundDaemons.psm1
@@ -1,0 +1,62 @@
+function Show-IcingaForWindowsManagementConsoleRegisterBackgroundDaemons()
+{
+    [array]$AvailableDaemons = @();
+    $ModuleList              = Get-Module 'icinga-powershell-*' -ListAvailable;
+
+    $AvailableDaemons += @{
+        'Caption'  = 'Register background daemon "Start-IcingaServiceCheckDaemon"';
+        'Command'  = 'Show-IcingaForWindowsManagementConsoleRegisterBackgroundDaemons';
+        'Help'     = ((Get-Help 'Start-IcingaServiceCheckDaemon' -Full).Description.Text);
+        'Disabled' = $FALSE;
+        'Action'   = @{
+            'Command'   = 'Show-IcingaWindowsManagementConsoleYesNoDialog';
+            'Arguments' = @{
+                '-Caption'      = 'Register background daemon "Start-IcingaServiceCheckDaemon"';
+                '-Command'      = 'Register-IcingaBackgroundDaemon';
+                '-CmdArguments' = @{
+                    '-Command' = 'Start-IcingaServiceCheckDaemon';
+                }
+            }
+        }
+    }
+
+    foreach ($module in $ModuleList) {
+
+        $ModuleInfo = $null;
+
+        Import-LocalizedData -BaseDirectory (Join-Path -Path (Get-IcingaFrameworkRootPath) -ChildPath $module.Name) -FileName ([string]::Format('{0}.psd1', $module.Name)) -BindingVariable ModuleInfo -ErrorAction SilentlyContinue;
+
+        if ($null -eq $ModuleInfo -Or $null -eq $ModuleInfo.PrivateData -Or $null -eq $ModuleInfo.PrivateData.Type -Or ([string]::IsNullOrEmpty($ModuleInfo.PrivateData.Type)) -Or $ModuleInfo.PrivateData.Type -ne 'daemon' -Or $null -eq $ModuleInfo.PrivateData.Function -Or ([string]::IsNullOrEmpty($ModuleInfo.PrivateData.Function))) {
+            continue;
+        }
+
+        $HelpObject  = Get-Help ($ModuleInfo.PrivateData.Function) -Full -ErrorAction SilentlyContinue;
+        $HelpText    = '';
+        $Caption     = [string]::Format('Register background daemon "{0}"', ($ModuleInfo.PrivateData.Function));
+
+        if ($null -ne $HelpObject) {
+            $HelpText = $HelpObject.Description.Text;
+        }
+
+        $AvailableDaemons += @{
+            'Caption'  = $Caption;
+            'Command'  = 'Show-IcingaForWindowsManagementConsoleRegisterBackgroundDaemons';
+            'Help'     = $HelpText;
+            'Disabled' = $FALSE;
+            'Action'   = @{
+                'Command'   = 'Show-IcingaWindowsManagementConsoleYesNoDialog';
+                'Arguments' = @{
+                    '-Caption'      = $Caption;
+                    '-Command'      = 'Register-IcingaBackgroundDaemon';
+                    '-CmdArguments' = @{
+                        '-Command' = $ModuleInfo.PrivateData.Function;
+                    }
+                }
+            }
+        }
+    }
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Register Icinga for Windows background daemon:' `
+        -Entries $AvailableDaemons;
+}

--- a/lib/core/installer/menu/manage/framework/backgrounddaemons/Show-IcingaForWindowsManagementConsoleUnregisterBackgroundDaemons.psm1
+++ b/lib/core/installer/menu/manage/framework/backgrounddaemons/Show-IcingaForWindowsManagementConsoleUnregisterBackgroundDaemons.psm1
@@ -1,0 +1,38 @@
+function Show-IcingaForWindowsManagementConsoleUnregisterBackgroundDaemons()
+{
+    [array]$RegisteredDaemons = @();
+
+    $BackgroundDaemons = Get-IcingaBackgroundDaemons;
+
+    foreach ($daemon in $BackgroundDaemons.Keys) {
+        $DaemonValue = $BackgroundDaemons[$daemon];
+        $HelpObject  = Get-Help $daemon -Full -ErrorAction SilentlyContinue;
+        $HelpText    = '';
+        $Caption     = [string]::Format('Unregister background daemon "{0}"', $daemon);
+
+        if ($null -ne $HelpObject) {
+            $HelpText = $HelpObject.Description.Text;
+        }
+
+        $RegisteredDaemons += @{
+            'Caption'  = $Caption;
+            'Command'  = 'Show-IcingaForWindowsManagementConsoleUnregisterBackgroundDaemons';
+            'Help'     = $HelpText;
+            'Disabled' = $FALSE;
+            'Action'   = @{
+                'Command'   = 'Show-IcingaWindowsManagementConsoleYesNoDialog';
+                'Arguments' = @{
+                    '-Caption'      = $Caption;
+                    '-Command'      = 'Unregister-IcingaBackgroundDaemon';
+                    '-CmdArguments' = @{
+                        '-BackgroundDaemon' = $daemon;
+                    }
+                }
+            }
+        }
+    }
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Unregister Icinga for Windows background daemon:' `
+        -Entries $RegisteredDaemons;
+}

--- a/lib/core/installer/menu/manage/general/Show-IcingaForWindowsMenuManage.psm1
+++ b/lib/core/installer/menu/manage/general/Show-IcingaForWindowsMenuManage.psm1
@@ -1,0 +1,23 @@
+function Show-IcingaForWindowsMenuManage()
+{
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Manage Icinga for Windows:' `
+        -Entries @(
+            @{
+                'Caption'  = 'Icinga Agent';
+                'Command'  = 'Show-IcingaForWindowsMenuManageIcingaAgent';
+                'Help'     = 'Allows you to manage the installed Icinga Agent';
+                'Disabled' = (-Not ([bool](Get-Service 'icinga2' -ErrorAction SilentlyContinue)));
+            },
+            @{
+                'Caption' = 'Icinga PowerShell Framework';
+                'Command' = 'Show-IcingaForWindowsManagementConsoleManageFramework';
+                'Help'    = 'Allows you to modify certain settings for the Icinga PowerShell Framework and to register background daemons';
+            }<#,
+            @{
+                'Caption' = 'Health Check';
+                'Command' = '';
+                'Help'    = 'Check the current health and status information of your installation';
+            }#>
+        );
+}

--- a/lib/core/installer/menu/manage/general/Show-IcingaForWindowsMenuRemoveComponents.psm1
+++ b/lib/core/installer/menu/manage/general/Show-IcingaForWindowsMenuRemoveComponents.psm1
@@ -1,0 +1,68 @@
+function Show-IcingaForWindowsMenuRemoveComponents()
+{
+
+    [array]$UninstallFeatures = @();
+    $AgentInstalled           = Get-Service -Name 'icinga2' -ErrorAction SilentlyContinue;
+    $ModuleList               = Get-Module 'icinga-powershell-*' -ListAvailable;
+
+    $UninstallFeatures += @{
+        'Caption'  = 'Uninstall Icinga Agent';
+        'Command'  = 'Show-IcingaForWindowsMenuRemoveComponents';
+        'Help'     = 'Will remove the Icinga Agent from this system. Please note that this option will leave content inside "ProgramData", like certificates, alone'
+        'Disabled' = ($null -eq $AgentInstalled);
+        'Action'   = @{
+            'Command'   = 'Show-IcingaWindowsManagementConsoleYesNoDialog';
+            'Arguments' = @{
+                '-Caption' = 'Uninstall Icinga Agent';
+                '-Command' = 'Uninstall-IcingaAgent';
+            }
+        }
+    }
+
+    $UninstallFeatures += @{
+        'Caption'  = 'Uninstall Icinga Agent (include ProgramData)';
+        'Command'  = 'Show-IcingaForWindowsMenuRemoveComponents';
+        'Help'     = 'Will remove the Icinga Agent from this system. Please note that this option will leave content inside "ProgramData", like certificates, alone'
+        'Disabled' = (-Not (Test-Path -Path (Join-Path -Path $Env:ProgramData -ChildPath 'icinga2')));
+        'Action'   = @{
+            'Command'   = 'Show-IcingaWindowsManagementConsoleYesNoDialog';
+            'Arguments' = @{
+                '-Caption'      = 'Uninstall Icinga Agent (include ProgramData)';
+                '-Command'      = 'Uninstall-IcingaAgent';
+                '-CmdArguments' = @{
+                    '-RemoveDataFolder' = $TRUE;
+                }
+            }
+        }
+    }
+
+    foreach ($module in $ModuleList) {
+        $ComponentName = $module.Name.Replace('icinga-powershell-', '');
+        $Caption       = ([string]::Format('Uninstall component "{0}"', $ComponentName));
+
+        if ($ComponentName -eq 'framework') {
+            continue;
+        }
+
+        $UninstallFeatures += @{
+            'Caption'  = $Caption;
+            'Command'  = 'Show-IcingaForWindowsMenuRemoveComponents';
+            'Help'     = ([string]::Format('This will remove the Icinga for Windows component "{0}" from this host', $ComponentName));
+            'Disabled' = $FALSE;
+            'Action'   = @{
+                'Command'   = 'Show-IcingaWindowsManagementConsoleYesNoDialog';
+                'Arguments' = @{
+                    '-Caption'      = $Caption;
+                    '-Command'      = 'Uninstall-IcingaFrameworkComponent';
+                    '-CmdArguments' = @{
+                        '-Name' = $ComponentName;
+                    }
+                }
+            }
+        }
+    }
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Uninstall Icinga for Windows components. Select an entry to continue:' `
+        -Entries $UninstallFeatures;
+}

--- a/lib/core/installer/menu/test/Test-IcingaForWindowsInstallerParentEndpoints.psm1
+++ b/lib/core/installer/menu/test/Test-IcingaForWindowsInstallerParentEndpoints.psm1
@@ -1,0 +1,49 @@
+function Test-IcingaForWindowsInstallerParentEndpoints()
+{
+    $Selection = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectConnection';
+
+    # Agents connects, therefor validate this setting. 1 only accepts connections from parent
+    if ($Selection -ne 1) {
+        $Values          = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes';
+        $NetworkMap      = @{ };
+        [bool]$HasErrors = $FALSE;
+
+        foreach ($endpoint in $Values) {
+            $Address     = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses' -Parent $endpoint;
+            $TestAddress = $Address;
+            if ($null -eq $Address -Or $Address.Count -eq 0) {
+                $TestAddress = $endpoint;
+            }
+
+            $Resolved = Convert-IcingaEndpointsToIPv4 -NetworkConfig $TestAddress;
+
+            if ($Resolved.HasErrors) {
+                $Address   = $endpoint;
+                $HasErrors = $TRUE;
+            } else {
+                $Address = $Resolved.Network[0];
+            }
+
+            $NetworkMap.Add(
+                $endpoint,
+                @{
+                    'Endpoint' = $endpoint;
+                    'Address'  = $Address;
+                    'Error'    = $Resolved.HasErrors;
+                }
+            );
+
+            Add-IcingaForWindowsInstallerConfigEntry -Selection 'c' -Values $Address -OverwriteValues `
+                -OverwriteMenu 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses' `
+                -OverwriteParent ([string]::Format('Show-IcingaForWindowsInstallerMenuEnterIcingaParentNodes:{0}', $endpoint));
+        }
+
+        if ($HasErrors) {
+            $global:Icinga.InstallWizard.NextCommand   = 'Show-IcingaForWindowsInstallerMenuEnterIcingaParentAddresses';
+            $global:Icinga.InstallWizard.NextArguments = @{ 'Value' = $NetworkMap };
+            return;
+        }
+    }
+
+    $global:Icinga.InstallWizard.NextCommand   = 'Add-IcingaForWindowsInstallationAdvancedEntries';
+}

--- a/lib/core/installer/tools/Add-IcingaForWindowsInstallerConfigEntry.psm1
+++ b/lib/core/installer/tools/Add-IcingaForWindowsInstallerConfigEntry.psm1
@@ -1,0 +1,59 @@
+function Add-IcingaForWindowsInstallerConfigEntry()
+{
+    param (
+        [string]$Selection       = $null,
+        [array]$Values           = @(),
+        [switch]$Hidden          = $FALSE,
+        [switch]$PasswordInput   = $FALSE,
+        [switch]$OverwriteValues = $FALSE,
+        [string]$OverwriteMenu   = '',
+        [string]$OverwriteParent = '',
+        [switch]$Advanced        = $FALSE
+    );
+
+    if ([string]::IsNullOrEmpty($OverwriteMenu) -eq $FALSE) {
+        $Step = $OverwriteMenu;
+    } else {
+        $Step = Get-IcingaForWindowsManagementConsoleMenu;
+    }
+    if ([string]::IsNullOrEmpty($OverwriteParent) -eq $FALSE) {
+        $Parent = $OverwriteParent;
+    } else {
+        $Parent = $global:Icinga.InstallWizard.ParentConfig;
+    }
+
+    $ConfigIndex  = $global:Icinga.InstallWizard.Config.Count;
+    $ParentEntry  = $null;
+
+    $Parent = Get-IcingaForWindowsManagementConsoleAlias -Command $Parent;
+    $Step   = Get-IcingaForWindowsManagementConsoleAlias -Command $Step;
+
+    if ([string]::IsNullOrEmpty($Parent) -eq $FALSE) {
+        $ParentEntry = $Parent.Split(':')[1];
+        $Parent = $Parent.Split(':')[0];
+        $Step = [string]::Format('{0}:{1}', $Step, $ParentEntry);
+    }
+
+    if ($global:Icinga.InstallWizard.Config.ContainsKey($Step) -eq $FALSE) {
+        $global:Icinga.InstallWizard.Config.Add(
+            $Step,
+            @{
+                'Selection'   = $Selection;
+                'Values'      = $Values
+                'Index'       = $ConfigIndex;
+                'Parent'      = $Parent;
+                'ParentEntry' = $ParentEntry;
+                'Hidden'      = [bool]$Hidden;
+                'Password'    = [bool]$PasswordInput;
+                'Advanced'    = [bool]$Advanced;
+                'Modified'    = ($Advanced -eq $FALSE);
+            }
+        );
+    } else {
+        $global:Icinga.InstallWizard.Config[$Step].Selection = $Selection;
+        $global:Icinga.InstallWizard.Config[$Step].Values    = $Values;
+        $global:Icinga.InstallWizard.Config[$Step].Modified  = $TRUE;
+    }
+
+    Write-IcingaforWindowsManagementConsoleConfigSwap -Config $global:Icinga.InstallWizard.Config;
+}

--- a/lib/core/installer/tools/Add-IcingaForWindowsManagementConsoleLastParent.psm1
+++ b/lib/core/installer/tools/Add-IcingaForWindowsManagementConsoleLastParent.psm1
@@ -1,0 +1,15 @@
+function Add-IcingaForWindowsManagementConsoleLastParent()
+{
+    $Menu = Get-IcingaForWindowsManagementConsoleAlias -Command (Get-IcingaForWindowsManagementConsoleMenu);
+
+    if ($Menu -eq (Get-IcingaForWindowsInstallerLastParent)) {
+        return;
+    }
+
+    # Do not add Yes/No Dialog to the list
+    if ($Menu -eq 'Show-IcingaWindowsManagementConsoleYesNoDialog') {
+        return;
+    }
+
+    $global:Icinga.InstallWizard.LastParent.Add($Menu) | Out-Null;
+}

--- a/lib/core/installer/tools/Clear-IcingaForWindowsInstallerValuesFromStep.psm1
+++ b/lib/core/installer/tools/Clear-IcingaForWindowsInstallerValuesFromStep.psm1
@@ -1,0 +1,14 @@
+function Clear-IcingaForWindowsInstallerValuesFromStep()
+{
+    $Step = Get-IcingaForWindowsManagementConsoleMenu;
+
+    if ($global:Icinga.InstallWizard.Config.ContainsKey($Step) -eq $FALSE) {
+        return;
+    }
+
+    if ($null -eq $global:Icinga.InstallWizard.Config[$Step].Values) {
+        return;
+    }
+
+    $global:Icinga.InstallWizard.Config[$Step].Values = @();
+}

--- a/lib/core/installer/tools/Clear-IcingaForWindowsManagementConsolePaginationCache.psm1
+++ b/lib/core/installer/tools/Clear-IcingaForWindowsManagementConsolePaginationCache.psm1
@@ -1,0 +1,4 @@
+function Clear-IcingaForWindowsManagementConsolePaginationCache()
+{
+    $global:Icinga.InstallWizard.LastParent.Clear();
+}

--- a/lib/core/installer/tools/Convert-IcingaForwindowsManagementConsoleJSONConfig.psm1
+++ b/lib/core/installer/tools/Convert-IcingaForwindowsManagementConsoleJSONConfig.psm1
@@ -1,0 +1,40 @@
+function Convert-IcingaForwindowsManagementConsoleJSONConfig()
+{
+    param (
+        $Config
+    );
+
+    [int]$Index                 = 0;
+    $MaxIndex                   = $Config.PSObject.Properties.Count;
+    [string]$Menu               = '';
+    [hashtable]$ConvertedConfig = @{ };
+
+    while ($Index -lt $MaxIndex.Count) {
+        foreach ($entry in $Config.PSObject.Properties) {
+
+            if ($index -eq [int]$entry.Value.Index) {
+                $ConvertedConfig.Add(
+                    $entry.Name,
+                    @{
+                        'Selection'   = $entry.Value.Selection;
+                        'Values'      = $entry.Value.Values;
+                        'Index'       = $index;
+                        'Parent'      = $entry.Value.Parent;
+                        'ParentEntry' = $entry.Value.ParentEntry;
+                        'Hidden'      = $entry.Value.Hidden;
+                        'Password'    = $entry.Value.Password;
+                        'Advanced'    = $entry.Value.Advanced;
+                        'Modified'    = $entry.Value.Modified;
+                    }
+                );
+
+                if ($entry.Value.Advanced -eq $FALSE) {
+                    $global:Icinga.InstallWizard.LastParent.Add($entry.Name) | Out-Null;
+                }
+            }
+        }
+        $Index += 1;
+    }
+
+    return $ConvertedConfig;
+}

--- a/lib/core/installer/tools/Get-IcingaForWindowsInstallerLastParent.psm1
+++ b/lib/core/installer/tools/Get-IcingaForWindowsInstallerLastParent.psm1
@@ -1,0 +1,9 @@
+function Get-IcingaForWindowsInstallerLastParent()
+{
+    if ($global:Icinga.InstallWizard.LastParent.Count -ne 0) {
+        $Parent   = $global:Icinga.InstallWizard.LastParent[-1];
+        return $Parent;
+    }
+
+    return $null;
+}

--- a/lib/core/installer/tools/Get-IcingaForWindowsInstallerStepSelection.psm1
+++ b/lib/core/installer/tools/Get-IcingaForWindowsInstallerStepSelection.psm1
@@ -1,0 +1,18 @@
+function Get-IcingaForWindowsInstallerStepSelection()
+{
+    param (
+        [string]$InstallerStep
+    );
+
+    if ([string]::IsNullOrEmpty($InstallerStep)) {
+        $InstallerStep = Get-IcingaForWindowsManagementConsoleMenu;
+    } else {
+        $InstallerStep = Get-IcingaForWindowsManagementConsoleAlias -Command $InstallerStep;
+    }
+
+    if ($global:Icinga.InstallWizard.Config.ContainsKey($InstallerStep)) {
+        return $global:Icinga.InstallWizard.Config[$InstallerStep].Selection;
+    }
+
+    return $null;
+}

--- a/lib/core/installer/tools/Get-IcingaForWindowsInstallerValuesFromStep.psm1
+++ b/lib/core/installer/tools/Get-IcingaForWindowsInstallerValuesFromStep.psm1
@@ -1,0 +1,29 @@
+function Get-IcingaForWindowsInstallerValuesFromStep()
+{
+    param (
+        [string]$InstallerStep,
+        [string]$Parent
+    );
+
+    [array]$Values = @();
+
+    $Step = Get-IcingaForWindowsManagementConsoleMenu;
+
+    if ([string]::IsNullOrEmpty($InstallerStep) -eq $FALSE) {
+        $Step = Get-IcingaForWindowsManagementConsoleAlias -Command $InstallerStep;
+
+        if ([string]::IsNullOrEmpty($Parent) -eq $FALSE) {
+            $Step = [string]::Format('{0}:{1}', $Step, $Parent);
+        }
+    }
+
+    if ($global:Icinga.InstallWizard.Config.ContainsKey($Step) -eq $FALSE) {
+        return @();
+    }
+
+    if ($null -eq $global:Icinga.InstallWizard.Config[$Step].Values) {
+        return @();
+    }
+
+    return [array]($global:Icinga.InstallWizard.Config[$Step].Values);
+}

--- a/lib/core/installer/tools/Get-IcingaForWindowsManagementConsoleAlias.psm1
+++ b/lib/core/installer/tools/Get-IcingaForWindowsManagementConsoleAlias.psm1
@@ -1,0 +1,30 @@
+function Get-IcingaForWindowsManagementConsoleAlias()
+{
+    param (
+        [string]$Command
+    );
+
+    if ([string]::IsNullOrEmpty($Command)) {
+        return '';
+    }
+
+    $ParentEntry = $null;
+
+    if ($Command.Contains(':')) {
+        $KeyValue    = $Command.Split(':');
+        $Command     = $KeyValue[0];
+        $ParentEntry = $KeyValue[1];
+    }
+
+    $CommandAlias = Get-Alias -Definition $Command -ErrorAction SilentlyContinue;
+
+    if ($null -ne $CommandAlias) {
+        $Command = $CommandAlias.Name;
+    }
+
+    if ([string]::IsNullOrEmpty($ParentEntry) -eq $FALSE) {
+        $Command = [string]::Format('{0}:{1}', $Command, $ParentEntry);
+    }
+
+    return $Command;
+}

--- a/lib/core/installer/tools/Get-IcingaForWindowsManagementConsoleConfigurationString.psm1
+++ b/lib/core/installer/tools/Get-IcingaForWindowsManagementConsoleConfigurationString.psm1
@@ -1,0 +1,80 @@
+function Get-IcingaForWindowsManagementConsoleConfigurationString()
+{
+    param (
+        [switch]$Compress = $FALSE
+    );
+
+    [hashtable]$Configuration = @{ };
+
+    foreach ($entry in $Global:Icinga.InstallWizard.Config.Keys) {
+        $Value = $Global:Icinga.InstallWizard.Config[$entry];
+
+        # Only print arguments that contain changes
+        if ($Value.Modified -eq $FALSE) {
+            continue;
+        }
+
+        $Command = $entry;
+        $Parent  = $null;
+
+        # Handle configurations with parent dependencies
+        if ($entry.Contains(':')) {
+            $KeyValue = $entry.Split(':');
+            $Command  = $KeyValue[0];
+            $Parent   = $KeyValue[1];
+        }
+
+        if ($Configuration.ContainsKey($Command) -eq $FALSE) {
+            $Configuration.Add($Command, @{ });
+        }
+
+        # No parent exist, just add the values
+        if ([string]::IsNullOrEmpty($Parent)) {
+            if ($null -ne $Value.Values -And $Value.Values.Count -ne 0) {
+                [array]$ConfigValues = @();
+
+                foreach ($element in $Value.Values) {
+                    if ([string]::IsNullOrEmpty($element) -eq $FALSE) {
+                        $ConfigValues += $element;
+                    }
+                }
+
+                if ($ConfigValues.Count -ne 0) {
+                    $Configuration[$Command].Add(
+                        'Values', $ConfigValues
+                    );
+                }
+            }
+        } else {
+            # Handle parent references
+            [hashtable]$ParentConfig = @{ };
+
+            if ($Configuration[$Command].ContainsKey('Values')) {
+                $ParentConfig = $Configuration[$Command].Values;
+            }
+
+            $ParentConfig.Add(
+                $Value.ParentEntry,
+                $Value.Values
+            );
+
+            $Configuration[$Command].Values = $ParentConfig;
+        }
+
+        if ($Configuration[$Command].ContainsKey('Selection')) {
+            continue;
+        }
+
+        if ([string]::IsNullOrEmpty($Value.Selection) -eq $FALSE -And $Value.Selection -ne 'c') {
+            $Configuration[$Command].Add(
+                'Selection', $Value.Selection
+            );
+        }
+
+        if ($Configuration[$Command].Count -eq 0) {
+            $Configuration.Remove($Command);
+        }
+    }
+
+    return ($Configuration | ConvertTo-Json -Depth 100 -Compress:$Compress);
+}

--- a/lib/core/installer/tools/Get-IcingaForWindowsManagementConsoleMenu.psm1
+++ b/lib/core/installer/tools/Get-IcingaForWindowsManagementConsoleMenu.psm1
@@ -1,0 +1,12 @@
+function Get-IcingaForWindowsManagementConsoleMenu()
+{
+    if ($null -eq $global:Icinga -Or $null -eq $global:Icinga.InstallWizard) {
+        return '';
+    }
+
+    if ([string]::IsNullOrEmpty($global:Icinga.InstallWizard.Menu) -Or $global:Icinga.InstallWizard.Menu -eq 'break') {
+        return '';
+    }
+
+    return (Get-IcingaForWindowsManagementConsoleAlias -Command $global:Icinga.InstallWizard.Menu);
+}

--- a/lib/core/installer/tools/Invoke-IcingaForWindowsManagementConsoleCustomConfig.psm1
+++ b/lib/core/installer/tools/Invoke-IcingaForWindowsManagementConsoleCustomConfig.psm1
@@ -1,0 +1,27 @@
+function Invoke-IcingaForWindowsManagementConsoleCustomConfig()
+{
+    param (
+        [hashtable]$IcingaConfiguration = @{ }
+    );
+
+    foreach ($cmd in $IcingaConfiguration.Keys) {
+        $cmdConfig = $IcingaConfiguration[$cmd];
+
+        if ($cmd.Contains(':')) {
+            continue; # skip for now, as more complicated
+        }
+
+        $cmdArguments = @{
+            'Automated' = $TRUE;
+        }
+
+        if ($cmdConfig.ContainsKey('Values') -And $null -ne $cmdConfig.Values) {
+            $cmdArguments.Add('Value', $cmdConfig.Values)
+        }
+        if ($cmdConfig.ContainsKey('Selection') -And $null -ne $cmdConfig.Selection) {
+            $cmdArguments.Add('DefaultInput', $cmdConfig.Selection)
+        }
+
+        &$cmd @cmdArguments;
+    }
+}

--- a/lib/core/installer/tools/Remove-IcingaForWindowsInstallerConfigEntry.psm1
+++ b/lib/core/installer/tools/Remove-IcingaForWindowsInstallerConfigEntry.psm1
@@ -1,0 +1,19 @@
+function Remove-IcingaForWindowsInstallerConfigEntry()
+{
+    param (
+        [string]$Menu,
+        [string]$Parent
+    );
+
+    $Menu = Get-IcingaForWindowsManagementConsoleAlias -Command $Menu;
+
+    if ([string]::IsNullOrEmpty($Parent) -eq $FALSE) {
+        $Menu = [string]::Format('{0}:{1}', $Menu, $Parent);
+    }
+
+    if ($global:Icinga.InstallWizard.Config.ContainsKey($Menu)) {
+        $global:Icinga.InstallWizard.Config.Remove($Menu);
+    }
+
+    Write-IcingaforWindowsManagementConsoleConfigSwap -Config $global:Icinga.InstallWizard.Config;
+}

--- a/lib/core/installer/tools/Remove-IcingaForWindowsInstallerLastParent.psm1
+++ b/lib/core/installer/tools/Remove-IcingaForWindowsInstallerLastParent.psm1
@@ -1,0 +1,6 @@
+function Remove-IcingaForWindowsInstallerLastParent()
+{
+    if ($global:Icinga.InstallWizard.LastParent.Count -ne 0) {
+        $global:Icinga.InstallWizard.LastParent.RemoveAt($global:Icinga.InstallWizard.LastParent.Count - 1);
+    }
+}

--- a/lib/core/installer/tools/Reset-IcingaForWindowsManagementConsoleInstallationDirectorConfigModifyState.psm1
+++ b/lib/core/installer/tools/Reset-IcingaForWindowsManagementConsoleInstallationDirectorConfigModifyState.psm1
@@ -1,0 +1,11 @@
+function Reset-IcingaForWindowsManagementConsoleInstallationDirectorConfigModifyState()
+{
+    foreach ($entry in $Global:Icinga.InstallWizard.Config.Keys) {
+
+        if ($entry -eq 'IfW-DirectorUrl' -Or $entry -eq 'IfW-DirectorSelfServiceKey') {
+            continue;
+        }
+
+        $Global:Icinga.InstallWizard.Config[$entry].Modified = $FALSE;
+    }
+}

--- a/lib/core/installer/tools/Set-IcingaForWindowsManagementConsoleMenu.psm1
+++ b/lib/core/installer/tools/Set-IcingaForWindowsManagementConsoleMenu.psm1
@@ -1,0 +1,12 @@
+function Set-IcingaForWindowsManagementConsoleMenu()
+{
+    param (
+        [string]$Menu
+    );
+
+    if ([string]::IsNullOrEmpty($Menu) -Or $Menu -eq 'break') {
+        return;
+    }
+
+    $global:Icinga.InstallWizard.Menu = (Get-IcingaForWindowsManagementConsoleAlias -Command $Menu);
+}

--- a/lib/core/installer/tools/Show-IcingaForWindowsInstallerMenu.psm1
+++ b/lib/core/installer/tools/Show-IcingaForWindowsInstallerMenu.psm1
@@ -1,0 +1,429 @@
+function Show-IcingaForWindowsInstallerMenu()
+{
+    param (
+        [string]$Header,
+        [array]$Entries,
+        [array]$DefaultValues        = @(),
+        [string]$DefaultIndex        = $null,
+        [string]$ParentConfig        = $null,
+        [switch]$AddConfig           = $FALSE,
+        [switch]$PasswordInput       = $FALSE,
+        [switch]$ContinueFirstValue  = $FALSE,
+        [switch]$MandatoryValue      = $FALSE,
+        [int]$ConfigLimit            = -1,
+        [switch]$JumpToSummary       = $FALSE,
+        [string]$ContinueFunction    = $null,
+        [switch]$ConfigElement       = $FALSE,
+        [switch]$HiddenConfigElement = $FALSE,
+        [switch]$ReadOnly       = $FALSE,
+        [switch]$Automated           = $FALSE,
+        [switch]$Advanced            = $FALSE
+    );
+
+    if ((Test-IcingaForWindowsInstallationHeaderPrint) -eq $FALSE -And (Get-IcingaFrameworkDebugMode) -eq $FALSE) {
+        Clear-Host;
+    }
+
+    $PSCallStack   = Get-PSCallStack;
+    $LastArguments = $null;
+    $LastCommand   = $null;
+
+    if ($PSCallStack.Count -gt 1) {
+        $LastCommand   = $PSCallStack[1].Command;
+        $LastArguments = $PSCallStack[1].InvocationInfo.BoundParameters;
+
+        # Only keep internal values as long as we are navigating within the same menu
+        if ($global:Icinga.InstallWizard.Menu -ne $LastCommand) {
+            $global:Icinga.InstallWizard.LastValues = @();
+        }
+
+        # Prevent from adding ourself because of stack calls.
+        # This should always be the "real" last command
+        if ($LastCommand -ne 'Show-IcingaForWindowsInstallerMenu') {
+            $global:Icinga.InstallWizard.Menu = $LastCommand;
+        } else {
+            $LastCommand = Get-IcingaForWindowsManagementConsoleMenu;
+        }
+    }
+
+    $SelectionForCurrentMenu                  = Get-IcingaForWindowsInstallerStepSelection -InstallerStep (Get-IcingaForWindowsManagementConsoleMenu);
+    [bool]$EntryModified                      = $FALSE;
+    [int]$EntryIndex                          = 0;
+    [hashtable]$KnownIndexes                  = @{ };
+    $LastParent                               = Get-IcingaForWindowsInstallerLastParent;
+    [array]$StoredValues                      = (Get-IcingaForWindowsInstallerValuesFromStep);
+    $global:Icinga.InstallWizard.ParentConfig = $ParentConfig;
+    $global:Icinga.InstallWizard.LastInput    = $null;
+
+    if ($LastParent -eq (Get-IcingaForWindowsManagementConsoleAlias -Command $LastCommand)) {
+        Remove-IcingaForWindowsInstallerLastParent;
+        $LastParent = Get-IcingaForWindowsInstallerLastParent;
+    }
+
+    if (Test-IcingaForWindowsInstallationJumpToSummary) {
+        $SelectionForCurrentMenu = $null;
+    }
+
+    if ($StoredValues.Count -eq 0 -And $DefaultValues.Count -ne 0) {
+        $StoredValues = $DefaultValues;
+    }
+
+    if ($global:Icinga.InstallWizard.DeleteValues) {
+        $StoredValues = @();
+        $global:Icinga.InstallWizard.DeleteValues = $FALSE;
+    }
+
+    if ((Test-IcingaForWindowsInstallationHeaderPrint) -eq $FALSE) {
+
+        $ConsoleHeaderLines = @(
+            'Icinga for Windows Management Console',
+            'Copyright $Copyright',
+            'User environment $UserDomain\$Username',
+            'Icinga PowerShell Framework $FrameworkVersion'
+        );
+
+        if ($global:Icinga.InstallWizard.AdminShell -eq $FALSE) {
+            $ConsoleHeaderLines += '[Warning]: Run this shell as Administrator to unlock all features'
+        }
+
+        $ConsoleHeaderLines += @(
+            'This is an experimental feature and might contain bugs',
+            'Please provide us with feedback, issues and input at',
+            'https://github.com/Icinga/icinga-powershell-framework/issues'
+        )
+
+        Write-IcingaConsoleHeader -HeaderLines $ConsoleHeaderLines;
+
+        Write-IcingaConsolePlain '';
+        Write-IcingaConsolePlain $Header;
+        Write-IcingaConsolePlain '';
+    }
+
+    foreach ($entry in $Entries) {
+        if ([string]::IsNullOrEmpty($entry.Caption) -eq $FALSE) {
+            $Header    = ([string]::Format('[{0}] {1}', $EntryIndex, $entry.Caption));
+            $FontColor = 'Default';
+
+            if ((Test-IcingaForWindowsInstallationHeaderPrint) -eq $FALSE) {
+                # Highlight the default index in a different color
+                if ($DefaultIndex -eq $EntryIndex) {
+                    $FontColor = 'Cyan';
+                }
+
+                # In case a entry is disabled, highlight it differently
+                if ($null -ne $entry.Disabled -And $entry.Disabled -eq $TRUE) {
+                    $FontColor = 'DarkGray';
+                }
+
+                # Mark our previous selection in another color for better highlighting
+                if ($null -ne $SelectionForCurrentMenu -And $SelectionForCurrentMenu -eq $EntryIndex) {
+                    $FontColor = 'Green';
+                }
+
+                Write-IcingaConsolePlain $Header -ForeColor $FontColor;
+
+                if ($global:Icinga.InstallWizard.ShowHelp -And ([string]::IsNullOrEmpty($entry.Help)) -eq $FALSE) {
+                    Write-IcingaConsolePlain '';
+                    Write-IcingaConsolePlain $entry.Help -ForeColor Magenta;
+                    Write-IcingaConsolePlain '';
+                }
+            } else {
+                if ((Get-IcingaForWindowsInstallationHeaderSelection) -eq $EntryIndex) {
+                    $global:Icinga.InstallWizard.HeaderPreview = $entry.Caption;
+                    return;
+                }
+            }
+        }
+
+        $KnownIndexes.Add([string]$EntryIndex, $TRUE);
+        $EntryIndex += 1;
+    }
+
+    if ((Test-IcingaForWindowsInstallationHeaderPrint)) {
+        return;
+    }
+
+    if ($StoredValues.Count -ne 0) {
+        if ($PasswordInput -eq $FALSE) {
+            Write-IcingaConsolePlain ([string]::Format(' {0}', (ConvertFrom-IcingaArrayToString -Array $StoredValues -AddQuotes))) -ForeColor Cyan;
+        } else {
+            Write-IcingaConsolePlain ([string]::Format(' {0}', (ConvertFrom-IcingaArrayToString -Array $StoredValues -AddQuotes -SecureContent))) -ForeColor Cyan;
+        }
+    }
+
+    if ($AddConfig) {
+        if ($global:Icinga.InstallWizard.ShowHelp -And ([string]::IsNullOrEmpty($Entries[0].Help)) -eq $FALSE) {
+            Write-IcingaConsolePlain '';
+            Write-IcingaConsolePlain $entry.Help -ForeColor Magenta;
+        }
+    }
+
+    $MenuNavigation = '[x] Exit';
+
+    Write-IcingaConsolePlain '';
+
+    if ($global:Icinga.InstallWizard.DisplayAdvanced) {
+        $MenuNavigation = [string]::Format('{0} [a] Advanced', $MenuNavigation)
+    }
+
+    $MenuNavigation = [string]::Format('{0} [c] Continue', $MenuNavigation)
+
+    if ($AddConfig -And $ReadOnly -eq $FALSE) {
+        $MenuNavigation = [string]::Format('{0} [d] Delete', $MenuNavigation)
+    }
+
+    $MenuNavigation = [string]::Format('{0} [h] Help [m] Main', $MenuNavigation)
+
+    if ([string]::IsNullOrEmpty($LastParent) -eq $FALSE -Or $global:Icinga.InstallWizard.LastParent.Count -gt 1) {
+        $MenuNavigation = [string]::Format('{0} [p] Previous', $MenuNavigation)
+    }
+
+    Write-IcingaConsolePlain $MenuNavigation;
+
+    $Prompt      = 'Input';
+    $CountPrompt = ([string]::Format('({0}/{1})', $StoredValues.Count, $ConfigLimit));
+    if ($ConfigLimit -eq -1) {
+        $CountPrompt = ([string]::Format('({0} values)', $StoredValues.Count));
+    }
+
+    if ($AddConfig) {
+        $Prompt = ([string]::Format('Input {0}', $CountPrompt));
+        # In case we reached the maximum entries, set c as default input for easier handling
+        if (($ConfigLimit -le $StoredValues.Count) -Or ($ContinueFirstValue -eq $TRUE -And $StoredValues.Count -ge 1)) {
+            $DefaultIndex = 'c';
+        }
+    }
+
+    if ([string]::IsNullOrEmpty($DefaultIndex) -eq $FALSE) {
+        if ((Test-Numeric $DefaultIndex)) {
+            $Prompt = [string]::Format('Input (Default {0} and c)', $DefaultIndex);
+        } else {
+            $Prompt = [string]::Format('Input (Default {0})', $DefaultIndex);
+        }
+        if ($AddConfig) {
+            $Prompt = [string]::Format('{0} {1}', $Prompt, $CountPrompt);
+        }
+    }
+
+    Write-IcingaConsolePlain '';
+
+    if ([string]::IsNullOrEmpty($global:Icinga.InstallWizard.LastError) -eq $FALSE) {
+        Write-IcingaConsoleError ($global:Icinga.InstallWizard.LastError);
+        $global:Icinga.InstallWizard.LastError = '';
+        Write-IcingaConsolePlain '';
+    }
+
+    if ([string]::IsNullOrEmpty($global:Icinga.InstallWizard.LastNotice) -eq $FALSE) {
+        Write-IcingaConsoleNotice ($global:Icinga.InstallWizard.LastNotice);
+        $global:Icinga.InstallWizard.LastNotice = '';
+        Write-IcingaConsolePlain '';
+    }
+
+    if ($Automated -eq $FALSE) {
+        $Result = Read-Host -Prompt $Prompt -AsSecureString:$PasswordInput;
+
+        # Translate the value back to check what we used for input. We are not going to share
+        # the content however
+        if ($PasswordInput) {
+            $Result = ConvertFrom-IcingaSecureString -SecureString $Result;
+        }
+
+        if ([string]::IsNullOrEmpty($Result) -And [string]::IsNullOrEmpty($DefaultIndex) -eq $FALSE) {
+            $Result = $DefaultIndex;
+        }
+    } else {
+        if ([string]::IsNullOrEmpty($DefaultIndex) -eq $FALSE) {
+            $Result = $DefaultIndex;
+        }
+    }
+
+    $global:Icinga.InstallWizard.NextCommand   = $LastCommand;
+    $global:Icinga.InstallWizard.NextArguments = $LastArguments;
+    $global:Icinga.InstallWizard.LastInput     = $Result;
+
+    switch ($Result) {
+        'x' {
+            Clear-Host;
+            $global:Icinga.InstallWizard.Closing = $TRUE;
+            return;
+        };
+        'a' {
+            $global:Icinga.InstallWizard.ShowAdvanced = (-Not ($global:Icinga.InstallWizard.ShowAdvanced));
+            return;
+        };
+        'h' {
+            $global:Icinga.InstallWizard.ShowHelp = (-Not ($global:Icinga.InstallWizard.ShowHelp));
+
+            return;
+        };
+        'm' {
+            $global:Icinga.InstallWizard.NextCommand   = $null;
+            $global:Icinga.InstallWizard.NextArguments = $null;
+
+            return;
+        }
+        'p' {
+            if ([string]::IsNullOrEmpty($LastParent) -eq $FALSE) {
+                Remove-IcingaForWindowsInstallerLastParent;
+
+                $global:Icinga.InstallWizard.NextCommand   = $LastParent;
+                $global:Icinga.InstallWizard.NextArguments = $null;
+
+                return;
+            }
+
+            $global:Icinga.InstallWizard.LastError = 'You cannot move to the previous menu from here.';
+            if ($global:Icinga.InstallWizard.LastParent.Count -eq 0) {
+                $global:Icinga.InstallWizard.NextCommand   = $null;
+                $global:Icinga.InstallWizard.NextArguments = $null;
+
+                return;
+            }
+
+            return;
+        };
+        'd' {
+            if ($ReadOnly -eq $FALSE) {
+                $StoredValues = @();
+                Clear-IcingaForWindowsInstallerValuesFromStep
+                $global:Icinga.InstallWizard.DeleteValues = $TRUE;
+                $global:Icinga.InstallWizard.LastValues = @();
+            }
+
+            return;
+        };
+        'c' {
+            if ($MandatoryValue -And $StoredValues.Count -eq 0) {
+                $global:Icinga.InstallWizard.LastError = 'You need to add at least one value!';
+
+                return;
+            }
+
+            if ($AddConfig -eq $FALSE) {
+                $Result = $DefaultIndex;
+                $global:Icinga.InstallWizard.LastInput = $Result;
+            }
+
+            $global:Icinga.InstallWizard.LastValues = $StoredValues;
+
+            break;
+        };
+        default {
+            if ($AddConfig) {
+
+                if ($ConfigLimit -eq -1 -Or $ConfigLimit -gt $StoredValues.Count) {
+                    if ([string]::IsNullOrEmpty($Result) -eq $FALSE) {
+
+                        $StoredValues += $Result;
+                        if ($ConfigElement) {
+                            Add-IcingaForWindowsInstallerConfigEntry -Values $StoredValues -Hidden:$HiddenConfigElement -PasswordInput:$PasswordInput -Advanced:$Advanced;
+                        }
+
+                        $global:Icinga.InstallWizard.LastValues = $StoredValues;
+                    } else {
+                        if ($DefaultValues.Count -ne 0) {
+                            $global:Icinga.InstallWizard.LastNotice = 'Empty values are not allowed! Resetting to default.';
+                        } else {
+                            $global:Icinga.InstallWizard.LastError = 'You cannot add an empty value!';
+                        }
+                    }
+                } else {
+                    $global:Icinga.InstallWizard.LastError = [string]::Format('You can only add {0} value(s)', $ConfigLimit);
+                }
+
+                return;
+            }
+            if ((Test-Numeric $Result) -eq $FALSE -Or $KnownIndexes.ContainsKey([string]$Result) -eq $FALSE) {
+                $global:Icinga.InstallWizard.LastError = [string]::Format('Invalid selection has been made: {0}', $Result);
+
+                return;
+            }
+
+            break;
+        };
+    }
+
+    $DisabledMenu  = $FALSE;
+    $NextMenu      = $null;
+    $NextArguments = @{ };
+    $ActionCmd     = $null;
+    $ActionArgs    = $null;
+
+    if ([string]::IsNullOrEmpty($Result) -eq $FALSE) {
+        if ($Result -eq 'c') {
+            if ([string]::IsNullOrEmpty($ContinueFunction) -eq $FALSE) {
+                $NextMenu = $ContinueFunction;
+            } else {
+                $NextMenu = $Entries[0].Command;
+                if ($null -ne $Entries[0].Disabled) {
+                    $DisabledMenu = $Entries[0].Disabled;
+                }
+            }
+            $ActionCmd  = $Entries[0].Action.Command;
+            $ActionArgs = $Entries[0].Action.Arguments;
+        } else {
+            $NextMenu = $Entries[$Result].Command;
+            if ($null -ne $Entries[$Result].Disabled) {
+                $DisabledMenu = $Entries[$Result].Disabled;
+            }
+            if ($Entries[$Result].ContainsKey('Arguments')) {
+                $NextArguments = $Entries[$Result].Arguments;
+            }
+            $ActionCmd  = $Entries[$Result].Action.Command;
+            $ActionArgs = $Entries[$Result].Action.Arguments;
+        }
+    }
+
+    if ($DisabledMenu) {
+        $global:Icinga.InstallWizard.LastNotice = [string]::Format('This menu is not enabled: {0}', $Result);
+
+        return;
+    }
+
+    if ([string]::IsNullOrEmpty($NextMenu)) {
+        $global:Icinga.InstallWizard.LastNotice = [string]::Format('This menu is not yet implemented: {0}', $Result);
+
+        return;
+    }
+
+    if ($Advanced -eq $FALSE) {
+        Add-IcingaForWindowsManagementConsoleLastParent;
+    }
+
+    if ($JumpToSummary) {
+        $NextMenu = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+    }
+
+    if ($ConfigElement) {
+        Add-IcingaForWindowsInstallerConfigEntry `
+            -InstallerStep (Get-IcingaForWindowsManagementConsoleMenu) `
+            -Selection $Result `
+            -Values $StoredValues `
+            -Hidden:$HiddenConfigElement `
+            -PasswordInput:$PasswordInput `
+            -Advanced:$Advanced;
+    }
+
+    # Reset Help View
+    $global:Icinga.InstallWizard.ShowHelp = $FALSE;
+
+    if ($NextMenu -eq 'break') {
+        return;
+    }
+
+    $global:Icinga.InstallWizard.NextCommand   = $NextMenu;
+    $global:Icinga.InstallWizard.NextArguments = $NextArguments;
+
+    if ($Automated) {
+        return;
+    }
+
+    # In case a action is defined, execute the given action
+    if ([string]::IsNullOrEmpty($ActionCmd) -eq $FALSE) {
+        if ($null -eq $ActionArgs -Or $ActionArgs.Count -eq 0) {
+            $ActionArgs = @{ };
+        }
+
+        & $ActionCmd @ActionArgs | Out-Null;
+    }
+}

--- a/lib/core/installer/tools/Write-IcingaForWindowsManagementConsoleConfigSwap.psm1
+++ b/lib/core/installer/tools/Write-IcingaForWindowsManagementConsoleConfigSwap.psm1
@@ -1,0 +1,33 @@
+function Write-IcingaforWindowsManagementConsoleConfigSwap()
+{
+    param (
+        $Config = @{ }
+    );
+
+    [hashtable]$NewConfig = @{ };
+
+    # Remove passwords - do not store them inside our local config file
+    foreach ($entry in $Config.Keys) {
+        $Value = $Config[$entry];
+
+        $NewConfig.Add($entry, @{ });
+
+        foreach ($configElement in $Value.Keys) {
+            $confValue = $Value[$configElement];
+
+            if ($Value.Password -eq $TRUE -And $configElement -eq 'Values') {
+                $NewConfig[$entry].Add(
+                    $configElement,
+                    @( '***' )
+                );
+            } else {
+                $NewConfig[$entry].Add(
+                    $configElement,
+                    $confValue
+                );
+            }
+        }
+    }
+
+    Set-IcingaPowerShellConfig -Path 'Framework.Config.Swap' -Value $NewConfig;
+}

--- a/lib/core/installer/tools/actions/Get-IcingaForWindowsManagementConsoleLastInput.psm1
+++ b/lib/core/installer/tools/actions/Get-IcingaForWindowsManagementConsoleLastInput.psm1
@@ -1,0 +1,4 @@
+function Get-IcingaForWindowsManagementConsoleLastInput()
+{
+    return $global:Icinga.InstallWizard.LastInput;
+}

--- a/lib/core/installer/tools/actions/Show-IcingaWindowsManagementConsoleYesNoDialog.psm1
+++ b/lib/core/installer/tools/actions/Show-IcingaWindowsManagementConsoleYesNoDialog.psm1
@@ -1,0 +1,40 @@
+function Show-IcingaWindowsManagementConsoleYesNoDialog()
+{
+    param (
+        [string]$Caption         = '',
+        [string]$Command         = '',
+        [hashtable]$CmdArguments = @{ },
+        [array]$Value            = @(),
+        [string]$DefaultInput    = '0',
+        [switch]$JumpToSummary   = $FALSE,
+        [switch]$Automated       = $FALSE,
+        [switch]$Advanced        = $FALSE
+    );
+
+    $LastParent = Get-IcingaForWindowsInstallerLastParent;
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header ([string]::Format('Are you sure you want to perform this action: "{0}"?', $Caption)) `
+        -Entries @(
+            @{
+                'Caption' = 'No';
+                'Command' = $LastParent;
+                'Help'    = 'Do not apply the last action and return without doing anything';
+            },
+            @{
+                'Caption' = 'Yes';
+                'Command' = $LastParent;
+                'Help'    = "Apply the action and confirm it's execution";
+            }
+        ) `
+        -DefaultIndex $DefaultInput;
+
+    if ((Get-IcingaForWindowsManagementConsoleLastInput) -eq '1') {
+        if ($null -eq $CmdArguments -Or $CmdArguments.Count -eq 0) {
+            & $Command | Out-Null;
+        } else {
+            & $Command @CmdArguments | Out-Null;
+        }
+        $global:Icinga.InstallWizard.LastNotice = [string]::Format('Action "{0}" has been executed', $Caption);
+    }
+}

--- a/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsoleContinue.psm1
+++ b/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsoleContinue.psm1
@@ -1,0 +1,12 @@
+function Test-IcingaForWindowsManagementConsoleContinue()
+{
+    if ([string]::IsNullOrEmpty($global:Icinga.InstallWizard.LastInput)) {
+        return $FALSE;
+    }
+
+    if ($global:Icinga.InstallWizard.LastInput -eq 'c') {
+        return $TRUE;
+    }
+
+    return $FALSE;
+}

--- a/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsoleDelete.psm1
+++ b/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsoleDelete.psm1
@@ -1,0 +1,12 @@
+function Test-IcingaForWindowsManagementConsoleDelete()
+{
+    if ([string]::IsNullOrEmpty($global:Icinga.InstallWizard.LastInput)) {
+        return $FALSE;
+    }
+
+    if ($global:Icinga.InstallWizard.LastInput -eq 'd') {
+        return $TRUE;
+    }
+
+    return $FALSE;
+}

--- a/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsoleExit.psm1
+++ b/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsoleExit.psm1
@@ -1,0 +1,12 @@
+function Test-IcingaForWindowsManagementConsoleExit()
+{
+    if ([string]::IsNullOrEmpty($global:Icinga.InstallWizard.LastInput)) {
+        return $FALSE;
+    }
+
+    if ($global:Icinga.InstallWizard.LastInput -eq 'x') {
+        return $TRUE;
+    }
+
+    return $FALSE;
+}

--- a/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsoleHelp.psm1
+++ b/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsoleHelp.psm1
@@ -1,0 +1,12 @@
+function Test-IcingaForWindowsManagementConsoleHelp()
+{
+    if ([string]::IsNullOrEmpty($global:Icinga.InstallWizard.LastInput)) {
+        return $FALSE;
+    }
+
+    if ($global:Icinga.InstallWizard.LastInput -eq 'h') {
+        return $TRUE;
+    }
+
+    return $FALSE;
+}

--- a/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsoleMenu.psm1
+++ b/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsoleMenu.psm1
@@ -1,0 +1,12 @@
+function Test-IcingaForWindowsManagementConsoleMenu()
+{
+    if ([string]::IsNullOrEmpty($global:Icinga.InstallWizard.LastInput)) {
+        return $FALSE;
+    }
+
+    if ($global:Icinga.InstallWizard.LastInput -eq 'm') {
+        return $TRUE;
+    }
+
+    return $FALSE;
+}

--- a/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsolePrevious.psm1
+++ b/lib/core/installer/tools/actions/Test-IcingaForWindowsManagementConsolePrevious.psm1
@@ -1,0 +1,12 @@
+function Test-IcingaForWindowsManagementConsolePrevious()
+{
+    if ([string]::IsNullOrEmpty($global:Icinga.InstallWizard.LastInput)) {
+        return $FALSE;
+    }
+
+    if ($global:Icinga.InstallWizard.LastInput -eq 'p') {
+        return $TRUE;
+    }
+
+    return $FALSE;
+}

--- a/lib/core/installer/tools/environment/Disable-IcingaForWindowsInstallationHeaderPrint.psm1
+++ b/lib/core/installer/tools/environment/Disable-IcingaForWindowsInstallationHeaderPrint.psm1
@@ -1,0 +1,4 @@
+function Disable-IcingaForWindowsInstallationHeaderPrint()
+{
+    $global:Icinga.InstallWizard.HeaderPrint = $FALSE;
+}

--- a/lib/core/installer/tools/environment/Disable-IcingaForWindowsInstallationJumpToSummary.psm1
+++ b/lib/core/installer/tools/environment/Disable-IcingaForWindowsInstallationJumpToSummary.psm1
@@ -1,0 +1,4 @@
+function Disable-IcingaForWindowsInstallationJumpToSummary()
+{
+    $global:Icinga.InstallWizard.JumpToSummary = $FALSE;
+}

--- a/lib/core/installer/tools/environment/Enable-IcingaForWindowsInstallationHeaderPrint.psm1
+++ b/lib/core/installer/tools/environment/Enable-IcingaForWindowsInstallationHeaderPrint.psm1
@@ -1,0 +1,4 @@
+function Enable-IcingaForWindowsInstallationHeaderPrint()
+{
+    $global:Icinga.InstallWizard.HeaderPrint = $TRUE;
+}

--- a/lib/core/installer/tools/environment/Enable-IcingaForWindowsInstallationJumpToSummary.psm1
+++ b/lib/core/installer/tools/environment/Enable-IcingaForWindowsInstallationJumpToSummary.psm1
@@ -1,0 +1,4 @@
+function Enable-IcingaForWindowsInstallationJumpToSummary()
+{
+    $global:Icinga.InstallWizard.JumpToSummary = $TRUE;
+}

--- a/lib/core/installer/tools/environment/Get-IcingaForWindowsInstallationHeaderSelection.psm1
+++ b/lib/core/installer/tools/environment/Get-IcingaForWindowsInstallationHeaderSelection.psm1
@@ -1,0 +1,4 @@
+function Get-IcingaForWindowsInstallationHeaderSelection()
+{
+    return $global:Icinga.InstallWizard.HeaderSelection;
+}

--- a/lib/core/installer/tools/environment/Set-IcingaForWindowsInstallationHeaderSelection.psm1
+++ b/lib/core/installer/tools/environment/Set-IcingaForWindowsInstallationHeaderSelection.psm1
@@ -1,0 +1,8 @@
+function Set-IcingaForWindowsInstallationHeaderSelection()
+{
+    param (
+        [string]$Selection = $null
+    );
+
+    $global:Icinga.InstallWizard.HeaderSelection = $Selection;
+}

--- a/lib/core/installer/tools/environment/Test-IcingaForWindowsInstallationHeaderPrint.psm1
+++ b/lib/core/installer/tools/environment/Test-IcingaForWindowsInstallationHeaderPrint.psm1
@@ -1,0 +1,4 @@
+function Test-IcingaForWindowsInstallationHeaderPrint()
+{
+    return $global:Icinga.InstallWizard.HeaderPrint;
+}

--- a/lib/core/installer/tools/environment/Test-IcingaForWindowsInstallationJumpToSummary.psm1
+++ b/lib/core/installer/tools/environment/Test-IcingaForWindowsInstallationJumpToSummary.psm1
@@ -1,0 +1,4 @@
+function Test-IcingaForWindowsInstallationJumpToSummary()
+{
+    return $global:Icinga.InstallWizard.JumpToSummary;
+}

--- a/lib/core/logging/Write-IcingaConsoleOutput.psm1
+++ b/lib/core/logging/Write-IcingaConsoleOutput.psm1
@@ -31,10 +31,14 @@ function Write-IcingaConsoleOutput()
     param (
         [string]$Message,
         [array]$Objects,
-        [ValidateSet('Black', 'DarkBlue', 'DarkGreen', 'DarkCyan', 'DarkRed', 'DarkMagenta', 'DarkYellow', 'Gray', 'DarkGray', 'Blue', 'Green', 'Cyan', 'Red', 'Magenta', 'Yellow', 'White')]
-        [string]$ForeColor = 'White',
+        [ValidateSet('Default', 'Black', 'DarkBlue', 'DarkGreen', 'DarkCyan', 'DarkRed', 'DarkMagenta', 'DarkYellow', 'Gray', 'DarkGray', 'Blue', 'Green', 'Cyan', 'Red', 'Magenta', 'Yellow', 'White')]
+        [string]$ForeColor = 'Default',
         [string]$Severity  = 'Notice'
     );
+
+    if ((Test-IcingaFrameworkConsoleOutput) -eq $FALSE) {
+        return;
+    }
 
     $OutputMessage = $Message;
     [int]$Index    = 0;
@@ -52,7 +56,14 @@ function Write-IcingaConsoleOutput()
         Write-Host '[' -NoNewline;
         Write-Host $Severity -NoNewline -ForegroundColor $ForeColor;
         Write-Host ']: ' -NoNewline;
+        Write-Host $OutputMessage;
+
+        return;
     }
 
-    Write-Host $OutputMessage;
+    if ($ForeColor -eq 'Default') {
+        Write-Host $OutputMessage;
+    } else {
+        Write-Host $OutputMessage -ForegroundColor $ForeColor;
+    }
 }

--- a/lib/core/logging/Write-IcingaConsolePlain.psm1
+++ b/lib/core/logging/Write-IcingaConsolePlain.psm1
@@ -23,12 +23,14 @@ function Write-IcingaConsolePlain()
 {
     param (
         [string]$Message,
-        [array]$Objects
+        [array]$Objects,
+        [ValidateSet('Default', 'Black', 'DarkBlue', 'DarkGreen', 'DarkCyan', 'DarkRed', 'DarkMagenta', 'DarkYellow', 'Gray', 'DarkGray', 'Blue', 'Green', 'Cyan', 'Red', 'Magenta', 'Yellow', 'White')]
+        [string]$ForeColor = 'Default'
     );
 
     Write-IcingaConsoleOutput `
         -Message $Message `
         -Objects $Objects `
-        -ForeColor 'Blue' `
+        -ForeColor $ForeColor `
         -Severity $null;
 }

--- a/lib/core/tools/ConvertFrom-IcingaArrayToString.psm1
+++ b/lib/core/tools/ConvertFrom-IcingaArrayToString.psm1
@@ -1,0 +1,37 @@
+function ConvertFrom-IcingaArrayToString()
+{
+    param (
+        [array]$Array          = @(),
+        [switch]$AddQuotes     = $FALSE,
+        [switch]$SecureContent = $FALSE
+    );
+
+    if ($null -eq $Array -Or $Array.Count -eq 0) {
+        if ($AddQuotes) {
+            return '""';
+        }
+
+        return '';
+    }
+
+    [array]$NewArray = @();
+
+    if ($AddQuotes) {
+        foreach ($entry in $Array) {
+            if ($SecureContent) {
+                $entry = '***';
+            }
+            $NewArray += ([string]::Format('"{0}"', $entry));
+        }
+    } else {
+        if ($SecureContent) {
+            foreach ($entry in $Array) {
+                $NewArray += '***';
+            }
+        } else {
+            $NewArray = $Array;
+        }
+    }
+
+    return ([string]::Join(', ', $NewArray));
+}

--- a/lib/core/tools/ConvertTo-IcingaSecureString.psm1
+++ b/lib/core/tools/ConvertTo-IcingaSecureString.psm1
@@ -4,9 +4,13 @@
  #>
 function ConvertTo-IcingaSecureString()
 {
-    param(
+    param (
         [string]$String
     );
+
+    if ([string]::IsNullOrEmpty($String)) {
+        return $null;
+    }
 
     return (ConvertTo-SecureString -AsPlainText $string -Force);
 }

--- a/lib/core/tools/Write-IcingaConsoleHeader.psm1
+++ b/lib/core/tools/Write-IcingaConsoleHeader.psm1
@@ -1,0 +1,68 @@
+function Write-IcingaConsoleHeader()
+{
+    param (
+        [array]$HeaderLines = @()
+    );
+
+    [array]$ParsedHeaders  = @();
+    [int]$MaxHeaderLength  = 0;
+    [int]$TableHeaderCount = 0;
+    [array]$TableHeader    = @();
+
+    Import-LocalizedData `
+        -BaseDirectory (Join-Path -Path (Get-IcingaFrameworkRootPath) -ChildPath 'icinga-powershell-framework') `
+        -FileName 'icinga-powershell-framework.psd1' `
+        -BindingVariable IcingaFrameworkData;
+
+    foreach ($line in $HeaderLines) {
+        $line = $line.Replace('$FrameworkVersion', $IcingaFrameworkData.PrivateData.Version);
+        $line = $line.Replace('$Copyright', $IcingaFrameworkData.Copyright);
+        $line = $line.Replace('$UserDomain', $env:USERDOMAIN);
+        $line = $line.Replace('$Username', $env:USERNAME);
+
+        $ParsedHeaders += $line;
+    }
+
+    foreach ($line in $ParsedHeaders) {
+        if ($MaxHeaderLength -lt $line.Length) {
+            $MaxHeaderLength = $line.Length
+        }
+    }
+
+    $TableHeaderCount = $MaxHeaderLength + 6;
+
+    while ($TableHeaderCount -ne 0) {
+        $TableHeader += '*';
+        $TableHeaderCount -= 1;
+    }
+
+    $TableHeaderCount = $MaxHeaderLength + 6;
+
+    Write-IcingaConsolePlain ([string]::Join('', $TableHeader));
+
+    foreach ($line in $ParsedHeaders) {
+        [array]$LeftSpacing = @();
+        [array]$RightSpacing = @();
+
+        if ($line.Length -lt $MaxHeaderLength) {
+            $Spacing = [math]::floor(($MaxHeaderLength - $line.Length) / 2);
+
+            while ($Spacing -gt 0) {
+                $LeftSpacing  += ' ';
+                $RightSpacing += ' ';
+                $Spacing      -= 1;
+            }
+
+            if ($TableHeaderCount -gt ($line.Length + $LeftSpacing.Count + $RightSpacing.Count + 6)) {
+                [int]$RightOffset = $TableHeaderCount - ($line.Length + $LeftSpacing.Count + $RightSpacing.Count + 6)
+                while ($RightOffset -gt 0) {
+                    $RightSpacing += ' ';
+                    $RightOffset  -= 1;
+                }
+            }
+        }
+        Write-IcingaConsolePlain -Message '**{1} {0} {2}**' -Objects $line, ([string]::Join('', $LeftSpacing)), ([string]::Join('', $RightSpacing));
+    }
+
+    Write-IcingaConsolePlain ([string]::Join('', $TableHeader));
+}

--- a/lib/daemons/ServiceCheckDaemon/Start-IcingaServiceCheckDaemon.psm1
+++ b/lib/daemons/ServiceCheckDaemon/Start-IcingaServiceCheckDaemon.psm1
@@ -1,3 +1,25 @@
+<#
+.SYNOPSIS
+   A background daemon executing registered service checks in the background to fetch
+   metrics for certain checks over time. Time frames are configurable individual
+.DESCRIPTION
+   This background daemon will execute checks registered with "Register-IcingaServiceCheck"
+   for the given time interval and store the collected metrics for a defined period of time
+   inside a JSON file. Check values collected by this daemon are then automatically added
+   to regular check executions for additional performance metrics.
+
+   Example: Register-IcingaServiceCheck -CheckCommand 'Invoke-IcingaCheckCPU' -Interval 30 -TimeIndexes 1,3,5,15;
+
+   This will execute the CPU check every 30 seconds and calculate the average of 1, 3, 5 and 15 minutes
+
+   More Information on
+   https://icinga.com/docs/icinga-for-windows/latest/doc/service/02-Register-Daemons/
+   https://icinga.com/docs/icinga-for-windows/latest/doc/service/10-Register-Service-Checks/
+.LINK
+   https://github.com/Icinga/icinga-powershell-framework
+.NOTES
+#>
+
 function Start-IcingaServiceCheckDaemon()
 {
     $ScriptBlock = {


### PR DESCRIPTION
Adds new experimental feature `Management Console` for better and easier management for Icinga for Windows and improved automation and deployed.

In addition following changes were made:
* Added support to fetch network interface for `Register-IcingaDirectorSelfServiceHost` directly from provided director url
* Added support for Icinga Framework Code Cache file being deleted once the feature is disabled
* Added support to suppress any console output for the current PowerShell session by using `Disable-IcingaFrameworkConsoleOutput` and to enable it again by using `Enable-IcingaFrameworkConsoleOutput`
* Added support for `-Release` argument for `Get-IcingaFrameworkServiceBinary` suppressing questions and using GitHub as source directly if set
* Added support to color console output by using `Write-IcingaConsolePlain` with the new argument `-ForeColor`
* Added new feature to write Icinga for Windows console headers more easily, better structured and formatted with `Write-IcingaConsoleHeader` by adding line content as array elements
* Fixed possible crash on `Get-IcingaAgentFeatures` if PowerShell is not running as administrator and therefor the command `icinga2 feature list` can not be processed
* Fixed `ConvertTo-IcingaSecureString` to return `$null` for empty strings instead of throwing an exception