### PR TITLE
Fix: Repository lookup on local path for ifw.repo.json

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -19,6 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#365](https://github.com/Icinga/icinga-powershell-framework/issues/365) Fixes Icinga environment corruption on Icinga Agent installation failure
 * [#366](https://github.com/Icinga/icinga-powershell-framework/issues/366) Fixes error handling with Icinga Director over IMC, by printing more detailed and user-friendly error messages
 * [#367](https://github.com/Icinga/icinga-powershell-framework/issues/367) Fixes Icinga Director register state not being saved on overview after registration of Host inside Self-Service API
+* [#368](https://github.com/Icinga/icinga-powershell-framework/issues/368) Fixes repository lookup on local path for ifw.repo.json, in the json file was added to the file path during repository add
 
 ### Enhancements
 

--- a/lib/core/repository/Read-IcingaRepositoryFile.psm1
+++ b/lib/core/repository/Read-IcingaRepositoryFile.psm1
@@ -22,10 +22,23 @@ function Read-IcingaRepositoryFile()
 
     if ([string]::IsNullOrEmpty($Repository.LocalPath) -eq $FALSE -And (Test-Path -Path $Repository.LocalPath)) {
         $RepoPath = $Repository.LocalPath;
-        $Content  = Get-Content -Path (Join-Path -Path $RepoPath -ChildPath 'ifw.repo.json') -Raw;
     } elseif ([string]::IsNullOrEmpty($Repository.RemotePath) -eq $FALSE -And (Test-Path -Path $Repository.RemotePath)) {
         $RepoPath = $Repository.RemotePath;
-        $Content  = Get-Content -Path (Join-Path -Path $RepoPath -ChildPath 'ifw.repo.json') -Raw;
+    }
+
+    if ([string]::IsNullOrEmpty($RepoPath) -eq $FALSE -And (Test-Path -Path $RepoPath)) {
+        if ([IO.Path]::GetExtension($RepoPath).ToLower() -ne '.json' -And $TryAlternate -eq $FALSE) {
+            return (Read-IcingaRepositoryFile -Name $Name -TryAlternate);
+        } elseif ([IO.Path]::GetExtension($RepoPath).ToLower() -ne '.json' -And $TryAlternat) {
+            Write-IcingaConsoleError 'Unable to read repository file from "{0}" for repository "{1}". No "ifw.repo.json" was found at defined location' -Objects $RepoPath, $Name;
+            return $null;
+        }
+
+        if ($TryAlternate) {
+            $RepoPath = Join-Path $RepoPath -ChildPath 'ifw.repo.json';
+        }
+
+        $Content  = Get-Content -Path $RepoPath -Raw;
     } else {
         try {
             $RepoPath = $Repository.RemotePath;


### PR DESCRIPTION
Fixes lookup for local ifw.repo.json, in case the path was specified with `ifw.repo.json` included, like `C:\icinga\stable\ifw.repo.json`