### PR TITLE
Fix: Removes experimental for API Checks and module requirements

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -23,6 +23,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#411](https://github.com/Icinga/icinga-powershell-framework/pull/411) Fixes Icinga Director error message output because of missing `[string]::Format()`
 * [#412](https://github.com/Icinga/icinga-powershell-framework/issues/412) Fixes possible defective state of the Icinga Agent by using a custom service user for JEA profiles which is larger than 20 digits
 * [#418](https://github.com/Icinga/icinga-powershell-framework/pull/418) Fixes crash on wrong variable usage introduced by [#411](https://github.com/Icinga/icinga-powershell-framework/pull/411)
+* [#421](https://github.com/Icinga/icinga-powershell-framework/issues/421) Fixes experimental state of `API Check` feature by removing that term and removing the requirement to install `icinga-powershell-restapi` and `icinga-powershell-apichecks`
 
 ### Enhancements
 

--- a/lib/core/framework/Disable-IcingaFrameworkApiChecks.psm1
+++ b/lib/core/framework/Disable-IcingaFrameworkApiChecks.psm1
@@ -15,5 +15,5 @@
 
 function Disable-IcingaFrameworkApiChecks()
 {
-    Set-IcingaPowerShellConfig -Path 'Framework.Experimental.UseApiChecks' -Value $FALSE;
+    Set-IcingaPowerShellConfig -Path 'Framework.ApiChecks' -Value $FALSE;
 }

--- a/lib/core/framework/Enable-IcingaFrameworkApiChecks.psm1
+++ b/lib/core/framework/Enable-IcingaFrameworkApiChecks.psm1
@@ -15,7 +15,5 @@
 
 function Enable-IcingaFrameworkApiChecks()
 {
-    Set-IcingaPowerShellConfig -Path 'Framework.Experimental.UseApiChecks' -Value $TRUE;
-
-    Write-IcingaConsoleNotice 'Please ensure to install the components "icinga-powershell-restapi" and "icinga-powershell-apichecks", install the Icinga for Windows Service and also register the daemon with "Register-IcingaBackgroundDaemon -Command {0}". Afterwards all checks will be executed by the background daemon in case it is running. Further details can be found at https://icinga.com/docs/icinga-for-windows/latest/doc/110-Installation/30-API-Check-Forwarder/' -Objects "'Start-IcingaWindowsRESTApi'";
+    Set-IcingaPowerShellConfig -Path 'Framework.ApiChecks' -Value $TRUE;
 }

--- a/lib/core/framework/Get-IcingaFrameworkApiChecks.psm1
+++ b/lib/core/framework/Get-IcingaFrameworkApiChecks.psm1
@@ -18,11 +18,11 @@
 
 function Get-IcingaFrameworkApiChecks()
 {
-    $CodeCaching = Get-IcingaPowerShellConfig -Path 'Framework.Experimental.UseApiChecks';
+    $ApiChecks = Get-IcingaPowerShellConfig -Path 'Framework.ApiChecks';
 
-    if ($null -eq $CodeCaching) {
+    if ($null -eq $ApiChecks) {
         return $FALSE;
     }
 
-    return $CodeCaching;
+    return $ApiChecks;
 }

--- a/lib/core/framework/Install-IcingaFrameworkUpdate.psm1
+++ b/lib/core/framework/Install-IcingaFrameworkUpdate.psm1
@@ -101,6 +101,11 @@ function Install-IcingaFrameworkUpdate()
         Write-IcingaFrameworkCodeCache;
     }
 
+    Import-Module -Name $ModuleDirectory -Force;
+
+    # Apply migration tasks
+    Invoke-IcingaForWindowsMigration;
+
     if ([string]::IsNullOrEmpty((Get-IcingaJEAContext)) -eq $FALSE) {
         Remove-IcingaFrameworkDependencyFile;
         Write-IcingaConsoleNotice 'Updating Icinga JEA profile';

--- a/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
+++ b/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
@@ -1,0 +1,14 @@
+function Invoke-IcingaForWindowsMigration()
+{
+    # Upgrade to v1.8.0
+    if ((Get-Module -ListAvailable -Name icinga-powershell-framework).Version -ge (New-IcingaVersionObject -Version '1.8.0')) {
+        Write-IcingaConsoleNotice 'Applying pending migrations required for Icinga for Windows v1.8.0';
+
+        $ApiChecks = Get-IcingaPowerShellConfig -Path 'Framework.Experimental.UseApiChecks';
+
+        if ($null -ne $ApiChecks) {
+            Remove-IcingaPowerShellConfig -Path 'Framework.Experimental.UseApiChecks' | Out-Null;
+            Set-IcingaPowerShellConfig -Path 'Framework.ApiChecks' -Value $ApiChecks;
+        }
+    }
+}

--- a/lib/core/framework/Invoke-IcingaInternalServiceCall.psm1
+++ b/lib/core/framework/Invoke-IcingaInternalServiceCall.psm1
@@ -29,11 +29,6 @@ function Invoke-IcingaInternalServiceCall()
         return;
     }
 
-    # If neither 'icinga-powershell-restapi' or 'icinga-powershell-apichecks' is installed, execute the plugin locally
-    if ((Test-IcingaFunction 'Invoke-IcingaApiChecksRESTCall') -eq $FALSE -Or (Test-IcingaFunction 'Start-IcingaWindowsRESTApi') -eq $FALSE) {
-        return;
-    }
-
     $RestApiPort  = 5668;
     [int]$Timeout = 30;
     $Daemon       = $BackgroundDaemons['Start-IcingaWindowsRESTApi'];

--- a/lib/core/installer/menu/manage/framework/FrameworkExperimental.psm1
+++ b/lib/core/installer/menu/manage/framework/FrameworkExperimental.psm1
@@ -4,16 +4,5 @@ function Show-IcingaForWindowsManagementConsoleFrameworkExperimental()
 
     Show-IcingaForWindowsInstallerMenu `
         -Header 'Manage Icinga for Windows experimental features. Not recommended for production!' `
-        -Entries @(
-            @{
-                'Caption'  = ([string]::Format('Forward checks to Api: {0}', (& { if ($ApiChecks) { 'Enabled' } else { 'Disabled' } } )));
-                'Command'  = 'Show-IcingaForWindowsManagementConsoleFrameworkExperimental';
-                'Help'     = 'In case enabled, all check commands executed by "Exit-IcingaExecutePlugin" are forwarded to an internal REST-Api and executed from within the Icinga for Windows background daemon. Requires the Icinga for Windows background daemon and the modules "icinga-powershell-restapi" and "icinga-powershell-apichecks"';
-                'Disabled' = $FALSE;
-                'Action'   = @{
-                    'Command'   = 'Invoke-IcingaForWindowsMangementConsoleToogleFrameworkApiChecks';
-                    'Arguments' = @{ };
-                }
-            }
-        );
+        -Entries @();
 }

--- a/lib/core/installer/menu/manage/framework/ManageFramework.psm1
+++ b/lib/core/installer/menu/manage/framework/ManageFramework.psm1
@@ -1,6 +1,7 @@
 function Show-IcingaForWindowsManagementConsoleManageFramework()
 {
     $FrameworkDebug = Get-IcingaFrameworkDebugMode;
+    $ApiChecks      = Get-IcingaFrameworkApiChecks;
     $IcingaService  = Get-Service 'icingapowershell' -ErrorAction SilentlyContinue;
     $AdminShell     = $global:Icinga.InstallWizard.AdminShell;
     $ServiceStatus  = $null;
@@ -35,6 +36,16 @@ function Show-IcingaForWindowsManagementConsoleManageFramework()
                 'Help'           = 'Allows you to manage Icinga for Windows JEA profile';
                 'Disabled'       = $JEADisabled;
                 'DisabledReason' = ([string]::Format('PowerShell version "{0}" is lower than 5.0 or you are not inside an administrative shell', $PSVersionTable.PSVersion.ToString(2)));
+            },
+            @{
+                'Caption'  = ([string]::Format('Forward checks to Api: {0}', (& { if ($ApiChecks) { 'Enabled' } else { 'Disabled' } } )));
+                'Command'  = 'Show-IcingaForWindowsManagementConsoleManageFramework';
+                'Help'     = 'In case enabled, all check commands executed by "Exit-IcingaExecutePlugin" are forwarded to an internal REST-Api and executed from within the Icinga for Windows background daemon. Requires the Icinga for Windows background daemon';
+                'Disabled' = $FALSE;
+                'Action'   = @{
+                    'Command'   = 'Invoke-IcingaForWindowsMangementConsoleToogleFrameworkApiChecks';
+                    'Arguments' = @{ };
+                }
             },
             @{
                 'Caption'  = ([string]::Format('Framework Debug Mode: {0}', (& { if ($FrameworkDebug) { 'Enabled' } else { 'Disabled' } } )));

--- a/lib/core/repository/Install-IcingaComponent.psm1
+++ b/lib/core/repository/Install-IcingaComponent.psm1
@@ -187,6 +187,11 @@ function Install-IcingaComponent()
                     Write-IcingaFrameworkCodeCache;
                 }
 
+                Import-Module -Name $ComponentFolder -Force;
+
+                # Apply migration tasks
+                Invoke-IcingaForWindowsMigration;
+
                 if ($ServiceStatus -eq 'Running') {
                     Write-IcingaConsoleNotice 'Starting Icinga for Windows service';
                     Start-IcingaService 'icingapowershell';
@@ -195,9 +200,9 @@ function Install-IcingaComponent()
                     Write-IcingaConsoleNotice 'Starting Icinga Agent service';
                     Start-IcingaService 'icinga2';
                 }
+            } else {
+                Import-Module -Name $ComponentFolder -Force;
             }
-
-            Import-Module -Name $ComponentFolder -Force;
 
             # This will ensure that Framework functions will always win over third party functions, overwriting functionality
             # of the Framework, which might cause problems during installation otherwise


### PR DESCRIPTION
Fixes experimental state of `API Check` feature by removing that term and removing the requirement to install `icinga-powershell-restapi` and `icinga-powershell-apichecks`

Fixes #421