### PR TITLE
Fix: JEA context cannot be created and command not found output

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -32,6 +32,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#441](https://github.com/Icinga/icinga-powershell-framework/pull/441) Fixes an exception while loading the Framework, caused by a race condition for missing environment variables which are accessed by some plugins before the Framework is loaded properly
 * [#446](https://github.com/Icinga/icinga-powershell-framework/pull/446) Fixes Icinga for Windows progress preference, which sometimes caused UI glitches
 * [#449](https://github.com/Icinga/icinga-powershell-framework/pull/449) Fixes unhandled exception while importing modules during `Install-IcingaComponent` process, because of possible missing dependencies
+* [#451](https://github.com/Icinga/icinga-powershell-framework/pull/451) Fixes PowerShell being unable to enter JEA context if only the Framework is installed and removes the `|` from plugin output, in case a JEA error is thrown that check commands are not present
 
 ### Enhancements
 

--- a/lib/core/jea/Get-IcingaJEAConfiguration.psm1
+++ b/lib/core/jea/Get-IcingaJEAConfiguration.psm1
@@ -154,6 +154,13 @@ function Get-IcingaJEAConfiguration()
         -CmdName 'Add-IcingaForWindowsDaemon' `
         -CmdType 'Function';
 
+    # Fixes error if only the Icinga PowerShell Framework is installed, which then causes JEA to fail entirely because of this missing Cmdlet
+    $UsedCmdlets = Get-IcingaCommandDependency `
+        -DependencyList $DependencyList `
+        -CompiledList $UsedCmdlets `
+        -CmdName 'Select-Object' `
+        -CmdType 'Cmdlet';
+
     # Finally loop through all commands again and build our JEA command list
     $DeserializedFile = Read-IcingaPowerShellModuleFile -FileContent $ModuleContent;
     [array]$JeaCmds   = $DeserializedFile.CommandList + $DeserializedFile.FunctionList;

--- a/lib/icinga/plugin/Write-IcingaPluginResult.psm1
+++ b/lib/icinga/plugin/Write-IcingaPluginResult.psm1
@@ -7,10 +7,15 @@ function Write-IcingaPluginResult()
 
     [string]$CheckResult = $PluginOutput;
 
-    if ($PluginPerfData -ne 0) {
-        $CheckResult += "`n`r| ";
+    if ($PluginPerfData.Count -ne 0) {
+        [string]$PerfDataContent = '';
         foreach ($PerfData in $PluginPerfData) {
-            $CheckResult += $PerfData;
+            $PerfDataContent += $PerfData;
+        }
+
+        if ([string]::IsNullOrEmpty($PerfDataContent) -eq $FALSE) {
+            $CheckResult += "`n`r| ";
+            $CheckResult += $PerfDataContent;
         }
     }
 


### PR DESCRIPTION
Fixes the PowerShell not being able to enter the JEA context, if only the Icinga PowerShell Framework is installed and no other component like plugins being present.

Fixes in addition the output for the JEA PowerShell, in case a check command cannot be executed. Previously the pipe `|` for performance data was always added, which is now gone.