### PR TITLE
Deprecated: Remove legacy import feature from files

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -24,6 +24,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#314](https://github.com/Icinga/icinga-powershell-framework/pull/314) Adds support to configure on which address TCP sockets are created on, defaults to `loopback` interface
 * [#316](https://github.com/Icinga/icinga-powershell-framework/pull/316) The reconfigure menu was previously present inside the Icinga Agent sub-menu and is now moved to the main installation menu for the Management Console
 * [#318](https://github.com/Icinga/icinga-powershell-framework/pull/318) We always enforce the Icinga Framework Code caching now and ship a plain file to build the cache on first loading
+* [#322](https://github.com/Icinga/icinga-powershell-framework/pull/322) Remove legacy import feature from Framework and replace it with a dummy function, as no longer required by Icinga for Windows
 
 ## 1.5.2 (2021-07-09)
 

--- a/lib/core/tools/ConvertFrom-TimeSpan.psm1
+++ b/lib/core/tools/ConvertFrom-TimeSpan.psm1
@@ -1,5 +1,3 @@
-Import-IcingaLib core\tools;
-
 function ConvertFrom-TimeSpan()
 {
     param (

--- a/lib/core/tools/ConvertTo-Seconds.psm1
+++ b/lib/core/tools/ConvertTo-Seconds.psm1
@@ -1,5 +1,3 @@
-Import-IcingaLib core\tools;
-
 <#
 .SYNOPSIS
    Converts unit to seconds.

--- a/lib/core/tools/New-IcingaCheckCommand.psm1
+++ b/lib/core/tools/New-IcingaCheckCommand.psm1
@@ -7,8 +7,7 @@ function New-IcingaCheckCommand()
             'Critical',
             '[switch]NoPerfData',
             '[int]Verbose'
-        ),
-        [array]$ImportLib    = @()
+        )
     );
 
     if ([string]::IsNullOrEmpty($Name) -eq $TRUE) {
@@ -48,12 +47,6 @@ function New-IcingaCheckCommand()
     }
 
     New-Item -Path $ModuleFolder -ItemType Directory | Out-Null;
-
-    Add-Content -Path $ScriptFile -Value 'Import-IcingaLib icinga\plugin;';
-
-    foreach ($Library in $ImportLib) {
-        Add-Content -Path $ScriptFile -Value "Import-IcingaLib $Library;";
-    }
 
     Add-Content -Path $ScriptFile -Value '';
     Add-Content -Path $ScriptFile -Value "function $CommandName()";

--- a/lib/help/help/Get-IcingaHelpThresholds.psm1
+++ b/lib/help/help/Get-IcingaHelpThresholds.psm1
@@ -1,5 +1,3 @@
-Import-IcingaLib icinga\plugin;
-
 function Get-IcingaHelpThresholds()
 {
     param (


### PR DESCRIPTION
In the past we used different ways to import certain information into Icinga for Windows. With the new version, we can get rid of most of the handling and reduce CPU impact in this matter.