### PR TITLE
Fix: Numeric converison to comparing thresholds is incorrect

### DIFF
--- a/lib/core/tools/Convert-IcingaPluginThresholds.psm1
+++ b/lib/core/tools/Convert-IcingaPluginThresholds.psm1
@@ -170,7 +170,7 @@ function Convert-IcingaPluginThresholds()
 
     if ([string]::IsNullOrEmpty($Value) -eq $FALSE -And $Value.Contains(':') -eq $FALSE) {
         if ((Test-Numeric $Value)) {
-            $RetValue.Value = $Value;
+            $RetValue.Value = [decimal]$Value;
             return $RetValue;
         }
     }

--- a/lib/icinga/plugin/Compare-IcingaPluginThresholds.psm1
+++ b/lib/icinga/plugin/Compare-IcingaPluginThresholds.psm1
@@ -255,9 +255,11 @@ function Compare-IcingaPluginThresholds()
 
             if ((Test-Numeric ($rangeMin.Replace('@', '').Replace('~', '')))) {
                 $IcingaThresholds.MinRangeValue = [decimal]($rangeMin.Replace('@', '').Replace('~', ''));
+                [decimal]$rangeMin = [decimal]$rangeMin;
             }
             if ((Test-Numeric $rangeMax)) {
                 $IcingaThresholds.MaxRangeValue = [decimal]$rangeMax;
+                [decimal]$rangeMax = [decimal]$rangeMax;
             }
 
             if ($IsNegating -eq $FALSE -And (Test-Numeric $rangeMin) -And (Test-Numeric $rangeMax)) {


### PR DESCRIPTION
Fixes values to be transformed properly to `decimal` to compare them against thresholds provided