### PR TITLE
Fix: REST-Api address argument not being used

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#402](https://github.com/Icinga/icinga-powershell-framework/pull/402) Fixes missing address attribute for REST-Api daemon, making it unable to change the listening address
 * [#403](https://github.com/Icinga/icinga-powershell-framework/pull/403) Fixes memory leak on newly EventLog reader for CLI event stream
 
 ## 1.7.1 (2021-11-11)

--- a/lib/daemons/RestAPI/daemon/New-IcingaForWindowsRESTApi.psm1
+++ b/lib/daemons/RestAPI/daemon/New-IcingaForWindowsRESTApi.psm1
@@ -3,6 +3,7 @@ function New-IcingaForWindowsRESTApi()
     # Allow us to parse the framework global data to this thread
     param (
         $IcingaDaemonData,
+        [string]$Address  = '',
         $Port,
         $RootFolder,
         $CertFile,

--- a/lib/daemons/RestAPI/daemon/Start-IcingaWindowsRESTApi.psm1
+++ b/lib/daemons/RestAPI/daemon/Start-IcingaWindowsRESTApi.psm1
@@ -71,6 +71,7 @@ function Start-IcingaWindowsRESTApi()
         -Command 'New-IcingaForWindowsRESTApi' `
         -CmdParameters @{
             'IcingaDaemonData' = $global:IcingaDaemonData;
+            'Address'          = $Address;
             'Port'             = $Port;
             'RootFolder'       = $RootFolder;
             'CertFile'         = $CertFile;


### PR DESCRIPTION
Fixes missing address attribute for REST-Api daemon, making it unable to change the listening address

Fixes #402