### PR TITLE
Fix: Unneeded continue on no JEA pid present

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -15,6 +15,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#361](https://github.com/Icinga/icinga-powershell-framework/issues/361) Fixes IMC freeze on Icinga Director Self-Service installation, in case no Agent installation set on Self-Service API config
 * [#362](https://github.com/Icinga/icinga-powershell-framework/issues/362) Fixes repository component installation from file share locations
+* [#363](https://github.com/Icinga/icinga-powershell-framework/issues/363) Fixes unneeded continue for JEA process lookup, in case no JEA pid is present
 
 ## 1.6.0 (2021-09-07)
 

--- a/lib/core/jea/Test-IcingaJEAServiceRunning.psm1
+++ b/lib/core/jea/Test-IcingaJEAServiceRunning.psm1
@@ -8,6 +8,10 @@ function Test-IcingaJEAServiceRunning()
         [string]$JeaPid = Get-IcingaJEAServicePid;
     }
 
+    if ([string]::IsNullOrEmpty($JeaPid)) {
+        return $FALSE;
+    }
+
     $JeaPowerShellProcess = Get-Process -Id $JeaPid -ErrorAction SilentlyContinue;
     if ($null -eq $JeaPowerShellProcess) {
         return $FALSE;


### PR DESCRIPTION
In case no JEA pid is present, we should not lookup any processes and simply return `False` instead.