### PR TITLE
Feature: Allow Force-Creation of certificates for Agent over IMC

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -26,6 +26,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Enhancements
 
 * [#388](https://github.com/Icinga/icinga-powershell-framework/issues/388) Improves performance for testing if `Add-Type` functions have been added, by adding an internal test for newly introduced environment variables within a PowerShell session
+* [#417](https://github.com/Icinga/icinga-powershell-framework/issues/417) Adds support to allow the force creation of Icinga Agent certificates, even when they are already present on the system over Icinga Management Console installation
 
 ## 1.7.1 (2021-11-11)
 

--- a/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
+++ b/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
@@ -22,6 +22,7 @@ function Start-IcingaForWindowsInstallation()
 
     # Certificate handler
     $CertificateType       = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectCertificate';
+    $CertificateForceGen   = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectForceCertificateGeneration';
     $CertificateTicket     = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaTicket';
     $CertificateCAFile     = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile';
 
@@ -65,6 +66,7 @@ function Start-IcingaForWindowsInstallation()
     $InstallPlugins        = $TRUE;
     $PluginPackageRelease  = $FALSE;
     $PluginPackageSnapshot = $FALSE;
+    $ForceCertificateGen   = $FALSE;
 
     if ([string]::IsNullOrEmpty($IcingaStableRepo) -eq $FALSE) {
         Add-IcingaRepository -Name 'Icinga Stable' -RemotePath $IcingaStableRepo -Force;
@@ -168,6 +170,10 @@ function Start-IcingaForWindowsInstallation()
         }
     }
 
+    if ($CertificateForceGen -eq 1) {
+        $ForceCertificateGen = $TRUE;
+    }
+
     if ($InstallAgent) {
         Set-IcingaPowerShellConfig -Path 'Framework.Icinga.AgentLocation' -Value $AgentInstallDir;
         Install-IcingaComponent -Name 'agent' -Version $AgentVersion -Confirm -Release;
@@ -185,7 +191,7 @@ function Start-IcingaForWindowsInstallation()
 
     # Only continue this, if our installation was successful
     if ((Get-IcingaAgentInstallation).Installed) {
-        if ((Install-IcingaAgentCertificates -Hostname $Hostname -Endpoint $IcingaCAServer -Port $IcingaPort -CACert $CertificateCAFile -Ticket $CertificateTicket) -eq $FALSE) {
+        if ((Install-IcingaAgentCertificates -Hostname $Hostname -Endpoint $IcingaCAServer -Port $IcingaPort -CACert $CertificateCAFile -Ticket $CertificateTicket -Force:$ForceCertificateGen) -eq $FALSE) {
             Disable-IcingaAgentFeature 'api';
             Write-IcingaConsoleWarning `
                 -Message '{0}{1}{2}{3}{4}' `

--- a/lib/core/installer/menu/installation/AdvancedEntries.psm1
+++ b/lib/core/installer/menu/installation/AdvancedEntries.psm1
@@ -12,6 +12,7 @@ function Add-IcingaForWindowsInstallationAdvancedEntries()
     Show-IcingaForWindowsInstallationMenuEnterIcingaPort -Automated -Advanced;
     Show-IcingaForWindowsInstallerMenuSelectOpenWindowsFirewall -DefaultInput $OpenFirewall -Automated -Advanced;
     Show-IcingaForWindowsInstallerMenuSelectCertificate -Automated -Advanced;
+    Show-IcingaForWindowsInstallerMenuSelectForceCertificateGeneration -Automated -Advanced;
     Show-IcingaForWindowsInstallerMenuSelectGlobalZones -Automated -Advanced;
     Show-IcingaForWindowsInstallationMenuEnterCustomGlobalZones -Automated -Advanced;
     Show-IcingaForWindowsInstallationMenuEnterIcingaAgentVersion -Automated -Advanced;

--- a/lib/core/installer/menu/installation/icinga/ForceCertificateGeneration.psm1
+++ b/lib/core/installer/menu/installation/icinga/ForceCertificateGeneration.psm1
@@ -1,0 +1,34 @@
+function Show-IcingaForWindowsInstallerMenuSelectForceCertificateGeneration()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '0',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    $Global:Icinga.InstallWizard.DirectorSelfService = $FALSE;
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Do you want to force the creation of possible existing Icinga Agent certificates?' `
+        -Entries @(
+            @{
+                'Caption' = 'Do not enforce certificate creation';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'In case certificates for the Icinga Agent for the matching hostname do already exist, they will not be re-created.'
+            },
+            @{
+                'Caption' = 'Enforce certificate creation';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'This will always create the Icinga Agent certificates and create a new certificate request, even when certificates do already exist.';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-ForceCertificateCreation' -Value 'Show-IcingaForWindowsInstallerMenuSelectForceCertificateGeneration';


### PR DESCRIPTION
Adds support to re\-create the Icinga Agent certificates, even when they are already present on the system. This will resolve the manual requirement to delete the folder or certificates, in case the Icinga CA changes for example

Fixes \#417