### PR TITLE
Fix: Removes unnecessary module import

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -15,6 +15,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#402](https://github.com/Icinga/icinga-powershell-framework/pull/402) Fixes missing address attribute for REST-Api daemon, making it unable to change the listening address
 * [#403](https://github.com/Icinga/icinga-powershell-framework/pull/403) Fixes memory leak on newly EventLog reader for CLI event stream
+* [#407](https://github.com/Icinga/icinga-powershell-framework/pull/407) Removes unnecessary module import inside `Invoke-IcingaNamespaceCmdlets`
 
 ## 1.7.1 (2021-11-11)
 

--- a/doc/100-General/20-Eventlog.md
+++ b/doc/100-General/20-Eventlog.md
@@ -1,4 +1,4 @@
-# Icinga for Windows Eventlog Documentation
+# Framework Eventlog Documentation
 
 Below you will find a list of EventId's which are exported by this module. The short and detailed message are both written directly into the eventlog. This documentation shall simply provide a summary of available EventId's
 
@@ -8,17 +8,77 @@ Below you will find a list of EventId's which are exported by this module. The s
 | --- | --- | --- |
 | Information | Generic debug message issued by the Framework or its components | The Framework or is components can issue generic debug message in case the debug log is enabled. Please ensure to disable it, if not used. You can do so with the command "Disable-IcingaFrameworkDebugMode" |
 
+## Event Id 1001
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Warning | Icinga for Windows deprecation warning | Icinga for Windows or one of its components executed a function or method, which is flagged as deprecated. Please modify your code or contact the responsible developer to update the component to no longer user this deprecated function or method. |
+
+## Event Id 1100
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Error | Corrupt Icinga for Windows configuration | Your Icinga for Windows configuration file was corrupt and could not be read successfully. A new configuration file was created and the old one renamed for review, to keep your settings available. |
+
+## Event Id 1101
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Warning | Unable to update Icinga for Windows file | Icinga for Windows could not update the specified file after several attempts, because another process is locking it. Modifications made on the file have not been persisted. |
+
+## Event Id 1102
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Warning | Unable to read Icinga for Windows content file | Icinga for Windows could not read the specified file after several attempts, because another process is locking the file. Icinga for Windows terminated itself to prevent damage to this file. |
+
+## Event Id 1103
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Error | Failed to load Icinga for Windows namespace content | Icinga for Windows was unable to run a specific command within the namespace content, to load additional extensions and component data into Icinga for Windows. |
+
+## Event Id 1400
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Error | Icinga for Windows background daemon not found | Icinga for Windows could not find the Function or Cmdlet for the specified background daemon. The daemon was not loaded. |
+
 ## Event Id 1500
 
 | Category | Short Message | Detailed Message |
 | --- | --- | --- |
-| Error | Failed to securely establish a communiation between this server and the client | A client connection could not be established to this server. This issue is mostly caused by using Self-Signed/Icinga 2 Agent certificates for the server and the client not trusting the certificate. To resolve this issue, either use trusted certificates signed by your trusted CA or setup the client to accept untrusted certificates |
+| Error | Failed to securely establish a communication between this server and the client | A client connection could not be established to this server. This issue is mostly caused by using Self-Signed/Icinga 2 Agent certificates for the server and the client not trusting the certificate. To resolve this issue, either use trusted certificates signed by your trusted CA or setup the client to accept untrusted certificates |
 
 ## Event Id 1501
 
 | Category | Short Message | Detailed Message |
 | --- | --- | --- |
 | Error | Client connection was interrupted because of invalid SSL stream | A client connection was terminated by the Framework because no secure SSL handshake could be established. This issue in general is followed by EventId 1500. |
+
+## Event Id 1502
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Error | Unable to create PowerShell RunSpace in JEA context | A PowerShell RunSpace for background threads could not be created, as the required Icinga for Windows session configuration file could not be found. Use "Install-IcingaJEAProfile" to resolve this problem. |
+
+## Event Id 1503
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Error | Unable to start Icinga for Windows service | Unable to start Icinga for Windows service, as the JEA session created by the service is still active. Run "Restart-IcingaWindowsService" to restart the Icinga for Windows service, while running in JEA context to prevent this issue. |
+
+## Event Id 1504
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Error | Icinga for Windows JEA context vanished | The Icinga for Windows JEA session is no longer available. It might have either crashed or get terminated by user actions, like restarting the WinRM service. |
+
+## Event Id 1505
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Warning | Icinga for Windows JEA context not available | The Icinga for Windows JEA session is no longer available and is attempted to be restarted on the system. This could have either happenend due to a crash or a user action, like restarting the WinRM service. |
 
 ## Event Id 1550
 
@@ -38,6 +98,12 @@ Below you will find a list of EventId's which are exported by this module. The s
 | --- | --- | --- |
 | Error | Failed to parse use credentials from base64 encoding | Provided user credentials encoded as base64 could not be converted to domain, user and password objects. |
 
+## Event Id 1553
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Error | Failed to query Icinga check over internal REST-Api check handler | A service check could not be executed by using the internal REST-Api check handler. The check either ran into a timeout or could not be processed. Maybe the check was not registered to be allowed for being executed. Further details can be found below. |
+
 ## Event Id 1560
 
 | Category | Short Message | Detailed Message |
@@ -49,3 +115,9 @@ Below you will find a list of EventId's which are exported by this module. The s
 | Category | Short Message | Detailed Message |
 | --- | --- | --- |
 | Error | Failed to authenticate user with given credentials | A web client trying to authenticate failed as the provided user credentials could not be verified. |
+
+## Event Id 1600
+
+| Category | Short Message | Detailed Message |
+| --- | --- | --- |
+| Error | Exception on function calls in JEA context | An exception occurred while executing Icinga for Windows code inside a JEA context. |

--- a/lib/core/framework/Invoke-IcingaNamespaceCmdlets.psm1
+++ b/lib/core/framework/Invoke-IcingaNamespaceCmdlets.psm1
@@ -15,15 +15,14 @@ function Invoke-IcingaNamespaceCmdlets()
     foreach ($Cmdlet in $CommandList) {
         try {
             $CommandName = $Cmdlet.Name;
-            Import-Module $Cmdlet.Module.Path -WarningAction SilentlyContinue -ErrorAction Stop;
+            $Content     = (& $CommandName);
 
-            $Content = (& $CommandName);
             Add-IcingaHashtableItem `
                 -Hashtable $CommandConfig `
                 -Key $Cmdlet.Name `
                 -Value $Content | Out-Null;
         } catch {
-            # TODO: Add event log logging on exceptions
+            Write-IcingaEventMessage -EventId 1103 -Namespace 'Framework' -Objects $CommandName, $_.Exception.Message;
         }
     }
 

--- a/lib/core/logging/Icinga_EventLog_Enums.psm1
+++ b/lib/core/logging/Icinga_EventLog_Enums.psm1
@@ -38,6 +38,12 @@ if ($null -eq $IcingaEventLogEnums -Or $IcingaEventLogEnums.ContainsKey('Framewo
                 'Details'   = 'Icinga for Windows could not read the specified file after several attempts, because another process is locking the file. Icinga for Windows terminated itself to prevent damage to this file.';
                 'EventId'   = 1102;
             };
+            1103 = @{
+                'EntryType' = 'Error';
+                'Message'   = 'Failed to load Icinga for Windows namespace content';
+                'Details'   = 'Icinga for Windows was unable to run a specific command within the namespace content, to load additional extensions and component data into Icinga for Windows.';
+                'EventId'   = 1103;
+            };
             1400 = @{
                 'EntryType' = 'Error';
                 'Message'   = 'Icinga for Windows background daemon not found';


### PR DESCRIPTION
Removes not required import of PowerShell modules for `Invoke-IcingaNamespaceCmdlets`, as by the time we fetch the content the specified module must be loaded already.

In addition adds proper error output in case something goes wrong. Errors are written directly into the EventLog.