### PR TITLE
Fix: Wrong IMC indention on host address summary

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -21,6 +21,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#367](https://github.com/Icinga/icinga-powershell-framework/issues/367) Fixes Icinga Director register state not being saved on overview after registration of Host inside Self-Service API
 * [#368](https://github.com/Icinga/icinga-powershell-framework/issues/368) Fixes repository lookup on local path for ifw.repo.json, in the json file was added to the file path during repository add
 * [#369](https://github.com/Icinga/icinga-powershell-framework/issues/369) Fixes experimental feature warning for API-Check Forwarder feature, which is fully supported since v1.6.0 and replaces it with proper information and link to docs
+* [#371](https://github.com/Icinga/icinga-powershell-framework/issues/371) Fixes wrong indention on Icinga parent host address at IMC configuration summary overview
 
 ### Enhancements
 

--- a/lib/core/installer/menu/installation/general/ConfigurationSummary.psm1
+++ b/lib/core/installer/menu/installation/general/ConfigurationSummary.psm1
@@ -9,8 +9,19 @@ function Show-IcingaForWindowsInstallerConfigurationSummary()
     );
 
     [array]$Entries      = @();
-    [int]$CurrentIndex   = 0
-    [int]$MaxEntryLength = (Get-IcingaMaxTextLength -TextArray $global:Icinga.InstallWizard.Config.Keys) - 4;
+    [int]$CurrentIndex   = 0;
+    [array]$KeyValues    = @();
+
+    foreach ($entry in $global:Icinga.InstallWizard.Config.Keys) {
+        if ($entry.Contains(':')) {
+            $KeySplit   = $entry.Split(':');
+            $KeyValues += [string]::Format('{0} for "{1}"', ($KeySplit[0]), ($KeySplit[1]));
+        } else {
+            $KeyValues += $entry;
+        }
+    }
+
+    [int]$MaxEntryLength = (Get-IcingaMaxTextLength -TextArray $KeyValues) - 4;
 
     Enable-IcingaForWindowsInstallationHeaderPrint;
 


### PR DESCRIPTION
Fixes wrong indention on Icinga parent host address at IMC configuration summary.