### PR TITLE
Fix: Module file should always point to .psd1 instead of .psm1

### DIFF
--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -199,7 +199,7 @@ function Get-IcingaForWindowsRootPath()
 
 function Get-IcingaPowerShellModuleFile()
 {
-    return (Join-Path -Path $PSScriptRoot -ChildPath 'icinga-powershell-framework.psm1');
+    return (Join-Path -Path $PSScriptRoot -ChildPath 'icinga-powershell-framework.psd1');
 }
 
 function Invoke-IcingaCommand()


### PR DESCRIPTION
We have to ensure with Icinga for Windows 1.6.0 that we always point to the `.psd1` file instead of the `.psm1` file, especially when working with the `icingapowershellservice`