### PR TITLE
Fix: Header summary should not include hidden packages/elements

### DIFF
--- a/lib/icinga/plugin/New-IcingaCheckPackage.psm1
+++ b/lib/icinga/plugin/New-IcingaCheckPackage.psm1
@@ -179,6 +179,10 @@ function New-IcingaCheckPackage()
 
             $check.Compile();
 
+            if ($check.__IsHidden()) {
+                continue;
+            }
+
             if ($WorstState -lt $check.__GetCheckState()) {
                 $WorstState = $check.__GetCheckState();
             }


### PR DESCRIPTION
Fixes header summary to no longer count in hidden elements for status counts