### PR TITLE
Feature: Adds support to keep IMC console output

### DIFF
--- a/lib/core/installer/Install-Icinga.psm1
+++ b/lib/core/installer/Install-Icinga.psm1
@@ -13,6 +13,7 @@ function Install-Icinga()
         $global:Icinga.Add(
             'InstallWizard', @{
                 'AdminShell'             = (Test-AdministrativeShell);
+                'BlockClearHost'         = $FALSE;
                 'LastInput'              = '';
                 'LastNotice'             = '';
                 'LastError'              = '';

--- a/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
+++ b/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
@@ -4,7 +4,7 @@ function Start-IcingaForWindowsInstallation()
         [switch]$Automated
     );
 
-    if ($global:Icinga.InstallWizard.DirectorInstallError -eq $FALSE -And (Get-IcingaFrameworkDebugMode) -eq $FALSE) {
+    if ($global:Icinga.InstallWizard.DirectorInstallError -eq $FALSE -And (Get-IcingaFrameworkDebugMode) -eq $FALSE -And $global:Icinga.InstallWizard.BlockClearHost -eq $FALSE) {
         Clear-Host;
     }
 
@@ -264,6 +264,14 @@ function Start-IcingaForWindowsInstallation()
         Start-Sleep -Seconds 5;
     }
 
-    $global:Icinga.InstallWizard.NextCommand   = 'Install-Icinga';
-    $global:Icinga.InstallWizard.NextArguments = @{ };
+    $global:Icinga.InstallWizard.NextCommand    = 'Install-Icinga';
+    $global:Icinga.InstallWizard.NextArguments  = @{ };
+
+    $BlockClearHost = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuBlockClearHost';
+
+    if ($BlockClearHost -eq 0) {
+        $global:Icinga.InstallWizard.BlockClearHost = $FALSE;
+    } else {
+        $global:Icinga.InstallWizard.BlockClearHost = $TRUE;
+    }
 }

--- a/lib/core/installer/menu/installation/AdvancedEntries.psm1
+++ b/lib/core/installer/menu/installation/AdvancedEntries.psm1
@@ -24,6 +24,7 @@ function Add-IcingaForWindowsInstallationAdvancedEntries()
     Show-IcingaForWindowsInstallationMenuStableRepository -Automated -Advanced;
     Show-IcingaForWindowsInstallerMenuSelectInstallJEAProfile -Automated -Advanced;
     Show-IcingaForWindowsInstallationMenuEnterIcingaCAServer -Automated -Advanced;
+    Show-IcingaForWindowsInstallerMenuBlockClearHost -Automated -Advanced;
 
     Enable-IcingaFrameworkConsoleOutput;
 

--- a/lib/core/installer/menu/manage/framework/BlockClearHost.psm1
+++ b/lib/core/installer/menu/manage/framework/BlockClearHost.psm1
@@ -1,0 +1,32 @@
+function Show-IcingaForWindowsInstallerMenuBlockClearHost()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = '0',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'Clear the console output before running the installation' `
+        -Entries @(
+            @{
+                'Caption' = 'Clear console';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'This will clear the current text of the console for a clean installation view and clear it afterwards as well';
+            },
+            @{
+                'Caption' = 'Do not clear console';
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'This will leave the console output on the console between installation steps and afterwards to possible debug purpose';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -JumpToSummary:$FALSE `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+}
+
+Set-Alias -Name 'IfW-BlockClearHost' -Value 'Show-IcingaForWindowsInstallerMenuBlockClearHost';

--- a/lib/core/installer/tools/ShowInstallerMenu.psm1
+++ b/lib/core/installer/tools/ShowInstallerMenu.psm1
@@ -22,7 +22,7 @@ function Show-IcingaForWindowsInstallerMenu()
         [switch]$NoConfigSwap        = $FALSE
     );
 
-    if ($global:Icinga.InstallWizard.DirectorInstallError -eq $FALSE -And (Test-IcingaForWindowsInstallationHeaderPrint) -eq $FALSE -And (Get-IcingaFrameworkDebugMode) -eq $FALSE) {
+    if ($global:Icinga.InstallWizard.DirectorInstallError -eq $FALSE -And (Test-IcingaForWindowsInstallationHeaderPrint) -eq $FALSE -And (Get-IcingaFrameworkDebugMode) -eq $FALSE -And $global:Icinga.InstallWizard.BlockClearHost -eq $FALSE) {
         Clear-Host;
     }
 


### PR DESCRIPTION
In some cases it might be helpful to keep the console output for the IMC, especially on rolled out setups with provisioning tools.

This feature will allow to keep the entire console window output.