### PR TITLE
Fix: Repository Manager is not using Icinga Web-Requests

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -11,9 +11,14 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/19?closed=1)
 
+## 1.7.1 (2021-11-11)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/22?closed=1)
+
 ### Bugfixes
 
 * [#398](https://github.com/Icinga/icinga-powershell-framework/pull/398) Fixes String.Builder object output, while creating new components by using `New-IcingaForWindowsComponent`
+* [#401](https://github.com/Icinga/icinga-powershell-framework/pull/401) Fixes the repository manager by now using Icinga WebRequests instead of Windows WebRequests, allowing the usage of the internal proxy feature
 
 ## 1.7.0 (2021-11-09)
 

--- a/lib/core/repository/Read-IcingaRepositoryFile.psm1
+++ b/lib/core/repository/Read-IcingaRepositoryFile.psm1
@@ -49,7 +49,7 @@ function Read-IcingaRepositoryFile()
                 $RepoPath = (Join-WebPath -Path $Repository.RemotePath -ChildPath 'ifw.repo.json');
             }
 
-            $WebContent = Invoke-WebRequest -UseBasicParsing -Uri $RepoPath;
+            $WebContent = Invoke-IcingaWebRequest -UseBasicParsing -Uri $RepoPath;
 
             if ($null -ne $WebContent) {
                 if ($WebContent.RawContent.Contains('application/octet-stream')) {

--- a/lib/core/repository/Sync-IcingaRepository.psm1
+++ b/lib/core/repository/Sync-IcingaRepository.psm1
@@ -97,10 +97,10 @@ function Sync-IcingaRepository()
     } else { # Sync Source is web path
         $ProgressPreference = "SilentlyContinue";
         try {
-            Invoke-WebRequest -USeBasicParsing -Uri $Source -OutFile $RepoFile;
+            Invoke-IcingaWebRequest -UseBasicParsing -Uri $Source -OutFile $RepoFile;
         } catch {
             try {
-                Invoke-WebRequest -USeBasicParsing -Uri (Join-WebPath -Path $Source -ChildPath 'ifw.repo.json') -OutFile $RepoFile;
+                Invoke-IcingaWebRequest -UseBasicParsing -Uri (Join-WebPath -Path $Source -ChildPath 'ifw.repo.json') -OutFile $RepoFile;
             } catch {
                 Write-IcingaConsoleError 'Unable to download repository file from "{0}". Exception: "{1}"' -Objects $Source, $_.Exception.Message;
                 $Success = Remove-Item -Path $TmpDir -Recurse -Force;
@@ -145,7 +145,7 @@ function Sync-IcingaRepository()
 
                 try {
                     Write-IcingaConsoleNotice 'Syncing repository component "{0}" as file "{1}" into temp directory' -Objects $component, $package.Location;
-                    Invoke-WebRequest -USeBasicParsing -Uri $DownloadLink -OutFile $TargetLocation;
+                    Invoke-IcingaWebRequest -USeBasicParsing -Uri $DownloadLink -OutFile $TargetLocation;
                 } catch {
                     Write-IcingaConsoleError 'Failed to download repository component "{0}". Exception: "{1}"' -Objects $DownloadLink, $_.Exception.Message;
                     continue;


### PR DESCRIPTION
Fixes the repository manager by now using Icinga WebRequests instead of Windows WebRequests, allowing the usage of the internal proxy feature.