### PR TITLE
Fix: NULL exception on GetBaseThresholdArguments

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -23,6 +23,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#285](https://github.com/Icinga/icinga-powershell-framework/issues/285) Fixes plain Icinga 2 conf generation for commands, which was caused by a new exception output for additional output
 * [#293](https://github.com/Icinga/icinga-powershell-framework/pull/293) Fixes crash on REST-Api for NULL values while parsing the REST message
 * [#295](https://github.com/Icinga/icinga-powershell-framework/issues/295) Fixes background service check daemon not working with arguments for plugins
+* [#297](https://github.com/Icinga/icinga-powershell-framework/pull/297) Fixes null exception error which can occur in certain edge cases, caused by testing `New-IcingaCheck` directly without function wrapper
 
 ## 1.5.0 (2021-06-02)
 

--- a/lib/icinga/plugin/Get-IcingaThresholdCache.psm1
+++ b/lib/icinga/plugin/Get-IcingaThresholdCache.psm1
@@ -1,0 +1,24 @@
+function Get-IcingaThresholdCache()
+{
+    param (
+        [string]$CheckCommand = $null
+    );
+
+    if ([string]::IsNullOrEmpty($CheckCommand)) {
+        return $null;
+    }
+
+    if ($null -eq $Global:Icinga) {
+        return $null;
+    }
+
+    if ($Global:Icinga.ContainsKey('ThresholdCache') -eq $FALSE) {
+        return $null;
+    }
+
+    if ($Global:Icinga.ThresholdCache.ContainsKey($CheckCommand) -eq $FALSE) {
+        return $null;
+    }
+
+    return $Global:Icinga.ThresholdCache[$CheckCommand];
+}

--- a/lib/icinga/plugin/New-IcingaCheck.psm1
+++ b/lib/icinga/plugin/New-IcingaCheck.psm1
@@ -387,7 +387,7 @@ function New-IcingaCheck()
             '-BaseValue'      = $this.BaseValue;
             '-Unit'           = $this.Unit;
             '-CheckName'      = $this.__GetName();
-            '-ThresholdCache' = $Global:Icinga.ThresholdCache[$this.__CheckCommand];
+            '-ThresholdCache' = (Get-IcingaThresholdCache -CheckCommand $this.__CheckCommand);
             '-Translation'    = $this.Translation;
             '-TimeInterval'   = $this.__TimeInterval;
         };


### PR DESCRIPTION
Fixes null exception error which can occur in certain edge cases, caused by testing `New-IcingaCheck` directly without function wrapper.