### PR TITLE
Fix: Performance for Add-Type testing

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -17,6 +17,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#403](https://github.com/Icinga/icinga-powershell-framework/pull/403) Fixes memory leak on newly EventLog reader for CLI event stream
 * [#407](https://github.com/Icinga/icinga-powershell-framework/pull/407) Removes unnecessary module import inside `Invoke-IcingaNamespaceCmdlets`
 
+### Enhancements
+
+* [#388](https://github.com/Icinga/icinga-powershell-framework/issues/388) Improves performance for testing if `Add-Type` functions have been added, by adding an internal test for newly introduced environment variables within a PowerShell session
+
 ## 1.7.1 (2021-11-11)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/22?closed=1)

--- a/lib/core/framework/Get-IcingaPrivateEnvironmentVariable.psm1
+++ b/lib/core/framework/Get-IcingaPrivateEnvironmentVariable.psm1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    Reads a private environment variable from Icinga for Windows
+    of the current PowerShell session
+.DESCRIPTION
+    Reads a private environment variable from Icinga for Windows
+    of the current PowerShell session
+.PARAMETER Name
+    The name of the variable to load the content from
+.EXAMPLE
+    Get-IcingaPrivateEnvironmentVariable -Name 'AddTypeFunctions';
+.NOTES
+General notes
+#>
+function Get-IcingaPrivateEnvironmentVariable()
+{
+    param (
+        [string]$Name
+    );
+
+    if ([string]::IsNullOrEmpty($Name)) {
+        return $null;
+    }
+
+    # Setup the environments in case not present already
+    New-IcingaEnvironmentVariable;
+
+    if ($global:Icinga.Private.ContainsKey($Name) -eq $FALSE) {
+        return $null;
+    }
+
+    return $global:Icinga.Private[$Name];
+}

--- a/lib/core/framework/New-IcingaCheckSchedulerEnvironment.psm1
+++ b/lib/core/framework/New-IcingaCheckSchedulerEnvironment.psm1
@@ -44,17 +44,5 @@ function New-IcingaCheckSchedulerEnvironment()
         $IcingaDaemonData.IcingaThreadContent.Add('Scheduler', @{ });
     }
 
-    if ($null -eq $global:Icinga) {
-        $global:Icinga = @{ };
-    }
-
-    if ($global:Icinga.ContainsKey('CheckResults') -eq $FALSE) {
-        $global:Icinga.Add('CheckResults', @());
-    }
-    if ($global:Icinga.ContainsKey('PerfData') -eq $FALSE) {
-        $global:Icinga.Add('PerfData', @());
-    }
-    if ($global:Icinga.ContainsKey('CheckData') -eq $FALSE) {
-        $global:Icinga.Add('CheckData', @{ });
-    }
+    New-IcingaEnvironmentVariable;
 }

--- a/lib/core/framework/New-IcingaEnvironmentVariable.psm1
+++ b/lib/core/framework/New-IcingaEnvironmentVariable.psm1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+    Creates all environment variables for Icinga for Windows for the
+    PowerShell session
+.DESCRIPTION
+    Creates all environment variables for Icinga for Windows for the
+    PowerShell session
+.EXAMPLE
+    New-IcingaEnvironmentVariable;
+#>
+
+function New-IcingaEnvironmentVariable()
+{
+    if ($null -eq $global:Icinga) {
+        $global:Icinga = @{ };
+    }
+
+    # Session specific configuration for this shell
+    if ($global:Icinga.ContainsKey('Private') -eq $FALSE) {
+        $global:Icinga.Add('Private', @{ });
+    }
+
+    # Shared configuration for all threads
+    if ($global:Icinga.ContainsKey('Public') -eq $FALSE) {
+        $global:Icinga.Add('Public', [hashtable]::Synchronized(@{ }));
+    }
+
+    if ($global:Icinga.ContainsKey('CheckResults') -eq $FALSE) {
+        $global:Icinga.Add('CheckResults', @());
+    }
+    if ($global:Icinga.ContainsKey('PerfData') -eq $FALSE) {
+        $global:Icinga.Add('PerfData', @());
+    }
+    if ($global:Icinga.ContainsKey('CheckData') -eq $FALSE) {
+        $global:Icinga.Add('CheckData', @{ });
+    }
+}

--- a/lib/core/framework/Set-IcingaPrivateEnvironmentVariable.psm1
+++ b/lib/core/framework/Set-IcingaPrivateEnvironmentVariable.psm1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+    Sets a private variable for the Icinga for Windows environment
+    to use within the current PowerShell Session
+.DESCRIPTION
+    Sets a private variable for the Icinga for Windows environment
+    to use within the current PowerShell Session
+.PARAMETER Name
+    The name of the variable
+.PARAMETER Value
+    The value the variable will be assigned with
+.EXAMPLE
+    Set-IcingaPrivateEnvironmentVariable -Name 'AddTypeFunctions' -Value @{ 'IcingaDiskAttributes', $TRUE };
+#>
+
+function Set-IcingaPrivateEnvironmentVariable()
+{
+    param (
+        [string]$Name,
+        $Value
+    );
+
+    if ([string]::IsNullOrEmpty($Name)) {
+        return;
+    }
+
+    # Setup the environments in case not present already
+    New-IcingaEnvironmentVariable;
+
+    if ($global:Icinga.Private.ContainsKey($Name) -eq $FALSE) {
+        $global:Icinga.Private.Add($Name, $Value);
+        return;
+    }
+
+    $global:Icinga.Private[$Name] = $Value;
+}

--- a/lib/core/tools/Test-IcingaAddTypeExist.psm1
+++ b/lib/core/tools/Test-IcingaAddTypeExist.psm1
@@ -1,3 +1,15 @@
+<#
+.SYNOPSIS
+    Tests if a Add-Type function is already installed inside the current
+    PowerShell session
+.DESCRIPTION
+    Tests if a Add-Type function is already installed inside the current
+    PowerShell session
+.PARAMETER Type
+    The name of the function being added
+.EXAMPLE
+    Test-IcingaAddTypeExis -Type 'IcingaDiskAttributes';
+#>
 function Test-IcingaAddTypeExist()
 {
     param (
@@ -8,8 +20,22 @@ function Test-IcingaAddTypeExist()
         return $FALSE;
     }
 
+    [hashtable]$LoadedTypes = Get-IcingaPrivateEnvironmentVariable -Name 'AddTypeFunctions';
+
+    if ($null -eq $LoadedTypes) {
+        $LoadedTypes = @{ };
+    }
+
+    if ($LoadedTypes.ContainsKey($Type)) {
+        return $TRUE;
+    }
+
     foreach ($entry in [System.AppDomain]::CurrentDomain.GetAssemblies()) {
         if ($entry.GetTypes() -Match $Type) {
+            $LoadedTypes.Add($Type, $TRUE);
+
+            Set-IcingaPrivateEnvironmentVariable -Name 'AddTypeFunctions' -Value $LoadedTypes;
+
             return $TRUE;
         }
     }


### PR DESCRIPTION
With recent versions we added a feature to test if Add-Type functions are added to the current PowerShell session, ensuring that the same type is not re-added which caused errors on the error stack.

While the code works perfectly fine, it takes a long time for execution which causes the plugin `Invoke-IcingaCheckDiskHealth` for example, to take way longer than usual.

This PR prepares the future `Private` and `Public` section of the Icinga for Windows environment variables and adds an internal, quick test if a Add-Type function is already added to the current session, once being tested with the old behaviour.

This reduces the disk health plugin execution time after the first run from around 10 seconds to 2 seconds.

Fixes #388