### PR TITLE
Fix: Director Self-Service ticket handling not working

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -19,7 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#327](https://github.com/Icinga/icinga-powershell-framework/pull/327) Fixes possible exception on first import run for certain systems
 * [#328](https://github.com/Icinga/icinga-powershell-framework/pull/328) Fixes installer while using installation files or the installation command, which did not overwrite default values with custom values
 * [#330](https://github.com/Icinga/icinga-powershell-framework/pull/330) Fixes `Remove-ItemSecure` which was not using all args and might fail on empty path entries
-* [#331](https://github.com/Icinga/icinga-powershell-framework/pull/331) Fixes Icinga Director Self-Service installation over Icinga Management Console
+* [#332](https://github.com/Icinga/icinga-powershell-framework/pull/332) Fixes Icinga Director Self-Service ticket handling, which was not working within the Icinga Management Console
 
 ### Enhancements
 

--- a/lib/core/installer/menu/installation/director/DirectorTemplate.psm1
+++ b/lib/core/installer/menu/installation/director/DirectorTemplate.psm1
@@ -83,6 +83,7 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
     $IcingaParentAddresses    = New-Object PSCustomObject;
     $ParentZone               = '';
     $MasterAddress            = '';
+    $Ticket                   = '';
 
     if ($DirectorUrl.ToLower().Contains('https://') -Or $DirectorUrl.ToLower().Contains('http://')) {
         $MasterAddress = $DirectorUrl.Split('/')[2];
@@ -115,6 +116,8 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
         if ($null -ne $DirectorConfig.parent_zone) {
             $ParentZone = $DirectorConfig.parent_zone;
         }
+
+        $Ticket = Get-IcingaDirectorSelfServiceTicket -DirectorUrl $DirectorUrl -ApiKey $SelfServiceKey;
     }
 
     if ($DirectorConfig.fetch_agent_fqdn) {
@@ -187,6 +190,9 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
     }
 
     Show-IcingaForWindowsInstallationMenuEnterIcingaCAServer -Automated -Value $MasterAddress;
+
+    Show-IcingaForWindowsInstallerMenuSelectCertificate -Automated -DefaultInput '1';
+    Show-IcingaForWindowsInstallerMenuEnterIcingaTicket -Automated -Value $Ticket;
 
     Show-IcingaForWindowsManagementConsoleInstallationDirectorRegisterHost -Automated;
 


### PR DESCRIPTION
Fixes the handling for the Icinga Director Self-Service API, which caused the ticket handling for certificate signing not to work