### PR TITLE
Fix: Install-IcingaSecurity should only run in administrative shell

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -37,6 +37,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#452](https://github.com/Icinga/icinga-powershell-framework/pull/452) Fixes unhandled `true` output on the console while running the installer
 * [#454](https://github.com/Icinga/icinga-powershell-framework/pull/454) Fixes JEA catalog compiler and background daemon execution in JEA context
 * [#456](https://github.com/Icinga/icinga-powershell-framework/pull/456) Fixes JEA service error count not resetting itself after a certain amount of time without errors
+* [#458](https://github.com/Icinga/icinga-powershell-framework/pull/458) Fixes `Install-IcingaSecurity` which should only run in an administrative shell
 
 ### Enhancements
 

--- a/lib/core/windows/Install-IcingaSecurity.psm1
+++ b/lib/core/windows/Install-IcingaSecurity.psm1
@@ -12,6 +12,11 @@ function Install-IcingaSecurity()
         return;
     }
 
+    if ((Test-AdministrativeShell) -eq $FALSE) {
+        Write-IcingaConsoleError -Message 'This command can only be executed from an administrative shell';
+        return;
+    }
+
     # Max length for the user name
     if ($IcingaUser.Length -gt 20) {
         Write-IcingaConsoleError 'The specified user name "{0}" is too long. The maximum character limit is 20 digits.' -Objects $IcingaUser;


### PR DESCRIPTION
We have to ensure that `Install-IcingaSecurity` is only allowed to be excuted from an administrative shell to not cause any errors.