### PR TITLE
Fix loading certificate from .pfx file

### DIFF
--- a/lib/webserver/Get-IcingaSSLCertForSocket.psm1
+++ b/lib/webserver/Get-IcingaSSLCertForSocket.psm1
@@ -10,8 +10,7 @@ function Get-IcingaSSLCertForSocket()
     # to get a proper certificate
     if ([string]::IsNullOrEmpty($CertFile) -eq $FALSE) {
         if ((Test-Path $CertFile)) {
-            $FileType = Get-Item -Path $CertFile;
-            if ($FileType -eq '.pfx') {
+            if ([IO.Path]::GetExtension($CertFile) -eq '.pfx') {
                 return (New-Object Security.Cryptography.X509Certificates.X509Certificate2 $CertFile);
             } else {
                 return ConvertTo-IcingaX509Certificate -CertFile $CertFile;


### PR DESCRIPTION
If you tried this
```
Use-Icinga; Get-IcingaSSLCertForSocket -CertFile "C:/my/cert.pfx"
```
the former code expanded like

```
$FileType = Get-Item -Path "C:/my/cert.pfx";
if ("cert.pfx" -eq '.pfx') { ... not reached ... }
```

and thus did not load the certificate file.

Now use `GetExtension` instead of `Get-Item` to make the .pfx check work.