### PR TITLE
Feature: Adds support for version names for snapshots

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -38,6 +38,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#333](https://github.com/Icinga/icinga-powershell-framework/pull/333) Adds Cmdlet `Test-IcingaForWindowsService` to test the Icinga for Windows service configuration
 * [#338](https://github.com/Icinga/icinga-powershell-framework/pull/338) Improves various styles, outputs and view for the Icinga for Windows Management Console and fixes some spelling mistakes
 * [#342](https://github.com/Icinga/icinga-powershell-framework/pull/342) Adds feature to print commands being executed by the Icinga Management Console with `l` and improves summary visualisation for better readability
+* [#346](https://github.com/Icinga/icinga-powershell-framework/pull/346) Adds support for version names for snapshots
 
 ## 1.5.2 (2021-07-09)
 

--- a/lib/core/repository/Get-IcingaRepositoryPackage.psm1
+++ b/lib/core/repository/Get-IcingaRepositoryPackage.psm1
@@ -65,7 +65,19 @@ function Get-IcingaRepositoryPackage()
                 continue;
             }
 
-            if ([string]::IsNullOrEmpty($Version) -And ($null -eq $LatestVersion -Or $LatestVersion -lt $package.Version)) {
+            if ($Snapshot -And [string]::IsNullOrEmpty($Version) -eq $FALSE -And (Test-Numeric $package.Version.Replace('.', '')) -eq $FALSE -And (Test-Numeric $Version) -eq $FALSE -And $package.Version -eq $Version) {
+                $InstallPackage = $package;
+                $HasRepo        = $TRUE;
+                $SourceRepo     = $RepoContent;
+                $RepoName       = $entry.Name;
+                break;
+            }
+
+            if ((Test-Numeric $package.Version.Replace('.', '')) -eq $FALSE -Or ((Test-Numeric $Version.Replace('.', '')) -eq $FALSE -And [string]::IsNullOrEmpty($Version) -eq $FALSE) ) {
+                continue;
+            }
+
+            if (([string]::IsNullOrEmpty($Version) -And ($null -eq $LatestVersion -Or $LatestVersion -lt $package.Version))) {
                 [Version]$LatestVersion = [Version]$package.Version;
                 $InstallPackage         = $package;
                 $HasRepo                = $TRUE;


### PR DESCRIPTION
In order to easy manage different snapshot versions for different branches, we now support providing a name as version for **snapshot** packages only,

Example:

```powershell
Add-IcingaRepository -Name 'icinga-powershell-framework/doc/doc_rewrite' -RemotePath 'https://packages.icinga.com/IcingaForWindows/snapshot/icinga-powershell-framework/doc/doc_rewrite/ifw.repo.json';
Install-IcingaComponent -Name 'framework' -Version 'doc/doc_rewrite' -Snapshot -Force;
```