### PR TITLE
Feature: Adds support to read EventLog for logs

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -24,6 +24,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Enhancements
 
 * [#383](https://github.com/Icinga/icinga-powershell-framework/pull/383) Moves the components REST-Api [icinga-powershell-restapi](https://icinga.com/docs/icinga-for-windows/latest/restapi/doc/01-Introduction/) and API-Checks [icinga-powershell-apichecks](https://icinga.com/docs/icinga-for-windows/latest/apichecks/doc/01-Introduction/) directly into the Framework
+* [#392](https://github.com/Icinga/icinga-powershell-framework/pull/392) Adds support to read logs from Windows EventLog while using `Read-IcingaAgentLogFile`
 
 ## 1.6.1 (2021-09-15)
 

--- a/lib/core/icingaagent/readers/Read-IcingaAgentLogFile.psm1
+++ b/lib/core/icingaagent/readers/Read-IcingaAgentLogFile.psm1
@@ -1,10 +1,53 @@
 function Read-IcingaAgentLogFile()
 {
-    $Logfile = Join-Path -Path (Get-IcingaAgentLogDirectory) -ChildPath 'icinga2.log';
-    if ((Test-Path $Logfile) -eq $FALSE) {
-        Write-IcingaConsoleError 'Icinga 2 logfile not present. Unable to load it';
-        return;
-    }
+    if ((Test-IcingaAgentFeatureEnabled -Feature 'windowseventlog') -And ([version](Get-IcingaAgentVersion).Full) -ge (New-IcingaVersionObject -Version '2.13.0')) {
 
-    Get-Content -Path $Logfile -Tail 20 -Wait;
+        # Icinga 2.13.0 and beyond will log directly into the EventLog
+
+        $LastEvent   = $null;
+        $LastMessage = $null;
+        $LastId      = $null;
+
+        while ($TRUE) {
+            $IcingaEvents = Get-WinEvent -LogName Application -MaxEvents 500 -ErrorAction Stop | Sort-Object { $_.TimeCreated };
+
+            foreach ($event in $IcingaEvents) {
+
+                if ($event.ProviderName -ne 'Icinga 2') {
+                    continue;
+                }
+
+                if ($null -ne $LastEvent -And $event.TimeCreated -lt $LastEvent) {
+                    continue;
+                }
+
+                if ($event.TimeCreated -eq $LastEvent -And (Get-StringSha1 -Content $event.Message) -eq $LastMessage -And $event.Id -eq $LastId) {
+                    continue;
+                }
+
+                $LastEvent   = [DateTime]$event.TimeCreated;
+                $LastMessage = (Get-StringSha1 -Content $event.Message);
+                $LastId      = $event.Id;
+                $ForeColor   = 'White';
+
+                if ($event.Level -eq 3) { # Warning
+                    $ForeColor = 'DarkYellow';
+                } elseif ($event.Level -eq 2) { # Error
+                    $ForeColor = 'Red';
+                }
+
+                Write-IcingaConsolePlain -Message '[{0}] {1}' -Objects $event.TimeCreated, $event.Message -ForeColor $ForeColor;
+            }
+
+            Start-Sleep -Seconds 1;
+        }
+    } else {
+        $Logfile = Join-Path -Path (Get-IcingaAgentLogDirectory) -ChildPath 'icinga2.log';
+        if ((Test-Path $Logfile) -eq $FALSE) {
+            Write-IcingaConsoleError 'Icinga 2 logfile not present. Unable to load it';
+            return;
+        }
+
+        Get-Content -Path $Logfile -Tail 20 -Wait;
+    }
 }


### PR DESCRIPTION
Starting with Icinga 2.13.0, the Agent will write to the Windows EventLog by default. Our `Read-IcingaAgentLogFile` Cmdlet will now support both and read from the EventLog if the feature is enabled and 2.13.0 or later is being installed