### PR TITLE
Fix: JEA service error count not resetting itself

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -36,6 +36,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#451](https://github.com/Icinga/icinga-powershell-framework/pull/451) Fixes PowerShell being unable to enter JEA context if only the Framework is installed and removes the `|` from plugin output, in case a JEA error is thrown that check commands are not present
 * [#452](https://github.com/Icinga/icinga-powershell-framework/pull/452) Fixes unhandled `true` output on the console while running the installer
 * [#454](https://github.com/Icinga/icinga-powershell-framework/pull/454) Fixes JEA catalog compiler and background daemon execution in JEA context
+* [#456](https://github.com/Icinga/icinga-powershell-framework/pull/456) Fixes JEA service error count not resetting itself after a certain amount of time without errors
 
 ### Enhancements
 


### PR DESCRIPTION
While running the Icinga for Windows service in JEA context, it can happen that the corresponding WinRM service is restarted or terminated. The service daemon will keep an eye on that and restart the JEA session up to 5 times, before terminating the service and printing an error.

This fix will not add a grace period, which will reset the failure counter in case the service was running for more than 3 minutes. Which is more then enough runtime to not asume a faulty service behavior.