### PR TITLE
Feature: Supresses error messages on progress status

### DIFF
--- a/lib/core/progress/New-IcingaProgressStatus.psm1
+++ b/lib/core/progress/New-IcingaProgressStatus.psm1
@@ -1,26 +1,27 @@
 function New-IcingaProgressStatus()
 {
     param (
-        [string]$Name      = '',
-        [int]$CurrentValue = 0,
-        [int]$MaxValue     = 1,
-        [string]$Message   = 'Processing Icinga for Windows',
-        [string]$Status    = '{0}% Complete',
-        [switch]$Details   = $FALSE
+        [string]$Name        = '',
+        [int]$CurrentValue   = 0,
+        [int]$MaxValue       = 1,
+        [string]$Message     = 'Processing Icinga for Windows',
+        [string]$Status      = '{0}% Complete',
+        [switch]$Details     = $FALSE,
+        [switch]$PrintErrors = $FALSE
     );
 
     if ([string]::IsNullOrEmpty($Name)) {
-        Write-IcingaConsoleError -Message 'Failed to create new progress status. You have to specify a name.';
+        Write-IcingaConsoleError -Message 'Failed to create new progress status. You have to specify a name.' -DropMessage:$(-Not $PrintErrors);
         return;
     }
 
     if ($MaxValue -le 0) {
-        Write-IcingaConsoleError -Message 'Failed to create new progress status. The maximum value has to be larger than 0.';
+        Write-IcingaConsoleError -Message 'Failed to create new progress status. The maximum value has to be larger than 0.' -DropMessage:$(-Not $PrintErrors);
         return;
     }
 
     if ($Global:Icinga.Private.ProgressStatus.ContainsKey($Name)) {
-        Write-IcingaConsoleError -Message 'Failed to create new progress status. A progress status with this name is already active. Use "Complete-IcingaProgressStatus" to remove it.';
+        Write-IcingaConsoleError -Message 'Failed to create new progress status. A progress status with this name is already active. Use "Complete-IcingaProgressStatus" to remove it.' -DropMessage:$(-Not $PrintErrors);
         return;
     }
 


### PR DESCRIPTION
Adds `-PrintErrors` to `New-IcingaProgressStatus`, surpressing all errors by default, allowing to add this for testing internally.