### PR TITLE
Fix: Links to public Icinga repos

### DIFF
--- a/doc/repositorymanager/01-Add-Existing-Repositories.md
+++ b/doc/repositorymanager/01-Add-Existing-Repositories.md
@@ -20,22 +20,22 @@ The best way to demonstrate on how to add new repositories, you can use the defa
 
 ### Icinga for Windows Stable
 
-The URL pointing to the stable releases is `http://packages.icinga.com/IcingaForWindows/stable`.
+The URL pointing to the stable releases is `https://packages.icinga.com/IcingaForWindows/stable/ifw.repo.json`.
 
 ```powershell
 Add-IcingaRepository `
     -Name 'Icinga Stable' `
-    -RemotePath 'http://packages.icinga.com/IcingaForWindows/stable';
+    -RemotePath 'https://packages.icinga.com/IcingaForWindows/stable/ifw.repo.json';
 ```
 
 ### Icinga for Windows Snapshot
 
-The URL pointing to the snapshot releases is `http://packages.icinga.com/IcingaForWindows/snapshot`.
+The URL pointing to the snapshot releases is `https://packages.icinga.com/IcingaForWindows/snapshot/ifw.repo.json`.
 
 ```powershell
 Add-IcingaRepository `
     -Name 'Icinga Snapshot' `
-    -RemotePath 'http://packages.icinga.com/IcingaForWindows/snapshot';
+    -RemotePath 'https://packages.icinga.com/IcingaForWindows/snapshot/ifw.repo.json';
 ```
 
 ## Using Repositories

--- a/doc/repositorymanager/02-Sync-Repositories.md
+++ b/doc/repositorymanager/02-Sync-Repositories.md
@@ -26,7 +26,7 @@ You can use the sync command to clone an existing public repository for example 
 Sync-IcingaRepository `
     -Name 'Icinga Stable Local' `
     -Path 'C:\icinga\icinga_stable' `
-    -Source 'http://packages.icinga.com/IcingaForWindows/stable';
+    -Source 'https://packages.icinga.com/IcingaForWindows/stable/ifw.repo.json';
 ```
 
 This will sync all files from the public Icinga repository into `C:\icinga\icinga_stable`. As `RemotePath` is not set, it will default to `C:\icinga\icinga_stable` and all files will be fetched from this location.
@@ -38,7 +38,7 @@ Sync-IcingaRepository `
     -Name 'Icinga Stable Local' `
     -Path 'C:\icinga\icinga_stable' `
     -RemotePath '\\myhost.example.com\icingastable' `
-    -Source 'http://packages.icinga.com/IcingaForWindows/stable';
+    -Source 'https://packages.icinga.com/IcingaForWindows/stable/ifw.repo.json';
 ```
 
 We can for example use file sharing, to make certain folders available in our network. This example will download all files into `C:\icinga\icinga_stable`, but tell Icinga for Windows to use your shared network drive `\\myhost.example.com\icingastable` to fetch them from.
@@ -60,13 +60,13 @@ Sync-IcingaRepository `
     -Name 'Icinga Stable Internal Web' `
     -Path 'icinga@icingarepo.example.com:/var/www/icingastable/' `
     -RemotePath 'https://icingarepo.example.com/icingastable' `
-    -Source 'http://packages.icinga.com/IcingaForWindows/stable' `
+    -Source 'https://packages.icinga.com/IcingaForWindows/stable/ifw.repo.json' `
     -UseSCP;
 ```
 
 In this example we will sync all files to a Linux machine at `/var/www/icingastable/`. If we are running a local Apache or Nginx, we can create a web resource for this path and make it available in our network. We have to use `-UseSCP`, to tell Icinga for Windows to copy them to the Linux machine over `scp`. Please note that both, `scp` and `ssh` have to be installed  on the system.
 
-On different machines, you can then use 
+On different machines, you can then use
 
 ```powershell
 Add-IcingaRepository `
@@ -86,7 +86,7 @@ Clone the repository to a local path:
 Sync-IcingaRepository `
     -Name 'Icinga Stable Local' `
     -Path 'C:\icinga\icinga_stable' `
-    -Source 'http://packages.icinga.com/IcingaForWindows/stable';
+    -Source 'https://packages.icinga.com/IcingaForWindows/stable/ifw.repo.json';
 ```
 
 Clone this repository to our internal web space:


### PR DESCRIPTION
Fixes the links to publi Icinga repos `stable` and `snapshot`, by always pointing directly to `ifw.repo.json`