### PR TITLE
Fix: IMC fails on Icinga Director Self-Service no Agent installation set

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
+## 1.6.1 (2021-09-15)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/21?closed=1)
+
+### Bugfixes
+
+* [#361](https://github.com/Icinga/icinga-powershell-framework/issues/361) Fixes IMC freeze on Icinga Director Self-Service installation, in case no Agent installation set on Self-Service API config
+
 ## 1.6.0 (2021-09-07)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/15?closed=1)

--- a/lib/core/installer/menu/installation/director/DirectorTemplate.psm1
+++ b/lib/core/installer/menu/installation/director/DirectorTemplate.psm1
@@ -69,15 +69,15 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
     }
 
     # No we need to identify which host selection is matching our config
-    $HostnameSelection        = -1;
-    $InstallPluginsSelection  = -1;
-    $InstallServiceSelection  = -1;
+    $HostnameSelection        = 1;
+    $InstallPluginsSelection  = 0;
+    $InstallServiceSelection  = 0;
     $WindowsFirewallSelection = 1;
+    $AgentVersion             = 'release';
+    $InstallIcingaAgent       = 0;
 
     $ServiceUserName          = $DirectorConfig.icinga_service_user;
     $AgentPackageSelection    = 1; #Always use custom source
-    $AgentPackageSource       = $DirectorConfig.download_url;
-    $AgentVersion             = $DirectorConfig.agent_version;
     $IcingaPort               = $DirectorConfig.agent_listen_port;
     $GlobalZones              = @();
     $IcingaParents            = @();
@@ -85,6 +85,12 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
     $ParentZone               = '';
     $MasterAddress            = '';
     $Ticket                   = '';
+
+    if (Test-IcingaPowerShellConfigItem -ConfigObject $DirectorConfig -ConfigKey 'agent_version') {
+        $AgentVersion = $DirectorConfig.agent_version;
+    } else {
+        $InstallIcingaAgent = 1;
+    }
 
     if ($DirectorUrl.ToLower().Contains('https://') -Or $DirectorUrl.ToLower().Contains('http://')) {
         $MasterAddress = $DirectorUrl.Split('/')[2];
@@ -163,6 +169,7 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
         # Do not install
         $InstallServiceSelection = 1;
     } else {
+        # Install the service from our repository
         $InstallServiceSelection = 0;
     }
 
@@ -170,7 +177,7 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
         # Do not install
         $InstallPluginsSelection = 1;
     } else {
-        # TODO: This is currently not supported. We use the "default" config for installing from GitHub by now
+        # Install the plugins from our repository
         $InstallPluginsSelection = 0;
     }
 
@@ -202,6 +209,7 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
     Show-IcingaForWindowsInstallerMenuSelectCertificate -Automated -DefaultInput '1';
     Show-IcingaForWindowsInstallerMenuEnterIcingaTicket -Automated -Value $Ticket;
 
+    Show-IcingaForWindowsInstallerMenuSelectInstallIcingaAgent -Automated -DefaultInput $InstallIcingaAgent;
     Show-IcingaForWindowsInstallationMenuEnterIcingaAgentVersion -Automated -Value $AgentVersion;
 
     Show-IcingaForWindowsManagementConsoleInstallationDirectorRegisterHost -Automated;


### PR DESCRIPTION
In case you are using the IMC and the Icinga Director Self-Service API, it can happen that once entered the Self-Service API key, the shell will only look like this:

```
Input (Default 0 and c ):
```

Without any other form content.

This occured, in case inside the Self-Service API config the entry `Installation Source` was set to `- no automatic installation -`.

This fix resolves the issue and renders the form including the settings correctly.