### PR TITLE
Fix: StackOverflowException on invalid ThresholdInterval

### DIFF
--- a/lib/icinga/plugin/Compare-IcingaPluginThresholds.psm1
+++ b/lib/icinga/plugin/Compare-IcingaPluginThresholds.psm1
@@ -63,6 +63,8 @@ function Compare-IcingaPluginThresholds()
                 $TimeInterval,
                 $MinuteInterval
             );
+
+            return $IcingaThresholds;
         }
     } <#else {
         # The symbol splitting our threshold from the time index value
@@ -130,12 +132,14 @@ function Compare-IcingaPluginThresholds()
     }
 
     # Calculate % value from base value of set
-    if ($null -ne $BaseValue -And $IcingaThresholds.Unit -eq '%') {
+    if ([string]::IsNullOrEmpty($BaseValue) -eq $FALSE -And $BaseValue -ne 0 -And $IcingaThresholds.Unit -eq '%') {
         $InputValue           = $InputValue / $BaseValue * 100;
         $UseDynamicPercentage = $TRUE;
-    } elseif ($null -eq $BaseValue -And $IcingaThresholds.Unit -eq '%') {
+    } elseif (([string]::IsNullOrEmpty($BaseValue) -eq $TRUE -Or $BaseValue -eq 0) -And $IcingaThresholds.Unit -eq '%') {
         $IcingaThresholds.HasError = $TRUE;
         $IcingaThresholds.ErrorMessage = 'This argument does not support the % unit';
+
+        return $IcingaThresholds;
     }
 
     # Always override our InputValue, case we might have change it
@@ -386,6 +390,8 @@ function Compare-IcingaPluginThresholds()
                         $Threshold
                     );
                     $IcingaThresholds.HasError = $TRUE;
+
+                    return $IcingaThresholds;
                 }
             }
         }

--- a/lib/icinga/plugin/New-IcingaCheck.psm1
+++ b/lib/icinga/plugin/New-IcingaCheck.psm1
@@ -33,6 +33,14 @@ function New-IcingaCheck()
     $IcingaCheck | Add-Member -MemberType NoteProperty -Name '__ThresholdObject' -Value $null;
     $IcingaCheck | Add-Member -MemberType NoteProperty -Name '__TimeInterval'    -Value $null;
 
+    $IcingaCheck | Add-Member -MemberType ScriptMethod -Force -Name 'Compile' -Value {
+        $this.__ValidateThresholdInput();
+        if ($null -eq $this.__ThresholdObject) {
+            $this.__CreateDefaultThresholdObject();
+        }
+        $this.__SetCheckOutput();
+    }
+
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Force -Name '__SetInternalTimeInterval' -Value {
         $CallStack           = Get-PSCallStack;
         [bool]$FoundInterval = $FALSE;
@@ -82,8 +90,8 @@ function New-IcingaCheck()
 
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Force -Name '__CreateDefaultThresholdObject' -Value {
         [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
-        $ThresholdObject = Compare-IcingaPluginThresholds @ThresholdArguments;
-        $this.__SetCheckState($ThresholdObject, $IcingaEnums.IcingaExitCode.Ok);
+        $this.__ThresholdObject = Compare-IcingaPluginThresholds @ThresholdArguments;
+        $this.__SetCheckState($this.__ThresholdObject, $IcingaEnums.IcingaExitCode.Ok);
     }
 
     # Override shared function
@@ -92,10 +100,6 @@ function New-IcingaCheck()
 
         if ($this.__InLockState()) {
             return;
-        }
-
-        if ($null -eq $this.__ThresholdObject) {
-            $this.__CreateDefaultThresholdObject();
         }
 
         $PluginThresholds = '';

--- a/lib/icinga/plugin/New-IcingaCheckBaseObject.psm1
+++ b/lib/icinga/plugin/New-IcingaCheckBaseObject.psm1
@@ -112,9 +112,8 @@ function New-IcingaCheckBaseObject()
         );
     }
 
+    # Shared function
     $IcingaCheckBaseObject | Add-Member -MemberType ScriptMethod -Name 'Compile' -Value {
-        $this.__ValidateThresholdInput();
-        $this.__SetCheckOutput();
     }
 
     $IcingaCheckBaseObject | Add-Member -MemberType ScriptMethod -Name '__SetVerbosity' -Value {


### PR DESCRIPTION
By using an invalid `-ThresholdInterval` argument, PowerShell will terminate itself with `StackOverflowException`, caused by a loop while creating default threshold values.