### PR TITLE
Fix: Use alias for args name on config generation

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#377](https://github.com/Icinga/icinga-powershell-framework/issues/377) Fixes overhead for testing of modules being loaded, which returned invalid path values and wrong exceptions, which was unnecessary in first place
 * [#381](https://github.com/Icinga/icinga-powershell-framework/issues/381) Fixes Repository Hash generator for new repositories, which always returned the same hash regardless of the files inside
 * [#386](https://github.com/Icinga/icinga-powershell-framework/pull/386) Fixes check command config generator for Icinga Director baskets/Icinga 2 conf files, in case we are using a check command with an alias as reference to a new name of a check command
+* [#387](https://github.com/Icinga/icinga-powershell-framework/pull/387) Fixes config generator to use alias names for command arguments/parameters in case available instead of the real name
 
 ### Enhancements
 

--- a/lib/core/tools/Convert-IcingaCheckArgumentToPSObject.psm1
+++ b/lib/core/tools/Convert-IcingaCheckArgumentToPSObject.psm1
@@ -1,7 +1,8 @@
 function Convert-IcingaCheckArgumentToPSObject()
 {
     param (
-        $Parameter = $null
+        $Parameter    = $null,
+        $CheckCommand = $null
     );
 
     $ParamValue = New-Object -TypeName PSObject;
@@ -10,11 +11,22 @@ function Convert-IcingaCheckArgumentToPSObject()
         return $ParamValue;
     }
 
+    $ParameterName = $Parameter.name;
+
+    if ([string]::IsNullOrEmpty($CheckCommand) -eq $FALSE) {
+        $CmdData = Get-Command $CheckCommand;
+        if ($CmdData.Parameters.ContainsKey($ParameterName)) {
+            if ($CmdData.Parameters[$ParameterName].Aliases.Count -ne 0) {
+                $ParameterName = $CmdData.Parameters[$ParameterName].Aliases[0];
+            }
+        }
+    }
+
     $ParamValue | Add-Member -MemberType NoteProperty -Name 'type'                   -Value (New-Object -TypeName PSObject);
     $ParamValue | Add-Member -MemberType NoteProperty -Name 'Description'            -Value (New-Object -TypeName PSObject);
     $ParamValue | Add-Member -MemberType NoteProperty -Name 'Attributes'             -Value (New-Object -TypeName PSObject);
     $ParamValue | Add-Member -MemberType NoteProperty -Name 'position'               -Value $Parameter.position;
-    $ParamValue | Add-Member -MemberType NoteProperty -Name 'Name'                   -Value $Parameter.name;
+    $ParamValue | Add-Member -MemberType NoteProperty -Name 'Name'                   -Value $ParameterName;
     $ParamValue | Add-Member -MemberType NoteProperty -Name 'required'               -Value $Parameter.required;
     $ParamValue.type | Add-Member -MemberType NoteProperty -Name 'name'              -Value $Parameter.type.name;
     $ParamValue.Description | Add-Member -MemberType NoteProperty -Name 'Text'       -Value $Parameter.Description.Text;

--- a/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
+++ b/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
@@ -183,7 +183,7 @@ function Get-IcingaCheckCommandConfig()
                     return;
                 }
             }
-            $CheckParamList += (Convert-IcingaCheckArgumentToPSObject -Parameter $entry);
+            $CheckParamList += (Convert-IcingaCheckArgumentToPSObject -Parameter $entry -CheckCommand $check);
         }
 
         foreach ($arg in $ParameterList.Keys) {
@@ -397,7 +397,7 @@ function Get-IcingaCheckCommandConfig()
         $CheckParamList  = @( $ThresholdIntervalArg );
 
         foreach ($entry in $Data.parameters.parameter) {
-            $CheckParamList += (Convert-IcingaCheckArgumentToPSObject -Parameter $entry);
+            $CheckParamList += (Convert-IcingaCheckArgumentToPSObject -Parameter $entry -CheckCommand $check);
         }
 
         foreach ($parameter in $CheckParamList) {


### PR DESCRIPTION
In case we are using aliases for command arguments/parameters, we should always use the first alias we find as argument instead of using the real name.