### PR TITLE
Fix: Icinga file writer fails on input not matching string

### DIFF
--- a/lib/core/tools/Write-IcingaFileSecure.psm1
+++ b/lib/core/tools/Write-IcingaFileSecure.psm1
@@ -9,6 +9,18 @@ function Write-IcingaFileSecure()
         return;
     }
 
+    if ($null -eq $Value) {
+        $Value = '';
+    } elseif ($Value.GetType().Name.ToLower() -eq 'hashtable') {
+        $Value = ConvertTo-Json -InputObject $Value -Depth 100;
+    } elseif (([string]($Value.GetType().BaseType)).ToLower() -eq 'array') {
+        $Value = $Value | Out-String;
+    } elseif ($Value.GetType().Name.ToLower() -eq 'pscustomobject') {
+        $Value = ConvertTo-Json -InputObject $Value -Depth 100;
+    } else {
+        $Value = $Value | Out-String;
+    }
+
     if ((Test-Path $File) -eq $FALSE) {
         try {
             New-Item -ItemType File -Path $File -ErrorAction Stop | Out-Null;


### PR DESCRIPTION
In case we add non-string values into our Icinga file writer, the output may not what we have been expected.
To resolve this, we will add support for these default inputs:

* Hashtable -> JSON
* Array -> Listed output
* PSCustomObject -> JSON
* Everything else -> simple string conversion