### PR TITLE
Fix: ThresholdInterval data type in plugin docs

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -20,6 +20,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#386](https://github.com/Icinga/icinga-powershell-framework/pull/386) Fixes check command config generator for Icinga Director baskets/Icinga 2 conf files, in case we are using a check command with an alias as reference to a new name of a check command
 * [#387](https://github.com/Icinga/icinga-powershell-framework/pull/387) Fixes config generator to use alias names for command arguments/parameters in case available instead of the real name
 * [#390](https://github.com/Icinga/icinga-powershell-framework/pull/390) Fixes threshold interval time conversion by using `-ThresholdInterval` with values that cause the used `TimeSpan` object to move from minutes to hours, like `60m` and `1h`
+* [#395](https://github.com/Icinga/icinga-powershell-framework/issues/395) Fixes `-ThresholdInterval` data type inside auto generated docs for plugins, which was of type `Object`, but should be of type `String`
 
 ### Enhancements
 

--- a/lib/core/framework/Publish-IcingaPluginDocumentation.psm1
+++ b/lib/core/framework/Publish-IcingaPluginDocumentation.psm1
@@ -124,7 +124,7 @@ function Publish-IcingaPluginDocumentation()
                 Add-Content -Path $PluginDescriptionFile -Value $TableContent;
             }
 
-            Add-Content -Path $PluginDescriptionFile -Value '| ThresholdInterval | Object |  |  | Change the value your defined threshold checks against from the current value to a collected time threshold of the Icinga for Windows daemon, as described [here](https://icinga.com/docs/icinga-for-windows/latest/doc/service/10-Register-Service-Checks/). An example for this argument would be 1m or 15m which will use the average of 1m or 15m for monitoring. |';
+            Add-Content -Path $PluginDescriptionFile -Value '| ThresholdInterval | String |  |  | Change the value your defined threshold checks against from the current value to a collected time threshold of the Icinga for Windows daemon, as described [here](https://icinga.com/docs/icinga-for-windows/latest/doc/service/10-Register-Service-Checks/). An example for this argument would be 1m or 15m which will use the average of 1m or 15m for monitoring. |';
         }
 
         if ($null -ne $PluginHelp.examples) {


### PR DESCRIPTION
Fixes `-ThresholdInterval` data type inside auto generated docs for plugins, which was of type `Object`, but should be of type `String`

Fixes #395