### PR TITLE
Fix: Security vulnerability on Icinga for Windows service register

### DIFF
--- a/doc/10-Knowledge-Base.md
+++ b/doc/10-Knowledge-Base.md
@@ -16,3 +16,4 @@ For this reason you will find a list of Icinga knowledge base entries below. Ent
 | [IWKB000006](knowledgebase/IWKB000006.md) | The user you are running this command as does not have permission to access the Windows Update ComObject "Microsoft.Update.Session". |
 | [IWKB000007](knowledgebase/IWKB000007.md) | Icinga Director Self-Service API fails with errors. [Error]: The remote host for address "..." could not be resolved [Error]: Failed to connect to your Icinga Director at "...". Please try again. |
 | [IWKB000008](knowledgebase/IWKB000008.md) | The EventLog contains many `Perflib`, `PerfNet` and `PerfProc` errors/warnings with EventId `1008`, `2002` and `2004` |
+| [IWKB000009](knowledgebase/IWKB000009.md) | The remote Windows host has at least one service installed that uses an unquoted service path, which contains at least one whitespace. A local attacker can gain elevated privileges by inserting an executable file in the path of the affected service |

--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -11,6 +11,14 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/15?closed=1)
 
+## 1.5.2 (2021-07-09)
+
+### Security Fixes
+
+* [#298](https://github.com/Icinga/icinga-powershell-framework/issues/298) Fixes possible security vulnerability on Icinga for Windows service registration, by not quoting the service path on registration
+
+You can read more on this on the [Knowledge Base Entry](https://icinga.com/docs/icinga-for-windows/latest/doc/knowledgebase/IWKB000009/) with further details, on how to apply the fix and test if you are affected.
+
 ## 1.5.1 (2021-07-07)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/17?closed=1)
@@ -53,6 +61,14 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#265](https://github.com/Icinga/icinga-powershell-framework/pull/265) Fixes `Test-Numeric` to now accept negative numeric values and als fixes errors, causing `.` to be allowed multiple times. `ConvertFrom-TimeSpan` now properly prints on negative values if the time provided is positive or negative and also prints microseconds as `us` in case the value is loer than `1ms`
 * [#269](https://github.com/Icinga/icinga-powershell-framework/pull/269) Fixes unhandled exception on `Set-IcingaCacheData`, as the `-ErrorAction Stop` argument was not set and therefor the function never halted on errors
 * [#272](https://github.com/Icinga/icinga-powershell-framework/pull/272) Fixes invalid unit conversion, in case first char of a string is matching time metrics
+
+## 1.4.2 (2021-07-09)
+
+### Security Fixes
+
+* [#298](https://github.com/Icinga/icinga-powershell-framework/issues/298) Fixes possible security vulnerability on Icinga for Windows service registration, by not quoting the service path on registration
+
+You can read more on this on the [Knowledge Base Entry](https://icinga.com/docs/icinga-for-windows/latest/doc/knowledgebase/IWKB000009/) with further details, on how to apply the fix and test if you are affected.
 
 ## 1.4.1 (2021-03-10)
 
@@ -101,6 +117,14 @@ There are changes made to the pre-compiled configuration files and `Get-IcingaCh
 
 * [#204](https://github.com/Icinga/icinga-powershell-framework/pull/204) Adds experimental feature to forward checks executed by the Icinga Agent to an internal REST-Api, to reduce the performance impact on systems with lower resources available
 * [#213](https://github.com/Icinga/icinga-powershell-framework/pull/213) Adds new experimental feature `Management Console` for better and easier management for Icinga for Windows and improved automation and deployed.
+
+## 1.3.2 (2021-07-09)
+
+### Security Fixes
+
+* [#298](https://github.com/Icinga/icinga-powershell-framework/issues/298) Fixes possible security vulnerability on Icinga for Windows service registration, by not quoting the service path on registration
+
+You can read more on this on the [Knowledge Base Entry](https://icinga.com/docs/icinga-for-windows/latest/doc/knowledgebase/IWKB000009/) with further details, on how to apply the fix and test if you are affected.
 
 ## 1.3.1 (2021-02-04)
 

--- a/doc/knowledgebase/IWKB000009.md
+++ b/doc/knowledgebase/IWKB000009.md
@@ -1,0 +1,58 @@
+# Icinga Knowledge Base - IWKB000009
+
+## Short Message
+
+Security Scanner: The remote Windows host has at least one service installed that uses an unquoted service path, which contains at least one whitespace. A local attacker can gain elevated privileges by inserting an executable file in the path of the affected service
+
+## Reason
+
+The path pointing to the `icinga-service.exe` is not encapsulated inside double quotes `"` during creation. This might open a possible vulnerability and provide a possible attack vector for attackers gaining access to the machine. In worst case, attackers can place a binary file on the location of the path where the whitespace stops. This binary is then executed with the privileges the service is running with, which could cause a security issue.
+
+You can read this [blogpost](http://www.ryanandjeffshow.com/blog/2013/04/05/the-microsoft-windows-unquoted-service-path-vulnerability/) by Jeff Liford to get a better idea on the problem.
+
+## Solution
+
+This is directly fixed within Icinga for Windows v1.3.2, 1.4.2, v1.5.2 and 1.6.0 during the service creation. If you created the service starting with one of these versions, you are not affected.
+
+If not, please update your environment to a version which includes the fix and start a new PowerShell. Afterwards use this code snippet to re-create the service with all your configuration:
+
+```powershell
+Use-Icinga;
+$IcingaService = Get-CimInstance Win32_Service `
+    | Where-Object {
+            $_.Name -eq 'icingapowershell'
+        } `
+    | Select-Object Name, StartName, PathName;
+
+if ($null -ne $IcingaService) {
+    $IfWUser = $IcingaService.StartName;
+    $IfWPath = $IcingaService.PathName.SubString(0, $IcingaService.PathName.IndexOf(' "'));
+
+    if ($IfWPath[0] -eq '"' -And $IfWPath[-1] -eq '"') {
+        return;
+    }
+
+    Uninstall-IcingaFrameworkService;
+    Install-IcingaFrameworkService -Path $IfWPath -User $IfWUser;
+}
+```
+
+## Test Vulnerability
+
+If you want to test if the above fix work or if you are affected by this problem, you can run this script:
+
+```powershell
+$IcingaService = Get-CimInstance Win32_Service `
+    | Where-Object {
+            $_.Name -eq 'icingapowershell'
+        } `
+    | Select-Object Name, StartName, PathName;
+
+$IfWPath = $IcingaService.PathName.SubString(0, $IcingaService.PathName.IndexOf(' "'));
+
+if ($IfWPath.Contains('"')) {
+    Write-Host -ForegroundColor Green 'Your service installation is secure';
+} else {
+    Write-Host -ForegroundColor Red 'You are possibly affected by a whitespace service vulnerability';
+}
+```

--- a/lib/core/framework/Install-IcingaFrameworkService.psm1
+++ b/lib/core/framework/Install-IcingaFrameworkService.psm1
@@ -61,7 +61,7 @@ function Install-IcingaFrameworkService()
     }
 
     $Path = [string]::Format(
-        '{0} \"{1}\"',
+        '\"{0}\" \"{1}\"',
         $Path,
         (Get-IcingaPowerShellModuleFile)
     );


### PR DESCRIPTION
Fixes possible security vulnerability on Icinga for Windows service registration, by not quoting the service path on registration.

You can read more on this on the [Knowledge Base Entry](https://icinga.com/docs/icinga-for-windows/latest/doc/knowledgebase/IWKB000009/) with further details, on how to apply the fix and test if you are affected.

Fixes #298