### PR TITLE
Feature: Relocating reconfigure menu entry

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -21,6 +21,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#305](https://github.com/Icinga/icinga-powershell-framework/pull/305) Adds a new Cmdlet to test if functions with `Add-Type` are already present inside the current scope of the shell
 * [#306](https://github.com/Icinga/icinga-powershell-framework/pull/306) Adds new Cmdlet `Exit-IcingaThrowCritical` to throw critical exit with a custom message, either by force or by using string filtering and adds storing of plugin exit codes internally
 * [#314](https://github.com/Icinga/icinga-powershell-framework/pull/314) Adds support to configure on which address TCP sockets are created on, defaults to `loopback` interface
+* [#316](https://github.com/Icinga/icinga-powershell-framework/pull/316) The reconfigure menu was previously present inside the Icinga Agent sub-menu and is now moved to the main installation menu for the Management Console
 
 ## 1.5.2 (2021-07-09)
 

--- a/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerMenuInstallWindows.psm1
+++ b/lib/core/installer/menu/installation/general/Show-IcingaForWindowsInstallerMenuInstallWindows.psm1
@@ -8,7 +8,7 @@ function Show-IcingaForWindowsInstallerMenuInstallWindows()
         [switch]$Advanced      = $FALSE
     );
 
-    if ($null -eq (Get-IcingaPowerShellConfig -Path 'Framework.Config.Swap')) {
+    if ($null -eq (Get-IcingaPowerShellConfig -Path 'Framework.Config.Swap') -And $null -eq (Get-IcingaPowerShellConfig -Path 'Framework.Config.Live')) {
         Show-IcingaForWindowsInstallerMenuSelectConnection;
         return;
     }
@@ -22,9 +22,16 @@ function Show-IcingaForWindowsInstallerMenuInstallWindows()
                 'Help'    = 'Start a new configuration and truncate all information stored on the current swap file. This will only modify your production if you hit "Start installation" at the end';
             },
             @{
-                'Caption' = 'Continue configuration';
-                'Command' = 'Show-IcingaForWindowsInstallerMenuContinueConfiguration';
-                'Help'    = 'Continue with the previous configuration swap file.';
+                'Caption'  = 'Continue configuration';
+                'Command'  = 'Show-IcingaForWindowsInstallerMenuContinueConfiguration';
+                'Help'     = 'Continue with the previous configuration swap file.';
+                'Disabled' = ([bool]($null -eq (Get-IcingaPowerShellConfig -Path 'Framework.Config.Swap')));
+            },
+            @{
+                'Caption'  = 'Reconfigure Environment';
+                'Command'  = 'Invoke-IcingaForWindowsManagementConsoleReconfigureAgent';
+                'Help'     = 'Load the current configuration of Icinga for Windows to modify it.';
+                'Disabled' = ([bool]($null -eq (Get-IcingaPowerShellConfig -Path 'Framework.Config.Live')));
             }
         ) `
         -DefaultIndex $DefaultInput `

--- a/lib/core/installer/menu/manage/agent/Show-IcingaForWindowsMenuManageIcingaAgent.psm1
+++ b/lib/core/installer/menu/manage/agent/Show-IcingaForWindowsMenuManageIcingaAgent.psm1
@@ -18,12 +18,6 @@ function Show-IcingaForWindowsMenuManageIcingaAgent()
                 'Disabled' = ($null -eq $IcingaService -Or (-Not $AdminShell));
             },
             @{
-                'Caption'  = 'Reconfigure Installation';
-                'Command'  = 'Invoke-IcingaForWindowsManagementConsoleReconfigureAgent';
-                'Help'     = 'Load the current applied configuration for your Icinga Agent and modify the values';
-                'Disabled' = ($null -eq (Get-IcingaPowerShellConfig -Path 'Framework.Config.Live'));
-            },
-            @{
                 'Caption'  = 'Read Icinga Agent Log File';
                 'Command'  = 'Show-IcingaForWindowsMenuManageIcingaAgent';
                 'Help'     = 'Allows to read the Icinga Agent log file in case the "mainlog" feature of the Icinga Agent is enabled';


### PR DESCRIPTION
The reconfigure menu was previously present inside the Icinga Agent sub-menu and is now moved to the main installation menu.

The reason was that in case Agent installation failed, no re-configuration was possible because the entry is locked for the Agent not being present.