### PR TITLE
Fix: Remove-ItemSecure is not using all args and might fail on empty path

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#326](https://github.com/Icinga/icinga-powershell-framework/pull/326) Fixes import for module files, by using the full path to the module now instead of the name only, as files could be placed inside a folder which is not listed inside the `$ENV:PSModulePath`
 * [#327](https://github.com/Icinga/icinga-powershell-framework/pull/327) Fixes possible exception on first import run for certain systems
 * [#328](https://github.com/Icinga/icinga-powershell-framework/pull/328) Fixes installer while using installation files or the installation command, which did not overwrite default values with custom values
+* [#330](https://github.com/Icinga/icinga-powershell-framework/pull/330) Fixes `Remove-ItemSecure` which was not using all args and might fail on empty path entries
 
 ### Enhancements
 

--- a/lib/core/framework/Remove-ItemSecure.psm1
+++ b/lib/core/framework/Remove-ItemSecure.psm1
@@ -31,27 +31,21 @@ function Remove-ItemSecure()
 {
     param(
         [string]$Path,
-        [switch]$Recurse,
-        [switch]$Force
+        [switch]$Recurse = $FALSE,
+        [switch]$Force   = $FALSE
     )
 
-    if ((Test-Path $Path) -eq $FALSE) {
+    if ([string]::IsNullOrEmpty($Path) -Or (Test-Path $Path) -eq $FALSE) {
+        Write-IcingaConsoleError 'The provided path "{0}" does not exist' -Objects $Path;
         return $FALSE;
     }
 
     try {
-        if ($Recurse -And $Force) {
-            Remove-Item -Path $Path -Recurse -Force;
-        } elseif ($Recurse -And -Not $Force) {
-            Remove-Item -Path $Path -Recurse;
-        } elseif (-Not $Recurse -And $Force) {
-            Remove-Item -Path $Path -Force;
-        } else {
-            Remove-Item -Path $Path;
-        }
+        Remove-Item -Path $Path -Recurse:$Recurse -Force:$Force -ErrorAction Stop;
         return $TRUE;
     } catch {
-        Write-IcingaConsoleError ([string]::Format('Failed to remove items from path "{0}": {1}', $Path, $_.Exception));
+        $ExMsg = $_.Exception;
+        Write-IcingaConsoleError 'Failed to remove items from path "{0}". Recurse is "{1}", Force is "{2}": "{3}"' -Objects $Path, $Recurse, $Force, $ExMsg;
     }
     return $FALSE;
 }


### PR DESCRIPTION
The Cmdlet `Remove-ItemSecure` was not using all args and might have crashed on empty values shipped to `-Path`