### PR TITLE
Fix: Installer should always overwrite values in automation mode

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -17,6 +17,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#317](https://github.com/Icinga/icinga-powershell-framework/pull/317) Fixes certain file names being too long, causing errors on deploying branches
 * [#326](https://github.com/Icinga/icinga-powershell-framework/pull/326) Fixes import for module files, by using the full path to the module now instead of the name only, as files could be placed inside a folder which is not listed inside the `$ENV:PSModulePath`
 * [#327](https://github.com/Icinga/icinga-powershell-framework/pull/327) Fixes possible exception on first import run for certain systems
+* [#328](https://github.com/Icinga/icinga-powershell-framework/pull/328) Fixes installer while using installation files or the installation command, which did not overwrite default values with custom values
 
 ### Enhancements
 

--- a/lib/core/installer/tools/ShowInstallerMenu.psm1
+++ b/lib/core/installer/tools/ShowInstallerMenu.psm1
@@ -64,7 +64,7 @@ function Show-IcingaForWindowsInstallerMenu()
         $SelectionForCurrentMenu = $null;
     }
 
-    if ($StoredValues.Count -eq 0 -And $DefaultValues.Count -ne 0) {
+    if (($StoredValues.Count -eq 0 -And $DefaultValues.Count -ne 0) -Or $Automated) {
         $StoredValues = $DefaultValues;
     }
 


### PR DESCRIPTION
The installer is not overwriting pre-defined values, in case we run in automation mode. This causes default values being used over custom defined values while using the installation file or the intallation command