### PR TITLE
Fix: Memory leak on background service daemon

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,11 +13,12 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
-## 1.4.1 (pending)
+## 1.4.1 (2021-03-10)
 
 ### Bugfixes
 
 * [#222](https://github.com/Icinga/icinga-powershell-framework/pull/222) Fixes an issue with [Secure.String] arguments for PowerShell plugins, caused by `ConvertTo-IcingaSecureString` Cmdlet not being pre-loaded
+* [#224](https://github.com/Icinga/icinga-powershell-framework/issues/224) Fixes "memory leak" on background daemon for registered service checks, by clearing the error stack and manually calling the PowerShell garbage collector to force freeing of memory
 
 ## 1.4.0 (2021-03-02)
 

--- a/lib/core/logging/Write-IcingaConsoleOutput.psm1
+++ b/lib/core/logging/Write-IcingaConsoleOutput.psm1
@@ -40,6 +40,11 @@ function Write-IcingaConsoleOutput()
         return;
     }
 
+    # Never write console output in case the Framework is running as daemon
+    if ($null -ne $global:IcingaDaemonData -And $null -ne $global:IcingaDaemonData.FrameworkRunningAsDaemon -And $global:IcingaDaemonData.FrameworkRunningAsDaemon -eq $TRUE) {
+        return;
+    }
+
     $OutputMessage = $Message;
     [int]$Index    = 0;
 

--- a/lib/icinga/plugin/New-IcingaCheck.psm1
+++ b/lib/icinga/plugin/New-IcingaCheck.psm1
@@ -63,8 +63,16 @@ function New-IcingaCheck()
                 );
             }
 
+            # Fix possible error for identical time stamps due to internal exceptions
+            # and check execution within the same time slot because of this
+            [string]$TimeIndex = Get-IcingaUnixTime;
+
+            if ($global:Icinga.CheckData[$this.checkcommand]['results'][$this.name].ContainsKey($TimeIndex)) {
+                return;
+            }
+
             $global:Icinga.CheckData[$this.checkcommand]['results'][$this.name].Add(
-                (Get-IcingaUnixTime),
+                $TimeIndex,
                 $this.value
             );
         }


### PR DESCRIPTION
Fixes "memory leak" on background daemon for registered service checks, by clearing the error stack and manually calling the PowerShell garbage collector to force the freeing of memory.

In addition background daemon tasks will no longer be able to write any information to consoles to keep memory clean as well.

Fixes #224