### PR TITLE
Fix wrong plugin not installed unknown checkresult

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -34,6 +34,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#208](https://github.com/Icinga/icinga-powershell-framework/pull/208) Fixes `Convert-IcingaPluginThresholds` which sometimes did not return proper numeric usable values for our internal functions, causing issues on plugin calls. In addition the function now also supports the handling for % units.
 * [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Fixed possible crash on `Get-IcingaAgentFeatures` if PowerShell is not running as administrator and therefor the command `icinga2 feature list` can not be processed
 * [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Fixed `ConvertTo-IcingaSecureString` to return `$null` for empty strings instead of throwing an exception
+* [#214](https://github.com/Icinga/icinga-powershell-framework/pull/214) Fixes wrong `[Unknown] PluginNotInstalled` exception because of new plugin configuration and wrong checking against APi result in case feature is enabled
 
 ### Experimental
 

--- a/lib/core/framework/Invoke-IcingaInternalServiceCall.psm1
+++ b/lib/core/framework/Invoke-IcingaInternalServiceCall.psm1
@@ -101,12 +101,17 @@ function Invoke-IcingaInternalServiceCall()
     $IcingaCR     = '';
 
     # In case we didn't receive a check result, fallback to local execution
-    if ($null -eq $IcingaResult.$Command.checkresult) {
+    if ([string]::IsNullOrEmpty($IcingaResult.$Command.checkresult)) {
         Write-IcingaEventMessage -Namespace 'Framework' -EventId 1553 -Objects 'The check result for the executed command was empty', $Command, $DebugArguments;
         return;
     }
 
-    $IcingaCR     = ($IcingaResult.$Command.checkresult.Replace("`r`n", "`n"));
+    if ([string]::IsNullOrEmpty($IcingaResult.$Command.exitcode)) {
+        Write-IcingaEventMessage -Namespace 'Framework' -EventId 1553 -Objects 'The check result for the executed command was empty', $Command, $DebugArguments;
+        return;
+    }
+
+    $IcingaCR = ($IcingaResult.$Command.checkresult.Replace("`r`n", "`n"));
 
     if ($IcingaResult.$Command.perfdata.Count -ne 0) {
         $IcingaCR += ' | ';

--- a/lib/icinga/plugin/Exit-IcingaExecutePlugin.psm1
+++ b/lib/icinga/plugin/Exit-IcingaExecutePlugin.psm1
@@ -4,8 +4,6 @@ function Exit-IcingaExecutePlugin()
         [string]$Command = ''
     );
 
-    Exit-IcingaPluginNotInstalled -Command $Command;
-
     Invoke-IcingaInternalServiceCall -Command $Command -Arguments $args;
 
     try {
@@ -13,6 +11,8 @@ function Exit-IcingaExecutePlugin()
         if ($null -eq $global:IcingaDaemonData) {
             Use-Icinga;
         }
+
+        Exit-IcingaPluginNotInstalled -Command $Command;
 
         exit (& $Command @args);
     } catch {


### PR DESCRIPTION
Unknown checks for the plugin handler were called to soon, as the minimal configuration does not load old check commands for the plugins.
In addition API checks did not throw an unknown and were not catched properly
