### PR TITLE
Fix: Repo hash generator causes file hashes to never compare

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#398](https://github.com/Icinga/icinga-powershell-framework/pull/398) Fixes String.Builder object output, while creating new components by using `New-IcingaForWindowsComponent`
+* [#399](https://github.com/Icinga/icinga-powershell-framework/issues/399) Fixes repository file hash generator, which now only includes .zip and .msi files, which otherwise turned into invalid hashes because of the repository index file always changing based on the assigned hash
 * [#401](https://github.com/Icinga/icinga-powershell-framework/pull/401) Fixes the repository manager by now using Icinga WebRequests instead of Windows WebRequests, allowing the usage of the internal proxy feature
 
 ## 1.7.0 (2021-11-09)

--- a/lib/core/repository/Get-IcingaRepositoryHash.psm1
+++ b/lib/core/repository/Get-IcingaRepositoryHash.psm1
@@ -9,7 +9,7 @@ function Get-IcingaRepositoryHash()
         return;
     }
 
-    $RepositoryFolder = Get-ChildItem -Path $Path -Recurse;
+    $RepositoryFolder = Get-ChildItem -Path $Path -Recurse -Include '*.zip', '*.msi';
     $FileHashes       = New-Object -TypeName 'System.Text.StringBuilder';
 
     foreach ($entry in $RepositoryFolder) {


### PR DESCRIPTION
Fixes repository file hash generator, which now only includes .zip and .msi files, which otherwise turned into invalid hashes because of the repository index file always changing based on the assigned hash, resulting in a different repository hash

Fixes #399