### PR TITLE
Fix: Unhandled units might cause exception on maximum compare

### DIFF
--- a/lib/core/tools/Convert-IcingaPluginThresholds.psm1
+++ b/lib/core/tools/Convert-IcingaPluginThresholds.psm1
@@ -133,7 +133,28 @@ function Convert-IcingaPluginThresholds()
             $Value         = ([string]$ThresholdValue).Replace(' ', '').Replace('%', '');
             $RetValue.Unit = $WorkUnit;
         } else {
-            $Value = $ThresholdValue;
+            # Load all other units/values genericly
+            [string]$StrNumeric = '';
+            [bool]$FirstChar    = $TRUE;
+            foreach ($entry in ([string]($ThresholdValue)).ToCharArray()) {
+                if (Test-Numeric $entry) {
+                    $StrNumeric += $entry;
+                    $FirstChar   = $FALSE;
+                } else {
+                    if ([string]::IsNullOrEmpty($RetValue.Unit) -And $FirstChar -eq $FALSE) {
+                        $RetValue.Unit = $entry;
+                    } else {
+                        $StrNumeric    = '';
+                        $RetValue.Unit = '';
+                        break;
+                    }
+                }
+            }
+            if ([string]::IsNullOrEmpty($StrNumeric)) {
+                $Value = $ThresholdValue;
+            } else {
+                $Value = [decimal]$StrNumeric;
+            }
         }
 
         if ($HasTilde) {


### PR DESCRIPTION
Unhandled units like `c` are causing exceptions, in case they are used as maximum or base value.