### PR TITLE
Fix: IMC summary header has misleading title

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -25,6 +25,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Enhancements
 
 * [#364](https://github.com/Icinga/icinga-powershell-framework/pull/364) Fixes a long lookup for the user table on environments with a large Active Directory
+* [#370](https://github.com/Icinga/icinga-powershell-framework/issues/370) Fixes misleading IMC summary header, implying installation will start immediately on continue
 
 ## 1.6.0 (2021-09-07)
 

--- a/lib/core/installer/menu/installation/general/ConfigurationSummary.psm1
+++ b/lib/core/installer/menu/installation/general/ConfigurationSummary.psm1
@@ -107,7 +107,7 @@ function Show-IcingaForWindowsInstallerConfigurationSummary()
     $global:Icinga.InstallWizard.DisplayAdvanced = $TRUE;
 
     Show-IcingaForWindowsInstallerMenu `
-        -Header 'Please validate your configuration. Installation starts on continue:' `
+        -Header 'Please validate your configuration. Installation or answer file/command export are available on next step:' `
         -Entries $Entries `
         -DefaultIndex 'c' `
         -ContinueFunction 'Show-IcingaForWindowsInstallerMenuFinishInstaller' `


### PR DESCRIPTION
Fixes misleading title for IMC summary header, which implies the installation instantly starts on continue, instead of notifying properly about the installation being started on the next step including the export of the answer file and install command.