### PR TITLE
Feature: Inform the user if plugins are executed which are not meeting dependency requirements

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -20,6 +20,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#241](https://github.com/Icinga/icinga-powershell-framework/pull/241) Ensures we use TLS 1.1 and 1.2 for REST-Api calls, as used certificates in general are created with these
 * [#243](https://github.com/Icinga/icinga-powershell-framework/pull/243) Adds stacktrace output for exceptions in case plugin execution fails
 * [#248](https://github.com/Icinga/icinga-powershell-framework/pull/248) Improves `Test-IcingaPerformanceCounterCategory` by creating an object for the Performance Counter category provided and checking if it is a valid object instead of relying on the registry which might not contain all categories in the correct language.
+* [#250](https://github.com/Icinga/icinga-powershell-framework/pull/250) Improve error handling on plugin execution by informing the user if the plugin is simply not installed or the entire module was not loaded because of errors or missing dependencies
 
 ### Bugfixes
 

--- a/lib/icinga/exception/Exit-IcingaPluginNotInstalled.psm1
+++ b/lib/icinga/exception/Exit-IcingaPluginNotInstalled.psm1
@@ -24,8 +24,26 @@
 function Exit-IcingaPluginNotInstalled()
 {
     param (
-        $Command
+        [string]$Command
     );
+
+    $PowerShellModule = Get-Module 'icinga-powershell-*' -ListAvailable |
+        ForEach-Object {
+            foreach ($cmd in $_.ExportedCommands.Values) {
+                if ($Command.ToLower() -eq $cmd.Name.ToLower()) {
+                    return $cmd.Source;
+                }
+            }
+        }
+
+    if ([string]::IsNullOrEmpty($PowerShellModule) -eq $FALSE) {
+        try {
+            Import-Module $PowerShellModule -ErrorAction Stop;
+        } catch {
+            $ExMsg = $_.Exception.Message;
+            Exit-IcingaThrowException -CustomMessage 'Module not loaded' -ExceptionType 'Configuration' -ExceptionThrown $ExMsg -Force;
+        }
+    }
 
     if ([string]::IsNullOrEmpty($Command)) {
         Exit-IcingaThrowException -CustomMessage 'Null-Command' -ExceptionType 'Configuration' -ExceptionThrown $IcingaExceptions.Configuration.PluginNotAssigned -Force;


### PR DESCRIPTION
Improve error handling on plugin execution by informing the user if the plugin is simply not installed or the entire module was not loaded because of errors or missing dependencies

Fixes #250