### PR TITLE
Fix: String builder creation on older windows machines

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,6 +7,17 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
+## 1.6.0 (pending)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/15?closed=1)
+
+## 1.5.1 (pending)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/17?closed=1)
+### Bugfixes
+
+* [#282](https://github.com/Icinga/icinga-powershell-framework/issues/282) Fixes issue on `System.Text.StringBuilder` which fails to initialize properly on some older Windows systems
+
 ## 1.5.0 (2021-06-02)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/13?closed=1)

--- a/lib/icinga/plugin/Compare-IcingaPluginThresholds.psm1
+++ b/lib/icinga/plugin/Compare-IcingaPluginThresholds.psm1
@@ -397,7 +397,7 @@ function Compare-IcingaPluginThresholds()
         }
     }
 
-    $PluginOutputMessage = [System.Text.StringBuilder]::New();
+    $PluginOutputMessage = New-Object -TypeName 'System.Text.StringBuilder';
 
     [string]$PluginCurrentValue = [string]::Format(
         '{0}',

--- a/lib/icinga/plugin/New-IcingaCheckPackage.psm1
+++ b/lib/icinga/plugin/New-IcingaCheckPackage.psm1
@@ -98,7 +98,7 @@ function New-IcingaCheckPackage()
         $UnknownChecks    = '';
         $CriticalChecks   = '';
         $WarningChecks    = '';
-        $CheckSummary     = [System.Text.StringBuilder]::New();
+        $CheckSummary     = New-Object -TypeName 'System.Text.StringBuilder';
         [bool]$HasContent = $FALSE;
 
         # Only apply this to the top parent package


### PR DESCRIPTION
Fixes issue on `System.Text.StringBuilder` which fails to initialize properly on some older Windows systems

Fixes #282