### PR TITLE
Fix: Adds missing attributes for services

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -19,6 +19,8 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#240](https://github.com/Icinga/icinga-powershell-framework/pull/240) While filtering for certain services with `Get-IcingaServices`, there were some attributes missing from the collection. These are now added resulting in always correct output data.
+
 ## 1.4.1 (2021-03-10)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/14?closed=1)

--- a/lib/core/tools/Get-IcingaServices.psm1
+++ b/lib/core/tools/Get-IcingaServices.psm1
@@ -11,14 +11,14 @@ function Get-IcingaServices()
     if ($Service.Count -eq 0) {
         $ServiceWmiInfo = Get-IcingaWindowsInformation Win32_Service;
     } else {
-        $ServiceWmiInfo = Get-IcingaWindowsInformation Win32_Service | Where-Object { $Service -Contains $_.Name } | Select-Object StartName, Name;
+        $ServiceWmiInfo = Get-IcingaWindowsInformation Win32_Service | Where-Object { $Service -Contains $_.Name } | Select-Object StartName, Name, ExitCode, StartMode;
     }
 
     if ($null -eq $ServiceInformation) {
         return $null;
     }
 
-    [hashtable]$ServiceData = @{};
+    [hashtable]$ServiceData = @{ };
 
     foreach ($service in $ServiceInformation) {
 


### PR DESCRIPTION
While filtering for certain services with `Get-IcingaServices`, there were some attributes missing from the collection. These are now added resulting in always correct output data.