### PR TITLE
Fix: Version splitting returns "mayor" instead of "major"

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#291](https://github.com/Icinga/icinga-powershell-framework/issues/291) Fixes `Split-IcingaVersion` by returning data with naming `mayor` for the version instead of `major`. We will return both results to give developers time to adjust their code before removing the `mayor` object
 * [#379](https://github.com/Icinga/icinga-powershell-framework/issues/379) Fixes memory leak for Icinga for Windows by using a custom function being more aggressive on memory cleanup
 * [#402](https://github.com/Icinga/icinga-powershell-framework/pull/402) Fixes missing address attribute for REST-Api daemon, making it unable to change the listening address
 * [#403](https://github.com/Icinga/icinga-powershell-framework/pull/403) Fixes memory leak on newly EventLog reader for CLI event stream

--- a/lib/core/icingaagent/misc/Compare-IcingaVersions.psm1
+++ b/lib/core/icingaagent/misc/Compare-IcingaVersions.psm1
@@ -17,7 +17,7 @@ function Compare-IcingaVersions()
         $CurrentVersion = Get-IcingaAgentVersion;
     }
 
-    if ($requiredVersion.Mayor -gt $currentVersion.Mayor) {
+    if ($requiredVersion.Major -gt $currentVersion.Major) {
         return $FALSE;
     }
 

--- a/lib/core/icingaagent/misc/Split-IcingaVersion.psm1
+++ b/lib/core/icingaagent/misc/Split-IcingaVersion.psm1
@@ -4,10 +4,13 @@ function Split-IcingaVersion()
         [string]$Version
     );
 
+    # TODO: Allow developers to adjust their code from mayor to major naming
+    #       for the next releases and remove the mayor naming in the future
     if ([string]::IsNullOrEmpty($Version)) {
         return @{
             'Full'     = '';
             'Mayor'    = $null;
+            'Major'    = $null;
             'Minor'    = $null;
             'Fixes'    = $null;
             'Snapshot' = $null;
@@ -24,6 +27,7 @@ function Split-IcingaVersion()
     return @{
         'Full'     = $Version;
         'Mayor'    = [int]$IcingaVersion[0];
+        'Major'    = [int]$IcingaVersion[0];
         'Minor'    = [int]$IcingaVersion[1];
         'Fixes'    = [int]$IcingaVersion[2];
         'Snapshot' = $Snapshot;


### PR DESCRIPTION
Fixes the output value from `Split-IcingaVersion` by returning the object `major`  in addition to the wrong value `mayor`.

We will keep both outputs present for the moment, allowing developers to update their code.

Fixes #291