### PR TITLE
Feature: Suppress other messages then plugin output

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Enhancements
 
+* [#228](https://github.com/Icinga/icinga-powershell-framework/issues/228) Adds feature to suppress any kind of console output except for plugin output and performance data
 * [#229](https://github.com/Icinga/icinga-powershell-framework/pull/229) CustomFields defined as `SecureString` are now set to `hidden` within the Icinga Director configuration basket - please read the [upgrading docs](30-upgrading-framework.md) carefully
 * [#234](https://github.com/Icinga/icinga-powershell-framework/pull/234) Adds support to allow custom exception lists for Icinga Exceptions, making it easier for different modules to ship their own exception messages
 * [#235](https://github.com/Icinga/icinga-powershell-framework/pull/235) Adds new Cmdlet `Show-IcingaEventLogAnalysis` to get a better overview on how many log entries are present within the EventLog based on hour, minute and day average/maximum for allowing a more dynamic configuration for `Invoke-IcingaCheckEventLog`

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -10,7 +10,7 @@
 
 function Use-Icinga()
 {
-    param(
+    param (
         [switch]$LibOnly   = $FALSE,
         [switch]$Daemon    = $FALSE,
         [switch]$DebugMode = $FALSE,
@@ -20,6 +20,14 @@ function Use-Icinga()
     Disable-IcingaProgressPreference;
 
     if ($Minimal) {
+        if ($null -eq $global:Icinga) {
+            $global:Icinga = @{ };
+        }
+
+        if ($global:Icinga.ContainsKey('Minimal') -eq $FALSE) {
+            $global:Icinga.Add('Minimal', $TRUE);
+        }
+
         # If we load the minimal Framework files, we have to ensure our enums are loaded
         Import-Module ([string]::Format('{0}\lib\icinga\exception\Icinga_IcingaExceptionEnums.psm1', $PSScriptRoot)) -Global;
         Import-Module ([string]::Format('{0}\lib\icinga\enums\Icinga_IcingaEnums.psm1', $PSScriptRoot)) -Global;

--- a/lib/icinga/plugin/Write-IcingaPluginOutput.psm1
+++ b/lib/icinga/plugin/Write-IcingaPluginOutput.psm1
@@ -1,10 +1,13 @@
 function Write-IcingaPluginOutput()
 {
-    param(
+    param (
         $Output
     );
 
     if ($global:IcingaDaemonData.FrameworkRunningAsDaemon -eq $FALSE) {
+        if ($null -ne $global:Icinga -And $global:Icinga.Minimal) {
+            Clear-Host;
+        }
         Write-IcingaConsolePlain $Output;
     } else {
         # New behavior with local thread separated results


### PR DESCRIPTION
Adds feature to suppress any kind of console output except for plugin output and performance data, while Icinga for Windows is initialised with `Use-Icinga -Minimal`