### PR TITLE
Fix: Exception on last uninstall message print

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
+## 1.7.0 (2021-11-09)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/16?closed=1)
+
+### Bugfixes
+
+* [#375](https://github.com/Icinga/icinga-powershell-framework/pull/375) Fixes exception on last message printed during `Uninstall-IcingaForWindows`, because the prior used function is no longer present at this point
+
 ## 1.6.1 (2021-09-15)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/21?closed=1)

--- a/lib/core/framework/Uninstall-IcingaForWindows.psm1
+++ b/lib/core/framework/Uninstall-IcingaForWindows.psm1
@@ -71,8 +71,8 @@ function Uninstall-IcingaForWindows()
     Remove-Module 'icinga-powershell-framework' -Force -ErrorAction SilentlyContinue;
 
     if ($HasErrors) {
-        Write-IcingaConsoleWarning 'Not all components could be removed. Please ensure no other PowerShell/Application is currently open and accessing Icinga for Windows files';
+        Write-Host 'Not all components could be removed. Please ensure no other PowerShell/Application is currently open and accessing Icinga for Windows files';
     } else {
-        Write-IcingaConsoleNotice 'Icinga for Windows was removed from this host.';
+        Write-Host 'Icinga for Windows was removed from this host.';
     }
 }


### PR DESCRIPTION
Fixes an exception on the last message output while running `Uninstall-IcingaForWindows`, as the used function is no longer available due to Framework uninstallation.

We now replaced the last messages with proper `Write-Host` output