### PR TITLE
Feature: Hide SecureString CustomFields input in Icinga Director

### DIFF
--- a/doc/30-upgrading-framework.md
+++ b/doc/30-upgrading-framework.md
@@ -4,6 +4,14 @@ Upgrading Icinga PowerShell Framework is usually quite straightforward.
 
 Specific version upgrades are described below. Please note that version updates are incremental.
 
+## Upgrading to v1.5.0 (pending)
+
+### `SecureString` and Icinga Director Baskets
+
+We have updated the configuration baskets generator to set arguments defined as `SecureString` (for passwords) to `hidden` within the Icinga Director. This will prevent users from simply gaining access to a password while having access to the Director.
+
+Please update manually all your CustomFields under `Icinga Director` -> `Define Data Fields` -> Search for `*_Securestring_*` -> Field `Visibility` to `Hidden` before importing new configuration baskets. Otherwise you will have two data fields stored within your Icinga Director and have to enter all passwords again for your service checks.
+
 ## Upgrading to v1.4.0 (2021-03-02)
 
 The pre-compiled configurations for each module and the result of `Get-IcingaCheckCommandConfig` have been changed. In order to use the new CheckCommand definitions for Icinga 2 you will **require** to update your entire environment to Icinga for Windows v1.4.0 **before** using the new configuration files!

--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Enhancements
 
+* [#229](https://github.com/Icinga/icinga-powershell-framework/pull/229) CustomFields defined as `SecureString` are now set to `hidden` within the Icinga Director configuration basket - please read the [upgrading docs](30-upgrading-framework.md) carefully
 * [#234](https://github.com/Icinga/icinga-powershell-framework/pull/234) Adds support to allow custom exception lists for Icinga Exceptions, making it easier for different modules to ship their own exception messages
 * [#235](https://github.com/Icinga/icinga-powershell-framework/pull/235) Adds new Cmdlet `Show-IcingaEventLogAnalysis` to get a better overview on how many log entries are present within the EventLog based on hour, minute and day average/maximum for allowing a more dynamic configuration for `Invoke-IcingaCheckEventLog`
 

--- a/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
+++ b/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
@@ -288,9 +288,15 @@ function Get-IcingaCheckCommandConfig()
                         }
                     );
                 } else {
+                    $CustomVarVisibility = 'visible';
+
+                    if ($parameter.type.name -eq 'SecureString') {
+                        $CustomVarVisibility = 'hidden';
+                    }
+
                     $Basket.Datafield[[string]$FieldID].Add(
                         'settings', @{
-                            'visbility' = 'visible';
+                            'visibility' = $CustomVarVisibility;
                         }
                     );
                 }


### PR DESCRIPTION
Adds feature to mask CustomField input values with `*` within the Icinga Director, in case the argument is defined as `SecureString`. Please ensure to read the [upgrading docs](https://icinga.com/docs/icinga-for-windows/latest/doc/30-upgrading-framework/) carefully, before importing new configurations.

Fixes #229