### PR TITLE
Feature: Removes password on Secure.String exceptions

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -11,6 +11,9 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/15?closed=1)
 
+## Enhancements
+
+* [#301](https://github.com/Icinga/icinga-powershell-framework/pull/301) Improves error handling to no longer print passwords in case `String` is used for `SecureString` arguments
 * [#305](https://github.com/Icinga/icinga-powershell-framework/pull/305) Adds a new Cmdlet to test if functions with `Add-Type` are already present inside the current scope of the shell
 * [#306](https://github.com/Icinga/icinga-powershell-framework/pull/306) Adds new Cmdlet `Exit-IcingaThrowCritical` to throw critical exit with a custom message, either by force or by using string filtering and adds storing of plugin exit codes internally
 

--- a/lib/icinga/plugin/Exit-IcingaExecutePlugin.psm1
+++ b/lib/icinga/plugin/Exit-IcingaExecutePlugin.psm1
@@ -18,8 +18,21 @@ function Exit-IcingaExecutePlugin()
     } catch {
         $ExMsg      = $_.Exception.Message;
         $StackTrace = $_.ScriptStackTrace;
+        $ExErrorId  = $_.FullyQualifiedErrorId;
+        $ArgName    = $_.Exception.ParameterName;
+        $ListArgs   = $args;
 
-        Write-IcingaConsolePlain '[UNKNOWN] Icinga Exception: {0}{1}{1}CheckCommand: {2}{1}Arguments: {3}{1}{1}StackTrace:{1}{4}' -Objects $ExMsg, (New-IcingaNewLine), $Command, $args, $StackTrace;
+        if ($ExErrorId -Like "*ParameterArgumentTransformationError*" -And $ExMsg.Contains('System.Security.SecureString')) {
+            $ExMsg = [string]::Format(
+                'Cannot bind parameter {0}. Cannot convert the provided value for argument "{0}" of type "System.String" to type "System.Security.SecureString".',
+                $ArgName
+            );
+
+            $args.Clear();
+            $ListArgs = 'Hidden for security reasons';
+        }
+
+        Write-IcingaConsolePlain '[UNKNOWN] Icinga Exception: {0}{1}{1}CheckCommand: {2}{1}Arguments: {3}{1}{1}StackTrace:{1}{4}' -Objects $ExMsg, (New-IcingaNewLine), $Command, $ListArgs, $StackTrace;
         exit 3;
     }
 }


### PR DESCRIPTION
Improves error handling in case of exceptions, which will now remove the arguments and content for passwords, in case `String` is tried to be used for `SecureString` arguments.

Fixes #301