### PR TITLE
Fix: Repository names with dots fail to load

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -22,6 +22,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#368](https://github.com/Icinga/icinga-powershell-framework/issues/368) Fixes repository lookup on local path for ifw.repo.json, in the json file was added to the file path during repository add
 * [#369](https://github.com/Icinga/icinga-powershell-framework/issues/369) Fixes experimental feature warning for API-Check Forwarder feature, which is fully supported since v1.6.0 and replaces it with proper information and link to docs
 * [#371](https://github.com/Icinga/icinga-powershell-framework/issues/371) Fixes wrong indention on Icinga parent host address at IMC configuration summary overview
+* [#373](https://github.com/Icinga/icinga-powershell-framework/issues/373) Fixes repository names with dots (`.`) by replacing them with `-`, as otherwise the config parser will fail finding the config object
 
 ### Enhancements
 

--- a/lib/config/Get-IcingaPowerShellConfig.psm1
+++ b/lib/config/Get-IcingaPowerShellConfig.psm1
@@ -36,4 +36,31 @@ function Get-IcingaPowerShellConfig()
     }
 
     return $ConfigObject;
+
+    <#
+    # Alternate config parser. Might come handy in the future, requires to redesign
+    # Set-IcingaPowerShellConfig including all calls for full coverage
+    $Config       = Read-IcingaPowerShellConfig;
+    $PathArray    = $Path.Split('.');
+    $ConfigObject = $Config;
+    [int]$Index   = 0;
+    $entry        = $PathArray[$Index];
+
+    while ($Index -lt $PathArray.Count) {
+        if (-Not (Test-IcingaPowerShellConfigItem -ConfigObject $ConfigObject -ConfigKey $entry) -And $Index -lt $PathArray.Count) {
+            $Index += 1;
+            $entry  = [string]::Format('{0}.{1}', $entry, $PathArray[$Index]);
+
+            continue;
+        } elseif (-Not (Test-IcingaPowerShellConfigItem -ConfigObject $ConfigObject -ConfigKey $entry) -And $Index -ge $PathArray.Count) {
+            return $null;
+        }
+
+        $ConfigObject = $ConfigObject.$entry;
+        $Index       += 1;
+        $entry        = $PathArray[$Index];
+    }
+
+    return $ConfigObject;
+    #>
 }

--- a/lib/config/Test-IcingaPowerShellConfigItem.psm1
+++ b/lib/config/Test-IcingaPowerShellConfigItem.psm1
@@ -26,5 +26,15 @@ function Test-IcingaPowerShellConfigItem()
         $ConfigKey
     );
 
-    return ([bool]($ConfigObject.PSObject.Properties.Name -eq $ConfigKey) -eq $TRUE);
+    if ($null -eq $ConfigObject -Or [string]::IsNullOrEmpty($ConfigKey)) {
+        return $FALSE;
+    }
+
+    foreach ($entry in $ConfigObject.PSObject.Properties) {
+        if ($entry.Name.ToLower() -eq $ConfigKey.ToLower()) {
+            return $TRUE;
+        }
+    }
+
+    return $FALSE;
 }

--- a/lib/core/repository/Add-IcingaRepository.psm1
+++ b/lib/core/repository/Add-IcingaRepository.psm1
@@ -11,6 +11,8 @@ function Add-IcingaRepository()
         return;
     }
 
+    $Name = $Name.Replace('.', '-');
+
     if ([string]::IsNullOrEmpty($RemotePath)) {
         Write-IcingaConsoleError 'You have to provide a remote path for the repository';
         return;

--- a/lib/core/repository/Disable-IcingaRepository.psm1
+++ b/lib/core/repository/Disable-IcingaRepository.psm1
@@ -9,6 +9,8 @@ function Disable-IcingaRepository()
         return;
     }
 
+    $Name = $Name.Replace('.', '-');
+
     $CurrentRepositories = Get-IcingaPowerShellConfig -Path ([string]::Format('Framework.Repository.Repositories.{0}', $Name));
 
     if ($null -eq $CurrentRepositories) {

--- a/lib/core/repository/Enable-IcingaRepository.psm1
+++ b/lib/core/repository/Enable-IcingaRepository.psm1
@@ -9,6 +9,8 @@ function Enable-IcingaRepository()
         return;
     }
 
