### PR TITLE
Fix: Repository component install from file share

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#361](https://github.com/Icinga/icinga-powershell-framework/issues/361) Fixes IMC freeze on Icinga Director Self-Service installation, in case no Agent installation set on Self-Service API config
+* [#362](https://github.com/Icinga/icinga-powershell-framework/issues/362) Fixes repository component installation from file share locations
 
 ## 1.6.0 (2021-09-07)
 

--- a/lib/core/repository/Read-IcingaRepositoryFile.psm1
+++ b/lib/core/repository/Read-IcingaRepositoryFile.psm1
@@ -24,8 +24,8 @@ function Read-IcingaRepositoryFile()
         $RepoPath = $Repository.LocalPath;
         $Content  = Get-Content -Path (Join-Path -Path $RepoPath -ChildPath 'ifw.repo.json') -Raw;
     } elseif ([string]::IsNullOrEmpty($Repository.RemotePath) -eq $FALSE -And (Test-Path -Path $Repository.RemotePath)) {
-        $RepoPath   = $Repository.RemotePath;
-        $WebContent = Get-Content -Path (Join-Path -Path $RepoPath -ChildPath 'ifw.repo.json') -Raw;
+        $RepoPath = $Repository.RemotePath;
+        $Content  = Get-Content -Path (Join-Path -Path $RepoPath -ChildPath 'ifw.repo.json') -Raw;
     } else {
         try {
             $RepoPath = $Repository.RemotePath;

--- a/lib/core/repository/Search-IcingaRepository.psm1
+++ b/lib/core/repository/Search-IcingaRepository.psm1
@@ -31,7 +31,7 @@ function Search-IcingaRepository()
     $SearchList | Add-Member -MemberType NoteProperty -Name 'Repos' -Value @();
 
     foreach ($entry in $Repositories) {
-        $RepoContent        = Read-IcingaRepositoryFile -Name $entry.Name;
+        $RepoContent = Read-IcingaRepositoryFile -Name $entry.Name;
 
         if ($null -eq $RepoContent) {
             continue;

--- a/lib/web/Invoke-IcingaWebRequest.psm1
+++ b/lib/web/Invoke-IcingaWebRequest.psm1
@@ -77,6 +77,12 @@ function Invoke-IcingaWebRequest()
         $Index++;
     }
 
+    # If our URI is a local path or a file share path, always ensure to use the correct Windows directory
+    # handling with '\' instead of '/'
+    if ([string]::IsNullOrEmpty($Uri) -eq $FALSE -And (Test-Path $Uri)) {
+        $Uri = $Uri.Replace('/', '\');
+    }
+
     $WebArguments = @{
         'Uri'    = $Uri;
         'Method' = $Method;


### PR DESCRIPTION
The installation from file share locations will fail, in case no `LocalPath` is assigned to the repository configuration and is also failing by invalid escaping of the path.

This is now fixed as the `RemotePath` is the only one being required and in addition downloads from file shares of component packages is now working as intended.