### PR TITLE
Fix: Exception on time conversion in case first letter matches time metric

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -33,6 +33,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#245](https://github.com/Icinga/icinga-powershell-framework/pull/245) Fixes loading of `.pfx` certificates by properly checking the file type
 * [#265](https://github.com/Icinga/icinga-powershell-framework/pull/265) Fixes `Test-Numeric` to now accept negative numeric values and als fixes errors, causing `.` to be allowed multiple times. `ConvertFrom-TimeSpan` now properly prints on negative values if the time provided is positive or negative and also prints microseconds as `us` in case the value is loer than `1ms`
 * [#269](https://github.com/Icinga/icinga-powershell-framework/pull/269) Fixes unhandled exception on `Set-IcingaCacheData`, as the `-ErrorAction Stop` argument was not set and therefor the function never halted on errors
+* [#272](https://github.com/Icinga/icinga-powershell-framework/pull/272) Fixes invalid unit conversion, in case first char of a string is matching time metrics
 
 ## 1.4.1 (2021-03-10)
 

--- a/lib/core/tools/ConvertFrom-TimeSpan.psm1
+++ b/lib/core/tools/ConvertFrom-TimeSpan.psm1
@@ -16,6 +16,10 @@ function ConvertFrom-TimeSpan()
         $Sign    = '-';
     }
 
+    if ((Test-Numeric $Seconds) -eq $FALSE) {
+        return $Seconds;
+    }
+
     $TimeSpan = [TimeSpan]::FromSeconds($Seconds);
 
     if ($TimeSpan.TotalDays -ge 1.0) {

--- a/lib/core/tools/ConvertTo-Seconds.psm1
+++ b/lib/core/tools/ConvertTo-Seconds.psm1
@@ -71,7 +71,7 @@ function ConvertTo-Seconds()
         $result = ($ValueSplitted / [math]::Pow(10, 3));
     } else {
         if ($UnitPart.Length -gt 1) {
-            Throw $errorMsg;
+            return $Value;
         }
 
         switch ([int][char]$UnitPart) {


### PR DESCRIPTION
Fixes invalid unit conversion, in case first char of a string is matching time metrics