### PR TITLE
Fix: Exception on loading by missing environment

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -28,6 +28,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#421](https://github.com/Icinga/icinga-powershell-framework/issues/421) Fixes experimental state of `API Check` feature by removing that term and removing the requirement to install `icinga-powershell-restapi` and `icinga-powershell-apichecks`
 * [#436](https://github.com/Icinga/icinga-powershell-framework/pull/436) Fixes a lookup error for existing plugin documentation files, which caused files not being generated properly in case a similar name was already present on the system
 * [#439](https://github.com/Icinga/icinga-powershell-framework/pull/439) Moves PerformanceCounter to private space from previous public, which caused some problems
+* [#441](https://github.com/Icinga/icinga-powershell-framework/pull/441) Fixes an exception while loading the Framework, caused by a race condition for missing environment variables which are accessed by some plugins before the Framework is loaded properly
 
 ### Enhancements
 

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -31,7 +31,6 @@ function Use-Icinga()
     }
 
     Disable-IcingaProgressPreference;
-    New-IcingaEnvironmentVariable;
 
     if ($Minimal) {
         $Global:Icinga.Protected.Minimal = $TRUE;
@@ -282,6 +281,12 @@ function Start-IcingaShellAsUser()
                 $User
             )
         );
+}
+
+# Always ensure our environment variables are set to reduce possibles errors
+# in case we call functions accessing them
+if (Get-Command -Name 'New-IcingaEnvironmentVariable' -ErrorAction SilentlyContinue) {
+    New-IcingaEnvironmentVariable;
 }
 
 Set-Alias icinga Invoke-IcingaCommand -Description "Execute Icinga Framework commands in a new PowerShell instance for testing or quick access to data";


### PR DESCRIPTION
Fixes an exception while loading the Framework, caused by a race condition for missing environment variables which are accessed by some plugins before the Framework is loaded properly.