### PR TITLE
Feature: Adds array thresholds and date time support

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,7 +7,7 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
-## 1.6.0 (pending)
+## 1.6.0 (2021-09-07)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/15?closed=1)
 
@@ -19,6 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Enhancements
 
 * [#301](https://github.com/Icinga/icinga-powershell-framework/pull/301) Improves error handling to no longer print passwords in case `String` is used for `SecureString` arguments
+* [#303](https://github.com/Icinga/icinga-powershell-framework/pull/303) Adds support to parse arrays to Icinga Check thresholds functions like `WarnOutOfRange` and adds two new functions `WarnDateTime` and `CritDateTime`, for easier comparing of time stamps.
 * [#305](https://github.com/Icinga/icinga-powershell-framework/pull/305) Adds a new Cmdlet to test if functions with `Add-Type` are already present inside the current scope of the shell
 * [#306](https://github.com/Icinga/icinga-powershell-framework/pull/306) Adds new Cmdlet `Exit-IcingaThrowCritical` to throw critical exit with a custom message, either by force or by using string filtering and adds storing of plugin exit codes internally
 * [#314](https://github.com/Icinga/icinga-powershell-framework/pull/314) Adds support to configure on which address TCP sockets are created on, defaults to `loopback` interface

--- a/lib/core/tools/Convert-IcingaPluginThresholds.psm1
+++ b/lib/core/tools/Convert-IcingaPluginThresholds.psm1
@@ -92,6 +92,20 @@ function Convert-IcingaPluginThresholds()
     [array]$Content    = @();
 
     if ($Threshold.Contains(':')) {
+        # If we have more than one ':' inside our string, lets check if this is a date time value
+        # In case it is convert it properly to a FileTime we can work with later on
+        if ([Regex]::Matches($Threshold, ":").Count -gt 1) {
+            try {
+                $DateTimeValue  = [DateTime]::ParseExact($Threshold, 'yyyy\/MM\/dd HH:mm:ss', $null);
+                $RetValue.Value = $DateTimeValue.ToFileTime();
+                $RetValue.Unit  = 's';
+            } catch {
+                $RetValue.Value = $Threshold;
+            }
+
+            return $RetValue;
+        }
+
         $Content = $Threshold.Split(':');
     } else {
         $Content += $Threshold;

--- a/lib/icinga/plugin/New-IcingaCheck.psm1
+++ b/lib/icinga/plugin/New-IcingaCheck.psm1
@@ -267,6 +267,23 @@ function New-IcingaCheck()
         }
     }
 
+    $IcingaCheck | Add-Member -MemberType ScriptMethod -Name '__SetCurrentExecutionTime' -Value {
+        if ($null -eq $global:Icinga) {
+            $global:Icinga = @{ };
+        }
+
+        if ($global:Icinga.ContainsKey('CurrentDate') -eq $FALSE) {
+            $global:Icinga.Add('CurrentDate', (Get-Date));
+            return;
+        }
+
+        if ($null -ne $global:Icinga.CurrentDate) {
+            return;
+        }
+
+        $global:Icinga.CurrentDate = (Get-Date).ToUniversalTime();
+    }
+
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name '__AddCheckDataToCache' -Value {
 
         # We only require this in case we are running as daemon
@@ -396,6 +413,19 @@ function New-IcingaCheck()
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'WarnOutOfRange' -Value {
         param ($Threshold);
 
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.WarnOutOfRange($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
+
         [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
         $ThresholdArguments.Add('-Threshold', $Threshold);
 
@@ -407,8 +437,49 @@ function New-IcingaCheck()
         return $this;
     }
 
+    $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'WarnDateTime' -Value {
+        param ($Threshold);
+
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.WarnDateTime($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
+
+        [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
+        $ThresholdArguments.Add('-Threshold', $Threshold);
+        $ThresholdArguments.Add('-DateTime', $TRUE);
+
+        $ThresholdObject = Compare-IcingaPluginThresholds @ThresholdArguments;
+
+        $this.__WarningValue = $ThresholdObject;
+        $this.__SetCheckState($ThresholdObject, $IcingaEnums.IcingaExitCode.Warning);
+
+        return $this;
+    }
+
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'WarnIfLike' -Value {
         param ($Threshold);
+
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.WarnIfLike($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
 
         [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
         $ThresholdArguments.Add('-Threshold', $Threshold);
@@ -424,6 +495,19 @@ function New-IcingaCheck()
 
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'WarnIfNotLike' -Value {
         param ($Threshold);
+
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.WarnIfNotLike($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
 
         [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
         $ThresholdArguments.Add('-Threshold', $Threshold);
@@ -452,6 +536,19 @@ function New-IcingaCheck()
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'CritOutOfRange' -Value {
         param ($Threshold);
 
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.CritOutOfRange($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
+
         [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
         $ThresholdArguments.Add('-Threshold', $Threshold);
 
@@ -463,8 +560,49 @@ function New-IcingaCheck()
         return $this;
     }
 
+    $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'CritDateTime' -Value {
+        param ($Threshold);
+
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.CritDateTime($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
+
+        [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
+        $ThresholdArguments.Add('-Threshold', $Threshold);
+        $ThresholdArguments.Add('-DateTime', $TRUE);
+
+        $ThresholdObject = Compare-IcingaPluginThresholds @ThresholdArguments;
+
+        $this.__CriticalValue = $ThresholdObject;
+        $this.__SetCheckState($ThresholdObject, $IcingaEnums.IcingaExitCode.Critical);
+
+        return $this;
+    }
+
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'CritIfLike' -Value {
         param ($Threshold);
+
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.CritIfLike($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
 
         [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
         $ThresholdArguments.Add('-Threshold', $Threshold);
@@ -480,6 +618,19 @@ function New-IcingaCheck()
 
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'CritIfNotLike' -Value {
         param ($Threshold);
+
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.CritIfNotLike($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
 
         [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
         $ThresholdArguments.Add('-Threshold', $Threshold);
@@ -524,6 +675,19 @@ function New-IcingaCheck()
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'WarnIfLowerThan' -Value {
         param ($Value);
 
+        if ($null -ne $Value -And $Value.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Value) {
+                $this.WarnIfLowerThan($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
+
         [string]$Threshold = [string]::Format('{0}:', $Value);
 
         return $this.WarnOutOfRange($Threshold);
@@ -531,6 +695,19 @@ function New-IcingaCheck()
 
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'CritIfLowerThan' -Value {
         param ($Value);
+
+        if ($null -ne $Value -And $Value.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Value) {
+                $this.CritIfLowerThan($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
 
         [string]$Threshold = [string]::Format('{0}:', $Value);
 
@@ -540,6 +717,19 @@ function New-IcingaCheck()
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'WarnIfGreaterThan' -Value {
         param ($Value);
 
+        if ($null -ne $Value -And $Value.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Value) {
+                $this.WarnIfGreaterThan($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
+
         [string]$Threshold = [string]::Format('~:{0}', $Value);
 
         return $this.WarnOutOfRange($Threshold);
@@ -547,6 +737,19 @@ function New-IcingaCheck()
 
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'CritIfGreaterThan' -Value {
         param ($Value);
+
+        if ($null -ne $Value -And $Value.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Value) {
+                $this.CritIfGreaterThan($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
 
         [string]$Threshold = [string]::Format('~:{0}', $Value);
 
@@ -588,6 +791,19 @@ function New-IcingaCheck()
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'WarnIfLowerEqualThan' -Value {
         param ($Threshold);
 
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.WarnIfLowerEqualThan($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
+
         [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
         $ThresholdArguments.Add('-Threshold', $Threshold);
         $ThresholdArguments.Add('-IsLowerEqual', $TRUE);
@@ -602,6 +818,19 @@ function New-IcingaCheck()
 
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'CritIfLowerEqualThan' -Value {
         param ($Threshold);
+
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.CritIfLowerEqualThan($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
 
         [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
         $ThresholdArguments.Add('-Threshold', $Threshold);
@@ -618,6 +847,19 @@ function New-IcingaCheck()
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'WarnIfGreaterEqualThan' -Value {
         param ($Threshold);
 
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.WarnIfGreaterEqualThan($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
+
         [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
         $ThresholdArguments.Add('-Threshold', $Threshold);
         $ThresholdArguments.Add('-IsGreaterEqual', $TRUE);
@@ -632,6 +874,19 @@ function New-IcingaCheck()
 
     $IcingaCheck | Add-Member -MemberType ScriptMethod -Name 'CritIfGreaterEqualThan' -Value {
         param ($Threshold);
+
+        if ($null -ne $Threshold -And $Threshold.GetType().BaseType.Name.ToLower() -eq 'array') {
+            foreach ($entry in $Threshold) {
+                $this.CritIfGreaterEqualThan($entry) | Out-Null;
+
+                # Break on first value causing a warning
+                if ($ThresholdObject.InRange -eq $FALSE) {
+                    break;
+                }
+            }
+
+            return $this;
+        }
 
         [hashtable]$ThresholdArguments = $this.__GetBaseThresholdArguments();
         $ThresholdArguments.Add('-Threshold', $Threshold);
@@ -686,6 +941,7 @@ function New-IcingaCheck()
 
     $IcingaCheck.__ValidateObject();
     $IcingaCheck.__ValidateUnit();
+    $IcingaCheck.__SetCurrentExecutionTime();
     $IcingaCheck.__AddCheckDataToCache();
     $IcingaCheck.__SetInternalTimeInterval();
     $IcingaCheck.__ConvertMinMax();

--- a/lib/icinga/plugin/New-IcingaCheckResult.psm1
+++ b/lib/icinga/plugin/New-IcingaCheckResult.psm1
@@ -26,6 +26,8 @@ function New-IcingaCheckResult()
 
         # Ensure we reset our internal cache once the plugin was executed
         $Global:Icinga.ThresholdCache[$this.Check.__GetCheckCommand()] = $null;
+        # Reset the current execution date
+        $Global:Icinga.CurrentDate                                     = $null;
 
         $ExitCode = $this.Check.__GetCheckState();
 


### PR DESCRIPTION
Adds support to parse arrays to Icinga Check thresholds functions like `WarnOutOfRange` and adds two new functions `WarnDateTime` and `CritDateTime`, for easier comparing of time stamps.

Required for new `Invoke-IcingaCheckScheduledTask` features requested on [Plugin Feature Reqest #208](https://github.com/Icinga/icinga-powershell-plugins/issues/208)