### PR TITLE
Fix: Exception on Use-Icinga

### DIFF
--- a/cache/framework_cache.psm1
+++ b/cache/framework_cache.psm1
@@ -8,10 +8,6 @@
     Manually enabling the feature is no longer required.
 #>
 
-$Global:Icinga = @{
-    'RebuildCache' = $TRUE;
-};
-
 Write-IcingaFrameworkCodeCache;
 
 Import-Module icinga-powershell-framework -Global -Force;

--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -16,6 +16,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#273](https://github.com/Icinga/icinga-powershell-framework/issues/273) Fixes exceptions and freezes while using Icinga for Windows within an PowerShell ISE session and informing the user properly about the limitations
 * [#291](https://github.com/Icinga/icinga-powershell-framework/issues/291) Fixes `Split-IcingaVersion` by returning data with naming `mayor` for the version instead of `major`. We will return both results to give developers time to adjust their code before removing the `mayor` object
 * [#379](https://github.com/Icinga/icinga-powershell-framework/issues/379) Fixes memory leak for Icinga for Windows by using a custom function being more aggressive on memory cleanup
+* [#380](https://github.com/Icinga/icinga-powershell-framework/issues/380) Fixes exception while using `Use-Icinga` inside the same shell Icinga for Windows is installed for the first time on the system
 * [#394](https://github.com/Icinga/icinga-powershell-framework/issues/394) Fixes lookup time for Icinga managed user for large Active Directory environments by limiting lookup to local system only
 * [#402](https://github.com/Icinga/icinga-powershell-framework/pull/402) Fixes missing address attribute for REST-Api daemon, making it unable to change the listening address
 * [#403](https://github.com/Icinga/icinga-powershell-framework/pull/403) Fixes memory leak on newly EventLog reader for CLI event stream

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -17,14 +17,6 @@ function Use-Icinga()
         [switch]$Minimal   = $FALSE
     );
 
-    if ($null -ne $Global:Icinga -And $Global:Icinga.ContainsKey('RebuildCache') -And $Global:Icinga.RebuildCache) {
-        # On some systems, this call will re-build the cache
-        Import-Module (Join-Path -Path (Get-IcingaForWindowsRootPath) -ChildPath 'icinga-powershell-framework') -Global -Force;
-        # The second run would then actually import the new module. Only happens on some systems, but with this we fix
-        # possible exceptions
-        Import-Module (Join-Path -Path (Get-IcingaForWindowsRootPath) -ChildPath 'icinga-powershell-framework') -Global -Force;
-    }
-
     # Only apply migrations if we directly call "Use-Icinga" without any other argument
     if ($LibOnly -eq $FALSE -And $Daemon -eq $FALSE -and $Minimal -eq $FALSE) {
         Invoke-IcingaForWindowsMigration;


### PR DESCRIPTION
In some cases it can happen, that Icinga for Windows throws an exception while using \`Use\-Icinga\`. This happens because of an internal handling for rebuilding the cache, which tried to re\-import the modules.

This code seems no longer to be required and causes only problems while trying to use \`Use\-Icinga\` while inside the same shell, that Icinga for Windows is being installed the first time in.

As this seems no longer to be required, we will remove this code.

Fixes \#380