### PR TITLE
Fix: Icinga Director Self-Service Zones and CA config

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -20,6 +20,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#328](https://github.com/Icinga/icinga-powershell-framework/pull/328) Fixes installer while using installation files or the installation command, which did not overwrite default values with custom values
 * [#330](https://github.com/Icinga/icinga-powershell-framework/pull/330) Fixes `Remove-ItemSecure` which was not using all args and might fail on empty path entries
 * [#332](https://github.com/Icinga/icinga-powershell-framework/pull/332) Fixes Icinga Director Self-Service ticket handling, which was not working within the Icinga Management Console
+* [#335](https://github.com/Icinga/icinga-powershell-framework/pull/335) Fixex Icinga Director Self-Service Zones and CA config for legacy installation wizard
 
 ### Enhancements
 

--- a/lib/core/icingaagent/misc/Convert-IcingaDirectorSelfServiceArguments.psm1
+++ b/lib/core/icingaagent/misc/Convert-IcingaDirectorSelfServiceArguments.psm1
@@ -5,7 +5,7 @@ function Convert-IcingaDirectorSelfServiceArguments()
     );
 
     if ($null -eq $JsonInput) {
-        return @{};
+        return @{ };
     }
 
     [hashtable]$DirectorArguments = @{
@@ -15,7 +15,7 @@ function Convert-IcingaDirectorSelfServiceArguments()
         AllowVersionChanges     = $JsonInput.allow_updates;
         GlobalZones             = $JsonInput.global_zones;
         ParentZone              = $JsonInput.parent_zone;
-        #CAEndpoint             = $JsonInput.ca_server;
+        CAEndpoint              = $JsonInput.IcingaMaster;
         Endpoints               = $JsonInput.parent_endpoints;
         AddFirewallRule         = $JsonInput.agent_add_firewall_rule;
         AcceptConnections       = $JsonInput.agent_add_firewall_rule;
@@ -61,8 +61,8 @@ function Convert-IcingaDirectorSelfServiceArguments()
     }
 
     $NetworkDefault = '';
-    foreach ($Endpoint in $JsonInput.parent_endpoints) {
-        $NetworkDefault += [string]::Format('[{0}]:{1},', $Endpoint, $JsonInput.agent_listen_port);
+    foreach ($Endpoint in $JsonInput.endpoints_config) {
+        $NetworkDefault += [string]::Format('[{0}]:{1},', ($Endpoint.Split(';')[0]), $JsonInput.agent_listen_port);
     }
     if ([string]::IsNullOrEmpty($NetworkDefault) -eq $FALSE) {
         $NetworkDefault = $NetworkDefault.Substring(0, $NetworkDefault.Length - 1).Split(',');
@@ -71,9 +71,6 @@ function Convert-IcingaDirectorSelfServiceArguments()
         );
 
         $EndpointConnections = $NetworkDefault;
-        $DirectorArguments.Add(
-            'CAEndpoint', (Get-IPConfigFromString $EndpointConnections[0]).address
-        );
     }
 
     return $DirectorArguments;


### PR DESCRIPTION
Fixes an issue on legacy installation wizard, which did not render the zones.conf properly with the correct information shipped for connection data and added missing `-CAEndpoint` assignment, which was wrong previously.