### PR TITLE
Feature: Adds upgrade notification to service binary

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -35,6 +35,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#417](https://github.com/Icinga/icinga-powershell-framework/issues/417) Adds support to allow the force creation of Icinga Agent certificates, even when they are already present on the system over Icinga Management Console installation
 * [#427](https://github.com/Icinga/icinga-powershell-framework/issues/427) Moves Icinga for Windows EventLog from `Application` to a custom log `Icinga for Windows`, allowing better separation
 * [#438](https://github.com/Icinga/icinga-powershell-framework/pull/438) Adds support for enabling the REST-Api background daemon and the Api-Check feature during the IMC installation wizard on advanced settings, which will be enabled by default
+* [#440](https://github.com/Icinga/icinga-powershell-framework/pull/440) Adds upgrade notification if Icinga for Windows Service binary older than v1.2.0 is used, which will not work with Icinga for Windows v1.8.0 or later
 
 ## 1.7.1 (2021-11-11)
 

--- a/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
+++ b/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
@@ -1,5 +1,16 @@
 function Invoke-IcingaForWindowsMigration()
 {
+    $IcingaForWindowsService = Get-IcingaForWindowsServiceData;
+
+    if (([string]::IsNullOrEmpty($IcingaForWindowsService.FullPath) -eq $FALSE -And (Test-Path $IcingaForWindowsService.FullPath))) {
+        $ServiceBinaryData = Read-IcingaServicePackage -File $IcingaForWindowsService.FullPath;
+
+        if ($ServiceBinaryData.FileVersion -lt (New-IcingaVersionObject -Version '1.2.0')) {
+            Write-IcingaConsoleWarning -Message 'You are running a Icinga for Windows Service binary older than v1.2.0. You need to upgrade to v1.2.0 or later before you can use Icinga for Windows properly. You can update it with "Update-Icinga -Name service"';
+            return;
+        }
+    }
+
     # Upgrade to v1.8.0
     if (Test-IcingaForWindowsMigration -MigrationVersion (New-IcingaVersionObject -Version '1.8.0')) {
         $ServiceStatus = (Get-Service 'icingapowershell' -ErrorAction SilentlyContinue).Status;


### PR DESCRIPTION
Ensures we add an upgrade notification if we are running the Icinga for Windows Service binary older than v1.2.0, which will not work with Icinga for Windows v1.8.0 or later.