### PR TITLE
Fix: MSI package reader not working on Windows 2012 R2

### DIFF
--- a/lib/core/repository/Read-IcingaMSIMetadata.psm1
+++ b/lib/core/repository/Read-IcingaMSIMetadata.psm1
@@ -25,21 +25,25 @@ function Read-IcingaMSIMetadata()
 
     try {
         $InstallerInstance = New-Object -ComObject 'WindowsInstaller.Installer';
-        $MSIPackage = $InstallerInstance.OpenDatabase($File, 0);
+        #$MSIPackage       = $InstallerInstance.OpenDatabase($File, 0); # Not Working on Windows 2012 R2
+        $MSIPackage        = $InstallerInstance.GetType().InvokeMember('OpenDatabase', 'InvokeMethod', $Null, $InstallerInstance, @($File, 0));
 
         foreach ($PackageInfo in $MSIObjects) {
             $MSIQuery = [string]::Format(
                 "SELECT `Value` FROM `Property` WHERE `Property` = '{0}'",
                 $PackageInfo
             );
-            $MSIDb     = $MSIPackage.OpenView($MSIQuery);
+            #$MSIDb     = $MSIPackage.OpenView($MSIQuery); # Not Working on Windows 2012 R2
+            $MSIDb      = $MSIPackage.GetType().InvokeMember('OpenView', 'InvokeMethod', $Null, $MSIPackage, $MSIQuery);
 
             if ($null -eq $MSIDb) {
                 continue;
             }
 
-            $MSIDb.Execute();
-            $MSITable = $MSIDb.Fetch();
+            #$MSIDb.Execute(); # Not Working on Windows 2012 R2
+            $MSIDb.GetType().InvokeMember('Execute', 'InvokeMethod', $Null, $MSIDb, $Null);
+            #$MSITable = $MSIDb.Fetch(); # Not Working on Windows 2012 R2
+            $MSITable  = $MSIDb.GetType().InvokeMember('Fetch' , 'InvokeMethod', $Null, $MSIDb, $Null);
 
             if ($null -eq $MSITable) {
                 continue;
@@ -47,13 +51,16 @@ function Read-IcingaMSIMetadata()
 
             $MSIPackageData[$PackageInfo] = $MSITable.GetType().InvokeMember('StringData', 'GetProperty', $null, $MSITable, 1);
 
-            $MSIDb.Close();
-            $MSIPackage.Commit();
+            #$MSIDb.Close(); # Not Working on Windows 2012 R2
+            $MSIDb.GetType().InvokeMember('Close', 'InvokeMethod', $null, $MSIDb, $null);
+            [void]([System.Runtime.InteropServices.Marshal]::ReleaseComObject($MSIDb));
+            $MSIDb = $null;
         }
 
-        $MSIPackage.Commit();
-        $MSIPackage = $null;
+        [void]([System.Runtime.InteropServices.Marshal]::ReleaseComObject($MSIPackage));
         [void]([System.Runtime.InteropServices.Marshal]::ReleaseComObject($InstallerInstance));
+        $MSIPackage        = $null;
+        $InstallerInstance = $null;
 
         if ($AgentFile.Name.Contains('x86_64')) {
             $MSIPackageData.Add('Architecture', 'x64')


### PR DESCRIPTION
On Windows 2012 R2, the current implementation for `Read-IcingaMSIMetadata` is not working, as we require to do it on a more complicated way.