### PR TITLE
Fix: Freeze on IMC in case commands are not found

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -21,6 +21,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#330](https://github.com/Icinga/icinga-powershell-framework/pull/330) Fixes `Remove-ItemSecure` which was not using all args and might fail on empty path entries
 * [#332](https://github.com/Icinga/icinga-powershell-framework/pull/332) Fixes Icinga Director Self-Service ticket handling, which was not working within the Icinga Management Console
 * [#335](https://github.com/Icinga/icinga-powershell-framework/pull/335) Fixes Icinga Director Self-Service Zones and CA config for legacy installation wizard
+* [#343](https://github.com/Icinga/icinga-powershell-framework/pull/343) Fixes freeze within Icinga Management Console, in case commands which previously existed were removed/renamed or the user applied an invalid configuration with unknown commands as install file or install command
 
 ### Enhancements
 

--- a/lib/core/installer/menu/installation/general/ConfigurationSummary.psm1
+++ b/lib/core/installer/menu/installation/general/ConfigurationSummary.psm1
@@ -65,7 +65,13 @@ function Show-IcingaForWindowsInstallerConfigurationSummary()
             if (Test-Numeric ($ConfigEntry.Selection)) {
                 Set-IcingaForWindowsInstallationHeaderSelection -Selection $ConfigEntry.Selection;
 
-                &$RealCommand;
+                try {
+                    &$RealCommand;
+                } catch {
+                    $ErrMsg = [string]::Format('Failed to apply configuration item "{0}". This could happen in case elements were removed or renamed between Framework versions: {1}', $RealCommand, $_.Exception.Message);
+                    $global:Icinga.InstallWizard.LastError += $ErrMsg;
+                    continue;
+                }
 
                 $Caption = ([string]::Format('{0}=> {1}', $PrintName, $global:Icinga.InstallWizard.HeaderPreview));
             } else {
@@ -84,6 +90,8 @@ function Show-IcingaForWindowsInstallerConfigurationSummary()
 
         $CurrentIndex += 1;
     }
+
+    Write-Host 'Finished'
 
     Disable-IcingaForWindowsInstallationHeaderPrint;
     Enable-IcingaForWindowsInstallationJumpToSummary;


### PR DESCRIPTION
Fixes a freeze within Icinga Management Console, in case commands which previously existed were removed/renamed or the user applied an invalid configuration with unknown commands as install file or install command