### PR TITLE
Fix: Icinga Director state not being saved on overview

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#363](https://github.com/Icinga/icinga-powershell-framework/issues/363) Fixes unneeded continue for JEA process lookup, in case no JEA pid is present
 * [#365](https://github.com/Icinga/icinga-powershell-framework/issues/365) Fixes Icinga environment corruption on Icinga Agent installation failure
 * [#366](https://github.com/Icinga/icinga-powershell-framework/issues/366) Fixes error handling with Icinga Director over IMC, by printing more detailed and user-friendly error messages
+* [#367](https://github.com/Icinga/icinga-powershell-framework/issues/367) Fixes Icinga Director register state not being saved on overview after registration of Host inside Self-Service API
 
 ### Enhancements
 

--- a/lib/core/installer/menu/installation/director/DirectorTemplate.psm1
+++ b/lib/core/installer/menu/installation/director/DirectorTemplate.psm1
@@ -101,6 +101,11 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
     $ParentZone               = '';
     $MasterAddress            = '';
     $Ticket                   = '';
+    $DirectorHostRegister     = (Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsManagementConsoleInstallationDirectorRegisterHost');
+
+    if ($null -eq $DirectorHostRegister) {
+        $DirectorHostRegister = 0;
+    }
 
     if (Test-IcingaPowerShellConfigItem -ConfigObject $DirectorConfig -ConfigKey 'agent_version') {
         $AgentVersion = $DirectorConfig.agent_version;
@@ -227,8 +232,7 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
 
     Show-IcingaForWindowsInstallerMenuSelectInstallIcingaAgent -Automated -DefaultInput $InstallIcingaAgent;
     Show-IcingaForWindowsInstallationMenuEnterIcingaAgentVersion -Automated -Value $AgentVersion;
-
-    Show-IcingaForWindowsManagementConsoleInstallationDirectorRegisterHost -Automated;
+    Show-IcingaForWindowsManagementConsoleInstallationDirectorRegisterHost -DefaultInput $DirectorHostRegister -Automated;
 
     Enable-IcingaFrameworkConsoleOutput;
     Reset-IcingaForWindowsManagementConsoleInstallationDirectorConfigModifyState;


### PR DESCRIPTION
In case the Icinga Director host is registered in the IMC over the Self-Service API, the menu is defaulting to the message "Do not register host" instead of displaying the correct configuration.

This is only a displaying issue and has no technical impact, but we still need to fix that.