### PR TITLE
Fix: Unhandled exception on Icinga Cache

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -32,6 +32,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#240](https://github.com/Icinga/icinga-powershell-framework/pull/240) While filtering for certain services with `Get-IcingaServices`, there were some attributes missing from the collection. These are now added resulting in always correct output data.
 * [#245](https://github.com/Icinga/icinga-powershell-framework/pull/245) Fixes loading of `.pfx` certificates by properly checking the file type
 * [#265](https://github.com/Icinga/icinga-powershell-framework/pull/265) Fixes `Test-Numeric` to now accept negative numeric values and als fixes errors, causing `.` to be allowed multiple times. `ConvertFrom-TimeSpan` now properly prints on negative values if the time provided is positive or negative and also prints microseconds as `us` in case the value is loer than `1ms`
+* [#269](https://github.com/Icinga/icinga-powershell-framework/pull/269) Fixes unhandled exception on `Set-IcingaCacheData`, as the `-ErrorAction Stop` argument was not set and therefor the function never halted on errors
 
 ## 1.4.1 (2021-03-10)
 

--- a/lib/core/cache/Set-IcingaCacheData.psm1
+++ b/lib/core/cache/Set-IcingaCacheData.psm1
@@ -41,7 +41,7 @@ function Set-IcingaCacheData()
         $cacheData = Get-IcingaCacheData -Space $Space -CacheStore $CacheStore;
     } else {
         try {
-            New-Item -ItemType File -Path $CacheFile -Force | Out-Null;
+            New-Item -ItemType File -Path $CacheFile -Force -ErrorAction Stop | Out-Null;
         } catch {
             Exit-IcingaThrowException -InputString $_.Exception -CustomMessage (Get-IcingaCacheDir) -StringPattern 'NewItemUnauthorizedAccessError' -ExceptionType 'Permission' -ExceptionThrown $IcingaExceptions.Permission.CacheFolder;
             Exit-IcingaThrowException -CustomMessage $_.Exception -ExceptionType 'Unhandled' -Force;


### PR DESCRIPTION
Fixes unhandled exception on `Set-IcingaCacheData`, as the `-ErrorAction Stop` argument was not set and therefor the function never halted on errors.