### PR TITLE
Fix: Sync-IcingaRepository can cause invalid JSON primitive

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#402](https://github.com/Icinga/icinga-powershell-framework/pull/402) Fixes missing address attribute for REST-Api daemon, making it unable to change the listening address
 * [#403](https://github.com/Icinga/icinga-powershell-framework/pull/403) Fixes memory leak on newly EventLog reader for CLI event stream
 * [#407](https://github.com/Icinga/icinga-powershell-framework/pull/407) Removes unnecessary module import inside `Invoke-IcingaNamespaceCmdlets`
+* [#409](https://github.com/Icinga/icinga-powershell-framework/issues/409) Fixes URL builder for `Sync-IcingaRepository` which will now properly test the JSON file and try a secondary fallback by pointing to the `ifw.repo.json` in case a URL is returning the directory listing instead
 * [#411](https://github.com/Icinga/icinga-powershell-framework/pull/411) Fixes Icinga Director error message output because of missing `[string]::Format()`
 * [#412](https://github.com/Icinga/icinga-powershell-framework/issues/412) Fixes possible defective state of the Icinga Agent by using a custom service user for JEA profiles which is larger than 20 digits
 * [#418](https://github.com/Icinga/icinga-powershell-framework/pull/418) Fixes crash on wrong variable usage introduced by [#411](https://github.com/Icinga/icinga-powershell-framework/pull/411)

--- a/lib/core/icingaagent/getters/Get-IcingaAgentMSIPackage.psm1
+++ b/lib/core/icingaagent/getters/Get-IcingaAgentMSIPackage.psm1
@@ -110,7 +110,7 @@ function Get-IcingaAgentMSIPackage()
     if ($SkipDownload -eq $FALSE) {
         $DownloadPath = Join-Path $Env:TEMP -ChildPath $UsePackage;
         Write-IcingaConsoleNotice ([string]::Format('Downloading Icinga 2 Agent installer "{0}" into temp directory "{1}"', $UsePackage, $DownloadPath));
-        Invoke-IcingaWebRequest -Uri (Join-WebPath -Path $Source -ChildPath $UsePackage) -OutFile $DownloadPath;
+        Invoke-IcingaWebRequest -Uri (Join-WebPath -Path $Source -ChildPath $UsePackage) -OutFile $DownloadPath | Out-Null;
     }
 
     return @{

--- a/lib/core/repository/Test-IcingaValidJSON.psm1
+++ b/lib/core/repository/Test-IcingaValidJSON.psm1
@@ -1,0 +1,23 @@
+function Test-IcingaValidJSON()
+{
+    param (
+        [string]$String = '',
+        [string]$File   = ''
+    );
+
+    if ([string]::IsNullOrEmpty($File) -eq $FALSE) {
+        if ((Test-Path $File) -eq $FALSE) {
+            return $FALSE;
+        }
+
+        $String = Get-Content -Path $File -Raw;
+    }
+    try {
+        # Test the conversion to JSON and return false on failure and true on success
+        ConvertFrom-Json -InputObject $String -ErrorAction Stop | Out-Null;
+    } catch {
+        return $FALSE;
+    }
+
+    return $TRUE;
+}


### PR DESCRIPTION
By using the `Sync-IcingaRepository` function, it might happen that in case the parent site is returning a file listing instead of an error page, the downloaded **repository** file is only the list of the files and not the proper JSON repo file.

Instead we now check the result properly and fallback by adding `ifw.repo.json` as it was intended before.

Fixes #409