### PR TITLE
Feature: Adds critical exception cmdlet and exit code catch

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -12,6 +12,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/15?closed=1)
 
 * [#305](https://github.com/Icinga/icinga-powershell-framework/pull/305) Adds a new Cmdlet to test if functions with `Add-Type` are already present inside the current scope of the shell
+* [#306](https://github.com/Icinga/icinga-powershell-framework/pull/306) Adds new Cmdlet `Exit-IcingaThrowCritical` to throw critical exit with a custom message, either by force or by using string filtering and adds storing of plugin exit codes internally
 
 ## 1.5.2 (2021-07-09)
 

--- a/lib/icinga/exception/Exit-IcingaThrowCritical.psm1
+++ b/lib/icinga/exception/Exit-IcingaThrowCritical.psm1
@@ -1,0 +1,32 @@
+function Exit-IcingaThrowCritical()
+{
+    param (
+        [string]$Message      = '',
+        [string]$FilterString = $null,
+        [string]$SearchString = $null,
+        [switch]$Force        = $FALSE
+    );
+
+    if ($Force -eq $FALSE) {
+        if ([string]::IsNullOrEmpty($FilterString) -Or [string]::IsNullOrEmpty($SearchString)) {
+            return;
+        }
+
+        if ($FilterString -NotLike "*$SearchString*") {
+            return;
+        }
+    }
+
+    [string]$OutputMessage = [string]::Format(
+        '[CRITICAL] {0}',
+        $Message
+    );
+
+    Set-IcingaInternalPluginExitCode -ExitCode $IcingaEnums.IcingaExitCode.Critical;
+    Set-IcingaInternalPluginException -PluginException $OutputMessage;
+
+    if ($null -eq $global:IcingaDaemonData -Or $global:IcingaDaemonData.FrameworkRunningAsDaemon -eq $FALSE) {
+        Write-IcingaConsolePlain $OutputMessage;
+        exit $IcingaEnums.IcingaExitCode.Critical;
+    }
+}

--- a/lib/icinga/exception/Exit-IcingaThrowException.psm1
+++ b/lib/icinga/exception/Exit-IcingaThrowException.psm1
@@ -107,6 +107,9 @@ function Exit-IcingaThrowException()
         $ExceptionTypeString
     );
 
+    Set-IcingaInternalPluginExitCode -ExitCode $IcingaEnums.IcingaExitCode.Unknown;
+    Set-IcingaInternalPluginException -PluginException $OutputMessage;
+
     if ($null -eq $global:IcingaDaemonData -Or $global:IcingaDaemonData.FrameworkRunningAsDaemon -eq $FALSE) {
         Write-IcingaConsolePlain $OutputMessage;
         exit $IcingaEnums.IcingaExitCode.Unknown;

--- a/lib/icinga/plugin/New-IcingaCheckResult.psm1
+++ b/lib/icinga/plugin/New-IcingaCheckResult.psm1
@@ -27,7 +27,11 @@ function New-IcingaCheckResult()
         # Ensure we reset our internal cache once the plugin was executed
         $Global:Icinga.ThresholdCache[$this.Check.__GetCheckCommand()] = $null;
 
-        return $this.Check.__GetCheckState();
+        $ExitCode = $this.Check.__GetCheckState();
+
+        Set-IcingaInternalPluginExitCode -ExitCode $ExitCode;
+
+        return $ExitCode;
     }
 
     if ($Compile) {

--- a/lib/icinga/plugin/Set-IcingaInternalPluginException.psm1
+++ b/lib/icinga/plugin/Set-IcingaInternalPluginException.psm1
@@ -1,0 +1,29 @@
+function Set-IcingaInternalPluginException()
+{
+    param (
+        [string]$PluginException = ''
+    );
+
+    if ($null -eq $Global:Icinga) {
+        $Global:Icinga = @{ };
+    }
+
+    if ($Global:Icinga.ContainsKey('PluginExecution') -eq $FALSE) {
+        $Global:Icinga.Add(
+            'PluginExecution',
+            @{
+                'PluginException' = $PluginException;
+            }
+        )
+    } else {
+        if ($Global:Icinga.PluginExecution.ContainsKey('PluginException') -eq $FALSE) {
+            $Global:Icinga.PluginExecution.Add('PluginException', $PluginException);
+            return;
+        }
+
+        # Only catch the first exception
+        if ([string]::IsNullOrEmpty($Global:Icinga.PluginExecution.PluginException)) {
+            $Global:Icinga.PluginExecution.PluginException = $PluginException;
+        }
+    }
+}

--- a/lib/icinga/plugin/Set-IcingaInternalPluginExitCode.psm1
+++ b/lib/icinga/plugin/Set-IcingaInternalPluginExitCode.psm1
@@ -1,0 +1,29 @@
+function Set-IcingaInternalPluginExitCode()
+{
+    param (
+        $ExitCode = 0
+    );
+
+    if ($null -eq $Global:Icinga) {
+        $Global:Icinga = @{ };
+    }
+
+    if ($Global:Icinga.ContainsKey('PluginExecution') -eq $FALSE) {
+        $Global:Icinga.Add(
+            'PluginExecution',
+            @{
+                'LastExitCode' = $ExitCode;
+            }
+        )
+    } else {
+        if ($Global:Icinga.PluginExecution.ContainsKey('LastExitCode') -eq $FALSE) {
+            $Global:Icinga.PluginExecution.Add('LastExitCode', $ExitCode);
+            return;
+        }
+
+        # Only add the first exit code we should cover during one runtime
+        if ($null -eq $Global:Icinga.PluginExecution.LastExitCode) {
+            $Global:Icinga.PluginExecution.LastExitCode = $ExitCode;
+        }
+    }
+}


### PR DESCRIPTION
Adds new Cmdlet `Exit-IcingaThrowCritical` to throw critical exit with a custom message, either by force or by using string filtering and adds storing of plugin exit codes internally.