### PR TITLE
Fix: Memory leak on EventLog reader

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -11,6 +11,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/19?closed=1)
 
+### Bugfixes
+
+* [#403](https://github.com/Icinga/icinga-powershell-framework/pull/403) Fixes memory leak on newly EventLog reader for CLI event stream
+
 ## 1.7.1 (2021-11-11)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/22?closed=1)

--- a/lib/core/framework/Read-IcingaWindowsEventLog.psm1
+++ b/lib/core/framework/Read-IcingaWindowsEventLog.psm1
@@ -66,5 +66,7 @@ function Read-IcingaWindowsEventLog()
         }
 
         Start-Sleep -Seconds 1;
+        # Force PowerShell to call the garbage collector to free memory
+        [System.GC]::Collect();
     }
 }


### PR DESCRIPTION
With Icinga for Windows v1.7.0 we introdocued a way to read EventLog entries as stream directly into the CLI.
If used for a long time, the memory consumption of this active shell will increase over time, as the Garbage Collector does not kick in.

This will fix the issue by forcing the GC to be called after each loop cycle.