### PR TITLE
Fix: Error handling for failed module import

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -31,6 +31,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#439](https://github.com/Icinga/icinga-powershell-framework/pull/439) Moves PerformanceCounter to private space from previous public, which caused some problems
 * [#441](https://github.com/Icinga/icinga-powershell-framework/pull/441) Fixes an exception while loading the Framework, caused by a race condition for missing environment variables which are accessed by some plugins before the Framework is loaded properly
 * [#446](https://github.com/Icinga/icinga-powershell-framework/pull/446) Fixes Icinga for Windows progress preference, which sometimes caused UI glitches
+* [#449](https://github.com/Icinga/icinga-powershell-framework/pull/449) Fixes unhandled exception while importing modules during `Install-IcingaComponent` process, because of possible missing dependencies
 
 ### Enhancements
 

--- a/lib/core/repository/Install-IcingaComponent.psm1
+++ b/lib/core/repository/Install-IcingaComponent.psm1
@@ -202,16 +202,20 @@ function Install-IcingaComponent()
                     Start-IcingaService 'icinga2';
                 }
             } else {
-                Import-Module -Name $ComponentFolder -Force;
-                Import-Module -Name $ComponentFolder -Force -Global;
+                try {
+                    Import-Module -Name $ComponentFolder -Force -ErrorAction Stop;
+                    Import-Module -Name $ComponentFolder -Force -Global -ErrorAction Stop;
+
+                    Write-IcingaConsoleNotice 'Installation of component "{0}" with version "{1}" was successful. Open a new PowerShell to apply the changes' -Objects $Name.ToLower(), $ManifestFile.ModuleVersion;
+                } catch {
+                    Write-IcingaConsoleError 'Component "{0}" has been installed with version "{1}", but while importing the component an exception was thrown: {2}' -Objects $Name.ToLower(), $ManifestFile.ModuleVersion, $_.Exception.Message;
+                }
             }
 
             # This will ensure that Framework functions will always win over third party functions, overwriting functionality
             # of the Framework, which might cause problems during installation otherwise
             Import-Module (Join-Path -Path (Get-IcingaForWindowsRootPath) -ChildPath 'icinga-powershell-framework') -Force;
             Import-Module (Join-Path -Path (Get-IcingaForWindowsRootPath) -ChildPath 'icinga-powershell-framework') -Global -Force;
-
-            Write-IcingaConsoleNotice 'Installation of component "{0}" with version "{1}" was successful. Open a new PowerShell to apply the changes' -Objects $Name.ToLower(), $ManifestFile.ModuleVersion;
         } else {
             <#
                 Handles installation of Icinga for Windows service


### PR DESCRIPTION
Adds improved exception handling for using `Install-IcingaComponent` while importing of modules failed, because of missing dependencies for example.