### PR TITLE
Feature: Adds support to set listen ip, defaults to localhost

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -20,6 +20,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#301](https://github.com/Icinga/icinga-powershell-framework/pull/301) Improves error handling to no longer print passwords in case `String` is used for `SecureString` arguments
 * [#305](https://github.com/Icinga/icinga-powershell-framework/pull/305) Adds a new Cmdlet to test if functions with `Add-Type` are already present inside the current scope of the shell
 * [#306](https://github.com/Icinga/icinga-powershell-framework/pull/306) Adds new Cmdlet `Exit-IcingaThrowCritical` to throw critical exit with a custom message, either by force or by using string filtering and adds storing of plugin exit codes internally
+* [#314](https://github.com/Icinga/icinga-powershell-framework/pull/314) Adds support to configure on which address TCP sockets are created on, defaults to `loopback` interface
 
 ## 1.5.2 (2021-07-09)
 

--- a/lib/webserver/New-IcingaTCPSocket.psm1
+++ b/lib/webserver/New-IcingaTCPSocket.psm1
@@ -1,15 +1,23 @@
 function New-IcingaTCPSocket()
 {
-    param(
-        [int]$Port     = 0,
-        [switch]$Start = $FALSE
+    param (
+        [string]$Address = '',
+        [int]$Port       = 0,
+        [switch]$Start   = $FALSE
     );
 
     if ($Port -eq 0) {
         throw 'Please specify a valid port to open a TCP socket for';
     }
 
-    $TCPSocket = [System.Net.Sockets.TcpListener]$Port;
+    # Listen on localhost by default
+    $ListenAddress = New-Object System.Net.IPEndPoint([IPAddress]::Loopback, $Port);
+
+    if ([string]::IsNullOrEmpty($Address) -eq $FALSE) {
+        $ListenAddress = New-Object System.Net.IPEndPoint([IPAddress]::Parse($Address), $Port);
+    }
+
+    $TCPSocket = New-Object 'System.Net.Sockets.TcpListener' $ListenAddress;
 
     Write-IcingaDebugMessage -Message (
         [string]::Format(


### PR DESCRIPTION
We should ensure the local socket creation always defaults to the loopback interface, while making it configurable on which IP it listens.