### PR TITLE
Fix: Repository Hash generator

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -15,6 +15,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#375](https://github.com/Icinga/icinga-powershell-framework/pull/375) Fixes exception on last message printed during `Uninstall-IcingaForWindows`, because the prior used function is no longer present at this point
 * [#376](https://github.com/Icinga/icinga-powershell-framework/pull/376) Fixes IMC error handling on invalid JSON for installation command/file
+* [#381](https://github.com/Icinga/icinga-powershell-framework/issues/381) Fixes Repository Hash generator for new repositories, which always returned the same hash regardless of the files inside
 
 ## 1.6.1 (2021-09-15)
 

--- a/lib/core/repository/Get-IcingaRepositoryHash.psm1
+++ b/lib/core/repository/Get-IcingaRepositoryHash.psm1
@@ -9,11 +9,21 @@ function Get-IcingaRepositoryHash()
         return;
     }
 
-    $RepositoryFolder  = Get-ChildItem -Path $Path -Recurse;
-    [array]$FileHashes = @();
+    $RepositoryFolder = Get-ChildItem -Path $Path -Recurse;
+    $FileHashes       = New-Object -TypeName 'System.Text.StringBuilder';
 
     foreach ($entry in $RepositoryFolder) {
-        $FileHashes += (Get-FileHash -Path $entry.FullName -Algorithm SHA256).Hash;
+        $FileHash = (Get-FileHash -Path $entry.FullName -Algorithm SHA256).Hash;
+
+        if ([string]::IsNullOrEmpty($FileHash)) {
+            continue;
+        }
+
+        if ($FileHashes.Length -ne 0) {
+            $FileHashes.Append('+') | Out-Null;
+        }
+
+        $FileHashes.Append($FileHash) | Out-Null;
     }
 
     $HashAlgorithm = [System.Security.Cryptography.HashAlgorithm]::Create('SHA256');


### PR DESCRIPTION
Fixes the hash generator for the repository hash, which always returned the same hash.

Fixes #381