### PR TITLE
Fix: NULL exception on REST message

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -21,6 +21,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#282](https://github.com/Icinga/icinga-powershell-framework/issues/282) Fixes issue on `System.Text.StringBuilder` which fails to initialize properly on some older Windows systems
 * [#284](https://github.com/Icinga/icinga-powershell-framework/issues/284) Fixes exception while creating default threshold objects
 * [#285](https://github.com/Icinga/icinga-powershell-framework/issues/285) Fixes plain Icinga 2 conf generation for commands, which was caused by a new exception output for additional output
+* [#293](https://github.com/Icinga/icinga-powershell-framework/pull/293) Fixes crash on REST-Api for NULL values while parsing the REST message
 
 ## 1.5.0 (2021-06-02)
 

--- a/lib/webserver/Read-IcingaRESTMessage.psm1
+++ b/lib/webserver/Read-IcingaRESTMessage.psm1
@@ -54,10 +54,11 @@ function Read-IcingaRESTMessage()
     }
 
     # Header
-    $Request.Add( 'Header', @{} );
-    $SplitString = $RestMessage.split("`r`n");
+    $Request.Add( 'Header', @{ } );
+    $SplitString = $RestMessage.Split("`r`n");
+
     foreach ( $SingleString in $SplitString ) {
-        if ( ([string]::IsNullOrEmpty($SingleString) -eq $FALSE) -And ($SingleString -match '^{.+' -eq $FALSE) ) {
+        if ( ([string]::IsNullOrEmpty($SingleString) -eq $FALSE) -And ($SingleString -match '^{.+' -eq $FALSE) -And $SingleString.Contains(':') -eq $TRUE ) {
             $SingleSplitString = $SingleString.Split(':', 2);
             $Request.Header.Add( $SingleSplitString[0], $SingleSplitString[1].Trim());
         }
@@ -69,7 +70,10 @@ function Read-IcingaRESTMessage()
 
     # Body
     $RestMessage -match '(\{(.*\n)*}|\{.*\})' | Out-Null;
-    $Request.Add('Body', $Matches[1]);
+
+    if ($null -ne $Matches) {
+        $Request.Add('Body', $Matches[1]);
+    }
 
     # We received a content length, but couldnt load the body. Some clients will send the body as separate message
     # Lets try to read the body content


### PR DESCRIPTION
With the new REST-Api error handler, we detected a NULL exception while parsing REST message content and headers, causing issues and possibly resulting in a memory leak.