### PR TITLE
Fatures: Adds Cmdlet to test Icinga for Windows service

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -33,6 +33,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#318](https://github.com/Icinga/icinga-powershell-framework/pull/318) We always enforce the Icinga Framework Code caching now and ship a plain file to build the cache on first loading
 * [#322](https://github.com/Icinga/icinga-powershell-framework/pull/322) Remove legacy import feature from Framework and replace it with a dummy function, as no longer required by Icinga for Windows
 * [#323](https://github.com/Icinga/icinga-powershell-framework/pull/323) Adds `-RebuildCache` switch to `icinga` command alias and `Invoke-IcingaCommand`, for quicker cache re-creation for developers
+* [#333](https://github.com/Icinga/icinga-powershell-framework/pull/333) Adds Cmdlet `Test-IcingaForWindowsService` to test the Icinga for Windows service configuration
 
 ## 1.5.2 (2021-07-09)
 

--- a/lib/core/framework/Install-IcingaFrameworkUpdate.psm1
+++ b/lib/core/framework/Install-IcingaFrameworkUpdate.psm1
@@ -104,6 +104,7 @@ function Install-IcingaFrameworkUpdate()
 
     Write-IcingaConsoleNotice 'Framework update has been completed. Please start a new PowerShell instance now to complete the update';
 
+    Test-IcingaForWindowsService -ResolveProblems | Out-Null;
     Test-IcingaAgent;
 
     if ($ServiceStatus -eq 'Running') {

--- a/lib/core/framework/Test-IcingaForWindowsService.psm1
+++ b/lib/core/framework/Test-IcingaForWindowsService.psm1
@@ -1,0 +1,62 @@
+function Test-IcingaForWindowsService()
+{
+    param (
+        [switch]$ResolveProblems = $FALSE
+    );
+
+    $ServiceData   = Get-IcingaForWindowsServiceData;
+    $ServiceConfig = (Get-IcingaServices -Service 'icingapowershell').icingapowershell.configuration;
+    [bool]$Passed  = $TRUE;
+
+    if ($null -eq $ServiceConfig) {
+        Write-IcingaConsoleNotice 'Icinga for Windows service "icingapowershell" is not installed';
+        return $Passed;
+    }
+
+    [string]$PreparedServicePath = [string]::Format(
+        '\"{0}\" \"{1}\"',
+        $ServiceData.FullPath,
+        (Get-IcingaPowerShellModuleFile)
+    );
+    [string]$ServicePath         = $ServiceConfig.ServicePath.SubString(0, $ServiceConfig.ServicePath.IndexOf(' "'));
+
+    if ($ServicePath.Contains('"')) {
+        Write-IcingaTestOutput -Severity 'Passed' -Message 'Your service installation is not affected by IWKB000009';
+    } else {
+        if ($ResolveProblems) {
+            Write-IcingaTestOutput -Severity 'Warning' -Message 'Your service installation is affected by IWKB000009. Trying to resolve the problem.';
+            $ResolveStatus = Start-IcingaProcess -Executable 'sc.exe' -Arguments ([string]::Format('config icingapowershell binPath= "{0}"', $PreparedServicePath));
+
+            if ($ResolveStatus.ExitCode -ne 0) {
+                Write-IcingaConsoleError 'Failed to resolve problems for service "icingapowershell": {0}{1}' -Objects $ResolveStatus.Message, $ResolveStatus.Error;
+                $Passed = $FALSE;
+            } else {
+                Write-IcingaTestOutput -Severity 'Passed' -Message 'Your service installation is no longer affected by IWKB000009';
+            }
+        } else {
+            Write-IcingaTestOutput -Severity 'Failed' -Message 'Your service installation is affected by IWKB000009. Please have a look on https://icinga.com/docs/icinga-for-windows/latest/doc/knowledgebase/IWKB000009/ for further details. Run this Cmdlet with "-ResolveProblems" to fix it';
+            $Passed = $FALSE;
+        }
+    }
+
+    if ($ServiceConfig.ServicePath.Contains('.psm1')) {
+        if ($ResolveProblems) {
+            Write-IcingaTestOutput -Severity 'Warning' -Message 'Your service installation is referring to "icinga-powershell-framework.psm1" for module imports. Trying to resolve the problem.';
+            $ResolveStatus = Start-IcingaProcess -Executable 'sc.exe' -Arguments ([string]::Format('config icingapowershell binPath= "{0}"', $PreparedServicePath));
+
+            if ($ResolveStatus.ExitCode -ne 0) {
+                Write-IcingaConsoleError 'Failed to resolve problems for service "icingapowershell": {0}{1}' -Objects $ResolveStatus.Message, $ResolveStatus.Error;
+                $Passed = $FALSE;
+            } else {
+                Write-IcingaTestOutput -Severity 'Passed' -Message 'Your service installation is now properly referring to "icinga-powershell-framework.psd1" for module imports.';
+            }
+        } else {
+            Write-IcingaTestOutput -Severity 'Failed' -Message 'Your service installation is referring "icinga-powershell-framework.psm1". This is deprecated and has to be changed to "icinga-powershell-framework.psd1". Run this Cmdlet with "-ResolveProblems" to fix it.';
+            $Passed = $FALSE;
+        }
+    } else {
+        Write-IcingaTestOutput -Severity 'Passed' -Message 'Your service installation is properly referring to "icinga-powershell-framework.psd1" for module imports.';
+    }
+
+    return $Passed;
+}

--- a/lib/core/repository/Get-IcingaForWindowsServiceData.psm1
+++ b/lib/core/repository/Get-IcingaForWindowsServiceData.psm1
@@ -3,6 +3,7 @@ function Get-IcingaForWindowsServiceData()
     $IcingaForWindowsService = Get-IcingaServices -Service 'icingapowershell';
 
     [hashtable]$ServiceData = @{
+        'Binary'    = '';
         'Directory' = '';
         'FullPath'  = '';
         'User'      = '';
@@ -12,6 +13,7 @@ function Get-IcingaForWindowsServiceData()
         $ServicePath           = $IcingaForWindowsService.icingapowershell.configuration.ServicePath;
         $ServicePath           = $ServicePath.SubString(0, $ServicePath.IndexOf('.exe') + 4);
         $ServicePath           = $ServicePath.Replace('"', '');
+        $ServiceData.Binary    = $ServicePath.SubString($ServicePath.LastIndexOf('\') + 1, $ServicePath.Length - $ServicePath.LastIndexOf('\') - 1);
         $ServiceData.FullPath  = $ServicePath;
         $ServiceData.Directory = $ServicePath.Substring(0, $ServicePath.LastIndexOf('\') + 1);
         $ServiceData.User      = $IcingaForWindowsService.icingapowershell.configuration.ServiceUser;


### PR DESCRIPTION
Adds a new Cmdlet `Test-IcingaForWindowsService` which will test for security issue IWKB000009 and check if the service is properly configured to run against the .psd1 instead of .psm1 of the icinga-powershell-framework.