### PR TITLE
Fix: Exception on progress writer after upgrade

### DIFF
--- a/lib/core/progress/New-IcingaProgressStatus.psm1
+++ b/lib/core/progress/New-IcingaProgressStatus.psm1
@@ -20,6 +20,11 @@ function New-IcingaProgressStatus()
         return;
     }
 
+    # Can happen while upgrading from < 1.8.0 to >= 1.8.0
+    if ($Global:Icinga.Private.ContainsKey('ProgressStatus') -eq $FALSE) {
+        $Global:Icinga.Private.Add('ProgressStatus', @{ });
+    }
+
     if ($Global:Icinga.Private.ProgressStatus.ContainsKey($Name)) {
         Write-IcingaConsoleError -Message 'Failed to create new progress status. A progress status with this name is already active. Use "Complete-IcingaProgressStatus" to remove it.' -DropMessage:$(-Not $PrintErrors);
         return;


### PR DESCRIPTION
Fixes an issue on the newly introduced progress status writer, which can throw exceptions after upgrading from Icinga for Windows < 1.8.0 to >= 1.8.0 because of the missing `Private` space to store the progress informartion inside.

Starting a new PowerShell would solve this anyway, but this fix is more user friendly.