### PR TITLE
Fix: Removes String.Builder output while creating new components

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
+## 1.8.0 (2022-02-08)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/19?closed=1)
+
+### Bugfixes
+
+* [#398](https://github.com/Icinga/icinga-powershell-framework/pull/398) Fixes String.Builder object output, while creating new components by using `New-IcingaForWindowsComponent`
+
 ## 1.7.0 (2021-11-09)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/16?closed=1)

--- a/lib/core/dev/Write-IcingaForWindowsComponentManifest.psm1
+++ b/lib/core/dev/Write-IcingaForWindowsComponentManifest.psm1
@@ -50,17 +50,17 @@ function Write-IcingaForWindowsComponentManifest()
                 [int]$CurrentIndex = 0;
                 foreach ($module in $Value) {
                     $CurrentIndex += 1;
-                    $ContentString.Append('@{ ');
+                    $ContentString.Append('@{ ') | Out-Null;
 
                     foreach ($dependency in $module.Keys) {
                         $DependencyValue = $module[$dependency];
 
-                        $ContentString.Append([string]::Format("{0} = '{1}'; ", $dependency, $DependencyValue));
+                        $ContentString.Append([string]::Format("{0} = '{1}'; ", $dependency, $DependencyValue)) | Out-Null;
                     }
-                    $ContentString.Append('}');
+                    $ContentString.Append('}') | Out-Null;
 
                     if ($CurrentIndex -ne $Value.Count) {
-                        $ContentString.Append(",`r`n        ");
+                        $ContentString.Append(",`r`n        ") | Out-Null;
                     }
                 }
 
@@ -73,7 +73,7 @@ function Write-IcingaForWindowsComponentManifest()
         Write-IcingaFileSecure -File (Join-Path -Path $ModuleDir -ChildPath ([string]::Format('{0}.psd1', $ModuleName))) -Value $ManifestFileData;
     }
 
-    $ContentString.Clear();
+    $ContentString.Clear() | Out-Null;
 
     [array]$ManifestContent = Get-Content -Path (Join-Path -Path $ModuleDir -ChildPath ([string]::Format('{0}.psd1', $ModuleName)));
 


### PR DESCRIPTION
Fixes String.Builder object output, while creating new components by using `New-IcingaForWindowsComponent`