### PR TITLE
Fix: ConvertTo-IcingaSecureString exceptions because of not being pre-loaded

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,6 +13,12 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+## 1.4.1 (pending)
+
+### Bugfixes
+
+* [#222](https://github.com/Icinga/icinga-powershell-framework/pull/222) Fixes an issue with [Secure.String] arguments for PowerShell plugins, caused by `ConvertTo-IcingaSecureString` Cmdlet not being pre-loaded
+
 ## 1.4.0 (2021-03-02)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/11?closed=1)

--- a/icinga-powershell-framework.psd1
+++ b/icinga-powershell-framework.psd1
@@ -29,7 +29,8 @@
         '.\lib\core\logging\Write-IcingaConsolePlain.psm1',
         '.\lib\core\tools\Test-IcingaFunction.psm1',
         '.\lib\core\tools\Write-IcingaConsoleHeader.psm1',
-        '.\lib\core\framework\Test-IcingaFrameworkConsoleOutput.psm1'
+        '.\lib\core\framework\Test-IcingaFrameworkConsoleOutput.psm1',
+        '.\lib\core\tools\ConvertTo-IcingaSecureString.psm1'
     )
     FunctionsToExport = @(
         'Use-Icinga',
@@ -67,7 +68,8 @@
         'Write-IcingaConsolePlain',
         'Test-IcingaFunction',
         'Write-IcingaConsoleHeader',
-        'Test-IcingaFrameworkConsoleOutput'
+        'Test-IcingaFrameworkConsoleOutput',
+        'ConvertTo-IcingaSecureString'
     )
     CmdletsToExport   = @('*')
     VariablesToExport = '*'


### PR DESCRIPTION
With updating Icinga for Windows to v1.4.0, there is an issue with plugins using [Secure.String] variables. By default, we convert string values with the function `ConvertTo-IcingaSecureString` to a [Secure.String] for PowerShell for better usage. Because of the plugin execution change, this function is no longer available with `Use-Icinga -Minimal`

This only affects environments with udpated configuration

Fixes #222