### PR TITLE
Fix: Username has no length cap for JEA installation

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#403](https://github.com/Icinga/icinga-powershell-framework/pull/403) Fixes memory leak on newly EventLog reader for CLI event stream
 * [#407](https://github.com/Icinga/icinga-powershell-framework/pull/407) Removes unnecessary module import inside `Invoke-IcingaNamespaceCmdlets`
 * [#411](https://github.com/Icinga/icinga-powershell-framework/pull/411) Fixes Icinga Director error message output because of missing `[string]::Format()`
+* [#412](https://github.com/Icinga/icinga-powershell-framework/issues/412) Fixes possible defective state of the Icinga Agent by using a custom service user for JEA profiles which is larger than 20 digits
 * [#418](https://github.com/Icinga/icinga-powershell-framework/pull/418) Fixes crash on wrong variable usage introduced by [#411](https://github.com/Icinga/icinga-powershell-framework/pull/411)
 
 ### Enhancements

--- a/lib/core/jea/Install-IcingaJeaProfile.psm1
+++ b/lib/core/jea/Install-IcingaJeaProfile.psm1
@@ -13,6 +13,13 @@ function Install-IcingaJEAProfile()
         return;
     }
 
+    # Max length for the user name
+    if ($IcingaUser.Length -gt 20) {
+        Write-IcingaConsoleError 'The specified user name "{0}" is too long. The maximum character limit is 20 digits.' -Objects $IcingaUser;
+
+        return;
+    }
+
     Write-IcingaConsoleNotice 'Writing Icinga for Windows environment information as JEA profile'
     Write-IcingaJEAProfile -RebuildFramework:$RebuildFramework -AllowScriptBlocks:$AllowScriptBlocks;
     Write-IcingaConsoleNotice 'Registering Icinga for Windows JEA profile'

--- a/lib/core/windows/Install-IcingaSecurity.psm1
+++ b/lib/core/windows/Install-IcingaSecurity.psm1
@@ -12,6 +12,13 @@ function Install-IcingaSecurity()
         return;
     }
 
+    # Max length for the user name
+    if ($IcingaUser.Length -gt 20) {
+        Write-IcingaConsoleError 'The specified user name "{0}" is too long. The maximum character limit is 20 digits.' -Objects $IcingaUser;
+
+        return;
+    }
+
     Install-IcingaServiceUser -IcingaUser $IcingaUser;
     Install-IcingaJEAProfile -IcingaUser $IcingaUser -RebuildFramework:$RebuildFramework -AllowScriptBlocks:$AllowScriptBlocks -ConstrainedLanguage:$ConstrainedLanguage;
 

--- a/lib/core/windows/New-IcingaWindowsUser.psm1
+++ b/lib/core/windows/New-IcingaWindowsUser.psm1
@@ -13,6 +13,16 @@ function New-IcingaWindowsUser()
         };
     }
 
+    # Max length for the user name
+    if ($IcingaUser.Length -gt 20) {
+        Write-IcingaConsoleError 'The specified user name "{0}" is too long. The maximum character limit is 20 digits.' -Objects $IcingaUser;
+
+        return @{
+            'User' = $null;
+            'SID'  = $null;
+        };
+    }
+
     $UserMetadata = Get-IcingaWindowsUserMetadata;
     $UserConfig   = $null;
 


### PR DESCRIPTION
JEA profile installation can fail and cause the Icinga Agent to become defective, in case a username is used being longer than 20 digits.

Fixes #412