### PR TITLE
Fix: Input value from check objects was sometimes not properly converted to decimal

### DIFF
--- a/lib/icinga/plugin/Compare-IcingaPluginThresholds.psm1
+++ b/lib/icinga/plugin/Compare-IcingaPluginThresholds.psm1
@@ -113,6 +113,11 @@ function Compare-IcingaPluginThresholds()
     $TempValue                        = (Convert-IcingaPluginThresholds -Threshold ([string]::Format('{0}{1}', $InputValue, $Unit)));
     $InputValue                       = $TempValue.Value;
     $TmpUnit                          = $TempValue.Unit;
+
+    if (Test-Numeric $InputValue) {
+        [decimal]$InputValue = [decimal]$InputValue;
+    }
+
     $IcingaThresholds.RawValue        = $InputValue;
     $TempValue                        = (Convert-IcingaPluginThresholds -Threshold ([string]::Format('{0}{1}', $BaseValue, $Unit)));
     $BaseValue                        = $TempValue.Value;


### PR DESCRIPTION
Fixes input value conversion to `decimal` for check input values.