+    $Name = $Name.Replace('.', '-');
+
     $CurrentRepositories = Get-IcingaPowerShellConfig -Path ([string]::Format('Framework.Repository.Repositories.{0}', $Name));
 
     if ($null -eq $CurrentRepositories) {

--- a/lib/core/repository/New-IcingaRepository.psm1
+++ b/lib/core/repository/New-IcingaRepository.psm1
@@ -12,6 +12,8 @@ function New-IcingaRepository()
         return;
     }
 
+    $Name = $Name.Replace('.', '-');
+
     if ([string]::IsNullOrEmpty($Path) -Or (Test-Path $Path) -eq $FALSE) {
         Write-IcingaConsoleError 'The provided path "{0}" does not exist' -Objects $Path;
         return;

--- a/lib/core/repository/Pop-IcingaRepository.psm1
+++ b/lib/core/repository/Pop-IcingaRepository.psm1
@@ -9,6 +9,8 @@ function Pop-IcingaRepository()
         return;
     }
 
+    $Name = $Name.Replace('.', '-');
+
     $CurrentRepositories = Get-IcingaPowerShellConfig -Path 'Framework.Repository.Repositories';
 
     if ($null -eq $CurrentRepositories) {

--- a/lib/core/repository/Push-IcingaRepository.psm1
+++ b/lib/core/repository/Push-IcingaRepository.psm1
@@ -12,6 +12,8 @@ function Push-IcingaRepository()
         return;
     }
 
+    $Name = $Name.Replace('.', '-');
+
     $CurrentRepositories = Get-IcingaPowerShellConfig -Path 'Framework.Repository.Repositories';
 
     if ($null -eq $CurrentRepositories) {

--- a/lib/core/repository/Read-IcingaRepositoryFile.psm1
+++ b/lib/core/repository/Read-IcingaRepositoryFile.psm1
@@ -10,6 +10,8 @@ function Read-IcingaRepositoryFile()
         return $null;
     }
 
+    $Name = $Name.Replace('.', '-');
+
     $Repository = Get-IcingaPowerShellConfig -Path ([string]::Format('Framework.Repository.Repositories.{0}', $Name));
 
     if ($null -eq $Repository) {

--- a/lib/core/repository/Remove-IcingaRepository.psm1
+++ b/lib/core/repository/Remove-IcingaRepository.psm1
@@ -9,6 +9,8 @@ function Remove-IcingaRepository()
         return;
     }
 
+    $Name = $Name.Replace('.', '-');
+
     $CurrentRepositories = Get-IcingaPowerShellConfig -Path 'Framework.Repository.Repositories';
 
     if ((Test-IcingaPowerShellConfigItem -ConfigObject $CurrentRepositories -ConfigKey $Name) -eq $FALSE) {

--- a/lib/core/repository/Sync-IcingaRepository.psm1
+++ b/lib/core/repository/Sync-IcingaRepository.psm1
@@ -16,6 +16,8 @@ function Sync-IcingaRepository()
         return;
     }
 
+    $Name = $Name.Replace('.', '-');
+
     if ($UseSCP -And $null -eq (Get-Command 'scp' -ErrorAction SilentlyContinue) -And $null -eq (Get-Command 'ssh' -ErrorAction SilentlyContinue)) {
         Write-IcingaConsoleWarning 'You cannot use SCP on this system, as SCP and/or SSH seem not to be installed';
         return;

--- a/lib/core/repository/Update-IcingaRepository.psm1
+++ b/lib/core/repository/Update-IcingaRepository.psm1
@@ -18,6 +18,9 @@ function Update-IcingaRepository()
     }
 
     if ([string]::IsNullOrEmpty($Name) -eq $FALSE) {
+
+        $Name = $Name.Replace('.', '-');
+
         if ((Test-IcingaPowerShellConfigItem -ConfigObject $CurrentRepositories -ConfigKey $Name) -eq $FALSE -And $CreateNew -eq $FALSE) {
             Write-IcingaConsoleError 'A repository with the given name "{0}" does not exist. Use "New-IcingaRepository" or "Sync-IcingaForWindowsRepository" to create a new one.' -Objects $Name;
             return;


### PR DESCRIPTION
Fixes repository names with dots (`.`) by replacing them with `-`, as otherwise the config parser will fail finding the config object