### PR TITLE
Docs: readability change for Icinga Integration main page

### DIFF
--- a/doc/05-Icinga-Integration.md
+++ b/doc/05-Icinga-Integration.md
@@ -14,10 +14,13 @@ before you can execute framework related Cmdlets and functions. Otherwise you mi
 Configuring Check-Commands
 ---
 
-To get started, there are two ways to configure check command objects:
+To get started, there are three ways to configure check command objects:
 
 * [Automated Icinga Director configuration](icingaintegration/01-Director-Baskets.md) with Baskets
 * [Automated Icinga 2 configuration](icingaintegration/04-Icinga-Config.md) with plain Icinga config
 * [Manual configuration](icingaintegration/02-Manual-Integration.md) of check commands
+
+Other Topics
+---
 * [Using PowerShell Arrays in Icinga](icingaintegration/03-PowerShell-Arrays.md)
 * [Windows Terminal Integration](icingaintegration/50-Windows-Terminal.md)

--- a/doc/05-Icinga-Integration.md
+++ b/doc/05-Icinga-Integration.md
@@ -14,7 +14,7 @@ before you can execute framework related Cmdlets and functions. Otherwise you mi
 Configuring Check-Commands
 ---
 
-To get started, there are three ways to configure check command objects:
+Before you can add Services to Hosts you need to define CheckCommands.  These definitions are not provided with Icinga for Windows, but there are two automatic ways to generate these check command objects, and you can also do it manually:
 
 * [Automated Icinga Director configuration](icingaintegration/01-Director-Baskets.md) with Baskets
 * [Automated Icinga 2 configuration](icingaintegration/04-Icinga-Config.md) with plain Icinga config


### PR DESCRIPTION
The original page said "there are two ways to configure check command objects" followed by a list of 5 items.  This didn't make sense to me, I have proposed a document structure and text that seems more logical to me.