### PR TITLE
Fix: Crash on wrong variable usage

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#403](https://github.com/Icinga/icinga-powershell-framework/pull/403) Fixes memory leak on newly EventLog reader for CLI event stream
 * [#407](https://github.com/Icinga/icinga-powershell-framework/pull/407) Removes unnecessary module import inside `Invoke-IcingaNamespaceCmdlets`
 * [#411](https://github.com/Icinga/icinga-powershell-framework/pull/411) Fixes Icinga Director error message output because of missing `[string]::Format()`
+* [#418](https://github.com/Icinga/icinga-powershell-framework/pull/418) Fixes crash on wrong variable usage introduced by [#411](https://github.com/Icinga/icinga-powershell-framework/pull/411)
 
 ### Enhancements
 

--- a/lib/apis/Get-IcingaDirectorSelfServiceTicket.psm1
+++ b/lib/apis/Get-IcingaDirectorSelfServiceTicket.psm1
@@ -48,7 +48,7 @@ function Get-IcingaDirectorSelfServiceTicket()
         $ErrorMessage = '';
         switch ($response.StatusCode) {
             404 {
-                $ErrorMessage = ([string]::Format('Failed to fetch certificate ticket for this host over Self-Service API. Please check that your Icinga Director Url "{1}" is valid and the provided API key "{0}" belongs to a Icinga host object.', $DirectorUrl, ApiKey));
+                $ErrorMessage = ([string]::Format('Failed to fetch certificate ticket for this host over Self-Service API. Please check that your Icinga Director Url "{1}" is valid and the provided API key "{0}" belongs to a Icinga host object.', $DirectorUrl, $ApiKey));
                 break;
             };
             500 {


### PR DESCRIPTION
Fixes a crash while generating the cache file, because of wrong variable usage introduced with #411.