### PR TITLE
Feature: Improve show commands and extend Show-Icinga

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -42,6 +42,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#440](https://github.com/Icinga/icinga-powershell-framework/pull/440) Adds upgrade notification if Icinga for Windows Service binary older than v1.2.0 is used, which will not work with Icinga for Windows v1.8.0 or later
 * [#445](https://github.com/Icinga/icinga-powershell-framework/pull/445) Adds command `Repair-IcingaService` to repair Icinga Agent service in case it was broken during upgrades, mostly caused by `The specified service has been marked for deletion`
 * [#448](https://github.com/Icinga/icinga-powershell-framework/pull/448) Adds support to sort arrays without ScriptBlocks
+* [#450](https://github.com/Icinga/icinga-powershell-framework/pull/450) Improves show command `Show-IcingaRegisteredServiceChecks`, adds new command `Show-IcingaRegisteredBackgroundDaemons` and extends `Show-Icinga` by both commands and adds debug and api forwarder features to environment list
 
 ## 1.7.1 (2021-11-11)
 

--- a/doc/110-Installation/05-Background-Daemons.md
+++ b/doc/110-Installation/05-Background-Daemons.md
@@ -62,7 +62,15 @@ Register-IcingaBackgroundDaemon `
 To print a list of configured background daemons, you can run
 
 ```powershell
-Get-IcingaBackgroundDaemons;
+Show-IcingaRegisteredBackgroundDaemons;
+```
+
+```powershell
+List of configured background daemons on this system.
+
+Start-IcingaServiceCheckDaemon
+-----------
+No arguments defined
 ```
 
 ## Restart PowerShell Service

--- a/doc/110-Installation/06-Collect-Metrics-over-Time.md
+++ b/doc/110-Installation/06-Collect-Metrics-over-Time.md
@@ -85,22 +85,24 @@ Register-IcingaServiceCheck `
 
 ### Show Registered Service Checks
 
-To fetch a list of currently registerd service checks, you can run the following command:
+To fetch a list of currently registered service checks, you can run the following command:
 
 ```powershell
 Show-IcingaRegisteredServiceChecks;
 ```
 
 ```powershell
-[Notice]: Service Id: 1332191811682909517982372151451071972043015735175
-[Notice]:
-Name                           Value
-----                           -----
-CheckCommand                   Invoke-IcingaCheckPerfCounter
-Interval                       15
-Arguments                      @{-PerfCounter=System.Object[]}
-Id                             1332191811682909517982372151451071972043015735175
-TimeIndexes                    {1, 3, 5, 10...}
+List of configured background service checks on this system.
+=> https://icinga.com/docs/icinga-for-windows/latest/doc/110-Installation/06-Collect-Metrics-over-Time/
+
+Invoke-IcingaCheckPerfCounter
+-----------
+Arguments    => -PerfCounter '\Processor(*)\% Processor Time', '\Memory\% committed bytes in use', '\Memory\Available Bytes'
+CheckCommand => Invoke-IcingaCheckPerfCounter
+Id           => 1332191811682909517982372151451071972043015735175
+Interval     => 15
+TimeIndexes  => 1, 3, 5, 10, 15, 20
+
 ```
 
 You will then receive a list of all configured plugins, including their configuration and `service id`.

--- a/lib/core/installer/tools/Write-IcingaManagementConsoleCommand.psm1
+++ b/lib/core/installer/tools/Write-IcingaManagementConsoleCommand.psm1
@@ -25,34 +25,8 @@ function Write-IcingaManagementConsoleCommand()
         }
     }
 
-    foreach ($cmdArg in $DefinedArgs.Keys) {
-        $PrintValue        = $DefinedArgs[$cmdArg];
-        [string]$StringArg = ([string]$cmdArg).Replace('-', '');
-        if ($PrintValue.GetType().Name -eq 'Boolean') {
-            if ((Get-Command $PrintCommand).Parameters.$StringArg.ParameterType.Name -eq 'SwitchParameter') {
-                $PrintValue = '';
-            } else {
-                if ($PrintValue) {
-                    $PrintValue = '$TRUE';
-                } else {
-                    $PrintValue = '$FALSE';
-                }
-            }
-        } elseif ($PrintValue.GetType().Name -eq 'String') {
-            $PrintValue = (ConvertFrom-IcingaArrayToString -Array $PrintValue -AddQuotes -UseSingleQuotes);
-        }
-        if ([string]::IsNullOrEmpty($PrintValue)) {
-            $PrintArguments += ([string]::Format('{0} ', $cmdArg));
-        } else {
-            $PrintArguments += ([string]::Format('{0} {1} ', $cmdArg, $PrintValue));
-        }
-    }
-
+    $PrintArguments = ConvertTo-IcingaCommandArgumentString -Command $PrintCommand -CommandArguments $DefinedArgs;
     $PrintArguments = $PrintArguments.Replace('$DefaultValues$', ((ConvertFrom-IcingaArrayToString -Array $Values -AddQuotes)));
-
-    while ($PrintArguments[-1] -eq ' ') {
-        $PrintArguments = $PrintArguments.SubString(0, $PrintArguments.Length - 1);
-    }
 
     if ([string]::IsNullOrEmpty($PrintArguments) -eq $FALSE) {
         $PrintArguments = [string]::Format(' {0}', $PrintArguments);

--- a/lib/core/repository/Show-Icinga.psm1
+++ b/lib/core/repository/Show-Icinga.psm1
@@ -91,12 +91,16 @@ function Show-Icinga()
     $Output += ([string]::Format('Operating System Version        => {0}', $WindowsInformation.Version));
     $Output += ([string]::Format('JEA Context                     => {0}', $JEAContext));
     $Output += ([string]::Format('JEA Session File                => {0}', $JEASessionFile));
+    $Output += ([string]::Format('Api Check Forwarder             => {0}', (Get-IcingaFrameworkApiChecks)));
+    $Output += ([string]::Format('Debug Mode                      => {0}', (Get-IcingaFrameworkDebugMode)));
     $Output += '';
     $Output += 'Icinga for Windows Certificate';
     $Output += '';
     $Output += $IcingaForWindowsCert;
-
     $Output += '';
+
+    $Output += (Show-IcingaRegisteredBackgroundDaemons);
+    $Output += (Show-IcingaRegisteredServiceChecks);
     $Output += (Show-IcingaRepository);
 
     Write-Output $Output;

--- a/lib/core/tools/ConvertTo-IcingaCommandArgumentString.psm1
+++ b/lib/core/tools/ConvertTo-IcingaCommandArgumentString.psm1
@@ -1,0 +1,51 @@
+function ConvertTo-IcingaCommandArgumentString()
+{
+    param (
+        [string]$Command  = '',
+        $CommandArguments = $null
+    );
+
+    [hashtable]$Arguments = @{ };
+
+    if ($CommandArguments -Is [PSCustomObject]) {
+        foreach ($entry in $CommandArguments.PSObject.Properties) {
+            $Arguments.Add($entry.Name, $entry.Value);
+        }
+    } elseif ($CommandArguments -Is [hashtable]) {
+        $Arguments = $CommandArguments;
+    } else {
+        return '';
+    }
+
+    foreach ($cmdArg in $Arguments.Keys) {
+        $PrintValue        = $Arguments[$cmdArg];
+        [string]$StringArg = ([string]$cmdArg).Replace('-', '');
+
+        if ($PrintValue.GetType().Name -eq 'Boolean') {
+            if ((Get-Command $Command).Parameters.$StringArg.ParameterType.Name -eq 'SwitchParameter') {
+                $PrintValue = '';
+            } else {
+                if ($PrintValue) {
+                    $PrintValue = '$TRUE';
+                } else {
+                    $PrintValue = '$FALSE';
+                }
+            }
+        } elseif ($PrintValue.GetType().Name -eq 'String') {
+            $PrintValue = (ConvertFrom-IcingaArrayToString -Array $PrintValue -AddQuotes -UseSingleQuotes);
+        }  elseif ($PrintValue.GetType().Name -eq 'Object[]') {
+            $PrintValue = (ConvertFrom-IcingaArrayToString -Array $PrintValue -AddQuotes -UseSingleQuotes);
+        }
+        if ([string]::IsNullOrEmpty($PrintValue)) {
+            $PrintArguments += ([string]::Format('{0} ', $cmdArg));
+        } else {
+            $PrintArguments += ([string]::Format('{0} {1} ', $cmdArg, $PrintValue));
+        }
+    }
+
+    while ($PrintArguments[-1] -eq ' ') {
+        $PrintArguments = $PrintArguments.SubString(0, $PrintArguments.Length - 1);
+    }
+
+    return $PrintArguments;
+}

--- a/lib/daemon/Show-IcingaRegisteredBackgroundDaemons.psm1
+++ b/lib/daemon/Show-IcingaRegisteredBackgroundDaemons.psm1
@@ -1,0 +1,39 @@
+function Show-IcingaRegisteredBackgroundDaemons()
+{
+    [array]$DaemonSummary  = @(
+        'List of configured background daemons on this system.',
+        ''
+    );
+
+    [hashtable]$DaemonList = Get-IcingaBackgroundDaemons;
+
+    foreach ($daemon in $DaemonList.Keys) {
+
+        $DaemonSummary    += $daemon;
+        $DaemonSummary    += '-----------';
+        $DaemonConfig      = $DaemonList[$daemon];
+
+        [int]$MaxLength    = (Get-IcingaMaxTextLength -TextArray $DaemonConfig.Keys) - 1;
+        [array]$DaemonData = @();
+
+        foreach ($daemonArgument in $DaemonConfig.Keys) {
+            $daemonValue = $DaemonConfig[$daemonArgument];
+            $PrintName   = Add-IcingaWhiteSpaceToString -Text $daemonArgument -Length $MaxLength;
+            $DaemonData += [string]::Format('{0} => {1}', $PrintName, $daemonValue);
+        }
+
+        if ($DaemonConfig.Count -eq 0) {
+            $DaemonSummary += 'No arguments defined';
+        }
+
+        $DaemonSummary += $DaemonData | Sort-Object;
+        $DaemonSummary += '';
+    }
+
+    if ($DaemonList.Count -eq 0) {
+        $DaemonSummary += 'No background daemons configured';
+        $DaemonSummary += '';
+    }
+
+    Write-Output $DaemonSummary;
+}

--- a/lib/daemons/ServiceCheckDaemon/tools/Register-IcingaServiceCheck.psm1
+++ b/lib/daemons/ServiceCheckDaemon/tools/Register-IcingaServiceCheck.psm1
@@ -19,5 +19,5 @@ function Register-IcingaServiceCheck()
     Set-IcingaPowerShellConfig -Path ([string]::Format('{0}.Interval', $Path)) -Value $Interval;
     Set-IcingaPowerShellConfig -Path ([string]::Format('{0}.TimeIndexes', $Path)) -Value $TimeIndexes;
 
-    Write-IcingaConsoleNotice 'Icinga Service Check has been configured';
+    Write-IcingaConsoleNotice 'Icinga background service check has been added';
 }

--- a/lib/daemons/ServiceCheckDaemon/tools/Show-IcingaRegisteredServiceChecks.psm1
+++ b/lib/daemons/ServiceCheckDaemon/tools/Show-IcingaRegisteredServiceChecks.psm1
@@ -1,11 +1,41 @@
 function Show-IcingaRegisteredServiceChecks()
 {
-    $Services = Get-IcingaRegisteredServiceChecks;
+    [array]$ServiceSummary  = @(
+        'List of configured background service checks on this system.',
+        '=> https://icinga.com/docs/icinga-for-windows/latest/doc/110-Installation/06-Collect-Metrics-over-Time/',
+        ''
+    );
 
-    foreach ($service in $Services.Keys) {
-        Write-IcingaConsoleNotice ([string]::Format('Service Id: {0}', $service));
-        Write-IcingaConsoleNotice (
-            $Services[$service] | Out-String
-        );
+    [hashtable]$ServiceList = Get-IcingaRegisteredServiceChecks;
+
+    foreach ($serviceId in $ServiceList.Keys) {
+        $serviceDetails     = $ServiceList[$serviceId];
+
+        $ServiceSummary    += $serviceDetails.CheckCommand;
+        $ServiceSummary    += '-----------';
+
+        [int]$MaxLength     = (Get-IcingaMaxTextLength -TextArray $serviceDetails.Keys) - 1;
+        [array]$ServiceData = @();
+
+        foreach ($serviceArguments in $serviceDetails.Keys) {
+            $serviceValue = $serviceDetails[$serviceArguments];
+            $PrintName    = Add-IcingaWhiteSpaceToString -Text $serviceArguments -Length $MaxLength;
+            if ($serviceValue -Is [array]) {
+                $serviceValue = [string]::Join(', ', $serviceValue);
+            } elseif ($serviceValue -Is [PSCustomObject]) {
+                $serviceValue = ConvertTo-IcingaCommandArgumentString -Command $serviceDetails.CheckCommand -CommandArguments $serviceValue;
+            }
+            $ServiceData  += [string]::Format('{0} => {1}', $PrintName, $serviceValue);
+        }
+
+        $ServiceSummary += $ServiceData | Sort-Object;
+        $ServiceSummary += '';
     }
+
+    if ($ServiceList.Count -eq 0) {
+        $ServiceSummary += 'No background service checks configured';
+        $ServiceSummary += '';
+    }
+
+    Write-Output $ServiceSummary;
 }

--- a/lib/daemons/ServiceCheckDaemon/tools/Unregister-IcingaServiceCheck.psm1
+++ b/lib/daemons/ServiceCheckDaemon/tools/Unregister-IcingaServiceCheck.psm1
@@ -12,5 +12,5 @@ function Unregister-IcingaServiceCheck()
 
     Remove-IcingaPowerShellConfig -Path $Path;
 
-    Write-IcingaConsolePlain 'Icinga Service Check has been configured';
+    Write-IcingaConsoleNotice 'Icinga background service check has been removed';
 }


### PR DESCRIPTION
Improves show command `Show-IcingaRegisteredServiceChecks` to use new layout for displaying information and adds new command `Show-IcingaRegisteredBackgroundDaemons`, following the same layout and possiblity.

In addition extends `Show-Icinga` by both commands and adds debug and api forwarder features to environment list.