### PR TITLE
Fix: Test-Numeric allows no negative value and TimeSpan conversion ignores negatives and microseconds

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -31,6 +31,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#232](https://github.com/Icinga/icinga-powershell-framework/pull/232) Fixes wrong encoding while using REST-Api checks experimental feature, and now forces UTF8
 * [#240](https://github.com/Icinga/icinga-powershell-framework/pull/240) While filtering for certain services with `Get-IcingaServices`, there were some attributes missing from the collection. These are now added resulting in always correct output data.
 * [#245](https://github.com/Icinga/icinga-powershell-framework/pull/245) Fixes loading of `.pfx` certificates by properly checking the file type
+* [#265](https://github.com/Icinga/icinga-powershell-framework/pull/265) Fixes `Test-Numeric` to now accept negative numeric values and als fixes errors, causing `.` to be allowed multiple times. `ConvertFrom-TimeSpan` now properly prints on negative values if the time provided is positive or negative and also prints microseconds as `us` in case the value is loer than `1ms`
 
 ## 1.4.1 (2021-03-10)
 

--- a/lib/core/tools/Convert-IcingaPluginThresholds.psm1
+++ b/lib/core/tools/Convert-IcingaPluginThresholds.psm1
@@ -136,10 +136,14 @@ function Convert-IcingaPluginThresholds()
             # Load all other units/values genericly
             [string]$StrNumeric = '';
             [bool]$FirstChar    = $TRUE;
+            [bool]$Delimiter    = $FALSE;
             foreach ($entry in ([string]($ThresholdValue)).ToCharArray()) {
-                if (Test-Numeric $entry) {
+                if ((Test-Numeric $entry) -Or ($entry -eq '.' -And $Delimiter -eq $FALSE)) {
                     $StrNumeric += $entry;
                     $FirstChar   = $FALSE;
+                    if ($entry -eq '.') {
+                        $Delimiter = $TRUE;
+                    }
                 } else {
                     if ([string]::IsNullOrEmpty($RetValue.Unit) -And $FirstChar -eq $FALSE) {
                         $RetValue.Unit = $entry;

--- a/lib/core/tools/ConvertFrom-TimeSpan.psm1
+++ b/lib/core/tools/ConvertFrom-TimeSpan.psm1
@@ -6,12 +6,23 @@ function ConvertFrom-TimeSpan()
         $Seconds = 0
     );
 
+    if (([string]$Seconds).Contains(',') -Or (Test-Numeric $Seconds)) {
+        [decimal]$Seconds = [decimal]([string]$Seconds).Replace(',', '.');
+    }
+
+    $Sign = '';
+    if ($Seconds -lt 0) {
+        $Seconds = [math]::Abs($Seconds);
+        $Sign    = '-';
+    }
+
     $TimeSpan = [TimeSpan]::FromSeconds($Seconds);
 
     if ($TimeSpan.TotalDays -ge 1.0) {
         return (
             [string]::Format(
-                '{0}d',
+                '{0}{1}d',
+                $Sign,
                 ([math]::Round($TimeSpan.TotalDays, 2))
             )
         );
@@ -19,7 +30,8 @@ function ConvertFrom-TimeSpan()
     if ($TimeSpan.TotalHours -ge 1.0) {
         return (
             [string]::Format(
-                '{0}h',
+                '{0}{1}h',
+                $Sign,
                 ([math]::Round($TimeSpan.TotalHours, 2))
             )
         );
@@ -27,7 +39,8 @@ function ConvertFrom-TimeSpan()
     if ($TimeSpan.TotalMinutes -ge 1.0) {
         return (
             [string]::Format(
-                '{0}m',
+                '{0}{1}m',
+                $Sign,
                 ([math]::Round($TimeSpan.TotalMinutes, 2))
             )
         );
@@ -35,18 +48,24 @@ function ConvertFrom-TimeSpan()
     if ($TimeSpan.TotalSeconds -ge 1.0) {
         return (
             [string]::Format(
-                '{0}s',
+                '{0}{1}s',
+                $Sign,
                 ([math]::Round($TimeSpan.TotalSeconds, 2))
             )
         );
     }
-    if ($TimeSpan.TotalMilliseconds -gt 0) {
+    if ($TimeSpan.TotalMilliseconds -ge 1.0) {
         return (
             [string]::Format(
-                '{0}ms',
+                '{0}{1}ms',
+                $Sign,
                 $TimeSpan.TotalMilliseconds
             )
         );
+    }
+
+    if ($Seconds -lt 0.001) {
+        return ([string]::Format('{0}{1}us', $Sign, ([math]::Ceiling([decimal]($Seconds*[math]::Pow(10, 6))))));
     }
 
     return ([string]::Format('{0}s', $Seconds));

--- a/lib/core/tools/Test-Numeric.psm1
+++ b/lib/core/tools/Test-Numeric.psm1
@@ -13,5 +13,5 @@
 .NOTES
 #>
 function Test-Numeric ($number) {
-    return $number -Match "^[\d\.]+$";
+    return $number -Match "^-?[0-9]\d*(\.\d+)?$";
 }


### PR DESCRIPTION
Fixes `Test-Numeric` to now accept negative numeric values and als fixes errors, causing `.` to be allowed multiple times. `ConvertFrom-TimeSpan` now properly prints on negative values if the time provided is positive or negative and also prints microseconds as `us` in case the value is loer than `1ms`