### PR TITLE
Fix: Exception and freezes inside PowerShell ISE session

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#273](https://github.com/Icinga/icinga-powershell-framework/issues/273) Fixes exceptions and freezes while using Icinga for Windows within an PowerShell ISE session and informing the user properly about the limitations
 * [#291](https://github.com/Icinga/icinga-powershell-framework/issues/291) Fixes `Split-IcingaVersion` by returning data with naming `mayor` for the version instead of `major`. We will return both results to give developers time to adjust their code before removing the `mayor` object
 * [#379](https://github.com/Icinga/icinga-powershell-framework/issues/379) Fixes memory leak for Icinga for Windows by using a custom function being more aggressive on memory cleanup
 * [#394](https://github.com/Icinga/icinga-powershell-framework/issues/394) Fixes lookup time for Icinga managed user for large Active Directory environments by limiting lookup to local system only

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -242,6 +242,17 @@ function Invoke-IcingaCommand()
         Write-IcingaFrameworkCodeCache;
     }
 
+    if ($Manage -And $null -ne $psISE) {
+        Use-Icinga;
+        Write-IcingaConsoleError -Message 'Icinga for Windows was loaded, but the Icinga Management Console is not available within the PowerShell ISE context. Please start a regular PowerShell to use it.';
+        return;
+    }
+
+    if ($null -ne $psISE) {
+        Write-IcingaConsoleWarning -Message 'Icinga for Windows was successfully loaded, but the current PowerShell ISE environment is not fully supported. For advanced and production tasks, please use Icinga for Windows inside a regular PowerShell environment.';
+        return;
+    }
+
     powershell.exe -NoExit -Command {
         $Script          = $args[0];
         $RootPath        = $args[1];


### PR DESCRIPTION
Fixes Icinga for Windows exception while running `icinga` commands or the Icinga Mangement Console inside an `PowerShell ISE` session, which behaves differently.

Instead, we now load Icinga for Windows and inform the user about limitations properly.

Fixes #273