### PR TITLE
Fix: Plain Plugin Cmdlet execution on shell

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -25,6 +25,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#343](https://github.com/Icinga/icinga-powershell-framework/pull/343) Fixes freeze within Icinga Management Console, in case commands which previously existed were removed/renamed or the user applied an invalid configuration with unknown commands as install file or install command
 * [#345](https://github.com/Icinga/icinga-powershell-framework/pull/345) Fixes Framework environment variables like `$IcingaEnums` not working with v1.6.0
 * [#351](https://github.com/Icinga/icinga-powershell-framework/pull/351) Fixes file writer which could cause corruption on parallel read/write events on the same file
+* [#359](https://github.com/Icinga/icinga-powershell-framework/issues/359) Fixes Plain Plugin Cmdlet execution on shell
 
 ### Enhancements
 

--- a/lib/icinga/plugin/New-IcingaCheckResult.psm1
+++ b/lib/icinga/plugin/New-IcingaCheckResult.psm1
@@ -25,9 +25,12 @@ function New-IcingaCheckResult()
         }
 
         # Ensure we reset our internal cache once the plugin was executed
-        $Global:Icinga.ThresholdCache[$this.Check.__GetCheckCommand()] = $null;
+        $CheckCommand = $this.Check.__GetCheckCommand();
+        if ([string]::IsNullOrEmpty($CheckCommand) -eq $FALSE -And $Global:Icinga.ThresholdCache.ContainsKey($CheckCommand)) {
+            $Global:Icinga.ThresholdCache[$CheckCommand] = $null;
+        }
         # Reset the current execution date
-        $Global:Icinga.CurrentDate                                     = $null;
+        $Global:Icinga.CurrentDate = $null;
 
         $ExitCode = $this.Check.__GetCheckState();
 

--- a/lib/icinga/plugin/Write-IcingaPluginPerfData.psm1
+++ b/lib/icinga/plugin/Write-IcingaPluginPerfData.psm1
@@ -19,7 +19,11 @@ function Write-IcingaPluginPerfData()
         $PerformanceData = $PerformanceData.perfdata;
     }
 
-    $CheckResultCache = $Global:Icinga.ThresholdCache[$CheckCommand];
+    if ([string]::IsNullOrEmpty($CheckCommand) -eq $FALSE -And $Global:Icinga.ThresholdCache.ContainsKey($CheckCommand)) {
+        $CheckResultCache = $Global:Icinga.ThresholdCache[$CheckCommand];
+    } else {
+        $CheckResultCache = New-Object PSCustomObject;
+    }
 
     if ($global:IcingaDaemonData.FrameworkRunningAsDaemon -eq $FALSE -And $global:IcingaDaemonData.JEAContext -eq $FALSE) {
         [string]$PerfDataOutput = (Get-IcingaPluginPerfDataContent -PerfData $PerformanceData -CheckResultCache $CheckResultCache -IcingaCheck $IcingaCheck);


### PR DESCRIPTION
Fixes plain execution of plugin Cmdlets on the PowerShell, which caused an exception of being thrown before, as no check command was assigned.

Fixes #359