### PR TITLE
Adds support to allow custom exception lists

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,6 +13,8 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Enhancements
 
+* [#234](https://github.com/Icinga/icinga-powershell-framework/pull/234) Adds support to allow custom exception lists for Icinga Exceptions, making it easier for different modules to ship their own exception messages
+
 ### Bugfixes
 
 ## 1.4.1 (2021-03-10)

--- a/lib/icinga/exception/Exit-IcingaThrowException.psm1
+++ b/lib/icinga/exception/Exit-IcingaThrowException.psm1
@@ -7,6 +7,7 @@ function Exit-IcingaThrowException()
         $ExceptionThrown,
         [ValidateSet('Permission', 'Input', 'Configuration', 'Connection', 'Unhandled', 'Custom')]
         [string]$ExceptionType    = 'Unhandled',
+        [hashtable]$ExceptionList = @{ },
         [string]$KnowledgeBaseId,
         [switch]$Force
     );
@@ -21,25 +22,29 @@ function Exit-IcingaThrowException()
         }
     }
 
+    if ($null -eq $ExceptionList -Or $ExceptionList.Count -eq 0) {
+        $ExceptionList = $IcingaExceptions;
+    }
+
     $ExceptionMessageLib = $null;
     $ExceptionTypeString = '';
 
     switch ($ExceptionType) {
         'Permission' {
             $ExceptionTypeString = 'Permission';
-            $ExceptionMessageLib = $IcingaExceptions.Permission;
+            $ExceptionMessageLib = $ExceptionList.Permission;
         };
         'Input' {
             $ExceptionTypeString = 'Invalid Input';
-            $ExceptionMessageLib = $IcingaExceptions.Inputs;
+            $ExceptionMessageLib = $ExceptionList.Inputs;
         };
         'Configuration' {
             $ExceptionTypeString = 'Invalid Configuration';
-            $ExceptionMessageLib = $IcingaExceptions.Configuration;
+            $ExceptionMessageLib = $ExceptionList.Configuration;
         };
         'Connection' {
             $ExceptionTypeString = 'Connection error';
-            $ExceptionMessageLib = $IcingaExceptions.Connection;
+            $ExceptionMessageLib = $ExceptionList.Connection;
         };
         'Unhandled' {
             $ExceptionTypeString = 'Unhandled';


### PR DESCRIPTION
Allows to add a custom exception list hashtable to `Exit-IcingaThrowException` for better usability on different modules.