### PR TITLE
Fix: Plugin Doc generator file lookup

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -25,6 +25,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#412](https://github.com/Icinga/icinga-powershell-framework/issues/412) Fixes possible defective state of the Icinga Agent by using a custom service user for JEA profiles which is larger than 20 digits
 * [#418](https://github.com/Icinga/icinga-powershell-framework/pull/418) Fixes crash on wrong variable usage introduced by [#411](https://github.com/Icinga/icinga-powershell-framework/pull/411)
 * [#421](https://github.com/Icinga/icinga-powershell-framework/issues/421) Fixes experimental state of `API Check` feature by removing that term and removing the requirement to install `icinga-powershell-restapi` and `icinga-powershell-apichecks`
+* [#436](https://github.com/Icinga/icinga-powershell-framework/pull/436) Fixes a lookup error for existing plugin documentation files, which caused files not being generated properly in case a similar name was already present on the system
 
 ### Enhancements
 

--- a/lib/core/framework/Publish-IcingaPluginDocumentation.psm1
+++ b/lib/core/framework/Publish-IcingaPluginDocumentation.psm1
@@ -54,7 +54,7 @@ function Publish-IcingaPluginDocumentation()
         [string]$PluginDocName = '';
         foreach ($DocFile in $MDFiles) {
             $DocFileName = $DocFile.Name;
-            if ($DocFileName -Like "*$PluginName*") {
+            if ($DocFileName -Like "*$PluginName.md") {
                 $PluginDocName = $DocFile.Name;
                 break;
             }


### PR DESCRIPTION
Fixes a lookup error for existing plugin documentation files, which caused files not being generated properly in case a similar name was already present on the system.