### PR TITLE
Fix: IMC error handling on invalid JSON for install command/file

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#375](https://github.com/Icinga/icinga-powershell-framework/pull/375) Fixes exception on last message printed during `Uninstall-IcingaForWindows`, because the prior used function is no longer present at this point
+* [#376](https://github.com/Icinga/icinga-powershell-framework/pull/376) Fixes IMC error handling on invalid JSON for installation command/file
 
 ## 1.6.1 (2021-09-15)
 

--- a/lib/core/installer/tools/CustomConfig.psm1
+++ b/lib/core/installer/tools/CustomConfig.psm1
@@ -8,7 +8,7 @@ function Invoke-IcingaForWindowsManagementConsoleCustomConfig()
         $cmdConfig = $IcingaConfiguration[$cmd];
 
         if ($cmd.Contains(':')) {
-            continue; # skip for now, as more complicated
+            continue;
         }
 
         $cmdArguments = @{
@@ -22,6 +22,14 @@ function Invoke-IcingaForWindowsManagementConsoleCustomConfig()
             $cmdArguments.Add('DefaultInput', $cmdConfig.Selection)
         }
 
-        &$cmd @cmdArguments;
+        try {
+            &$cmd @cmdArguments;
+        } catch {
+            Enable-IcingaFrameworkConsoleOutput;
+            Write-IcingaConsoleError 'Failed to apply installation configuration of command "{0}" and argument list{1}because of the following error: "{2}"' -Objects $cmd, ($cmdArguments | Out-String), $_.Exception.Message;
+            return $FALSE;
+        }
     }
+
+    return $TRUE;
 }


### PR DESCRIPTION
Fixes error handling for IMC on automated installation with installation command or answer file, which will not abort the installation in case invalid JSON is provided or commands are used inside the command, not valid or exist on the system.

The system will write an error message and abort the installation in case of initial errors now.