### PR TITLE
Fix: Update-Icinga not working between snapshot/stable

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -38,6 +38,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#454](https://github.com/Icinga/icinga-powershell-framework/pull/454) Fixes JEA catalog compiler and background daemon execution in JEA context
 * [#456](https://github.com/Icinga/icinga-powershell-framework/pull/456) Fixes JEA service error count not resetting itself after a certain amount of time without errors
 * [#458](https://github.com/Icinga/icinga-powershell-framework/pull/458) Fixes `Install-IcingaSecurity` which should only run in an administrative shell
+* [#459](https://github.com/Icinga/icinga-powershell-framework/pull/459) Fixes `Update-Icinga` which was not working to downgrade snapshot packages pack to release (**NOTE:** It can still happen that migrations of the `Framework` might break your environment. Not recommended in production environments for the `Framework` component)
 
 ### Enhancements
 

--- a/lib/core/repository/Get-IcingaInstallation.psm1
+++ b/lib/core/repository/Get-IcingaInstallation.psm1
@@ -25,10 +25,6 @@ function Get-IcingaInstallation()
                 [string]$LatestVersion = $InstallPackage.Package.Version;
             }
 
-            if ([string]::IsNullOrEmpty($LatestVersion) -eq $FALSE -And [Version]$LatestVersion -le [Version]$CurrentVersion) {
-                $LatestVersion = '';
-            }
-
             Add-IcingaHashtableItem `
                 -Hashtable $InstalledComponents `
                 -Key $ComponentName `
@@ -58,10 +54,6 @@ function Get-IcingaInstallation()
             [string]$LatestVersion = $InstallPackage.Package.Version;
         }
 
-        if ([string]::IsNullOrEmpty($LatestVersion) -eq $FALSE -And [Version]$LatestVersion -le [Version]$CurrentVersion) {
-            $LatestVersion = '';
-        }
-
         $InstalledComponents.Add(
             'service',
             @{
@@ -87,10 +79,6 @@ function Get-IcingaInstallation()
 
         if ($InstallPackage.HasPackage) {
             $LatestVersion = $InstallPackage.Package.Version;
-        }
-
-        if ([string]::IsNullOrEmpty($LatestVersion) -eq $FALSE -And [Version]$LatestVersion -le [Version]$CurrentVersion) {
-            $LatestVersion = '';
         }
 
         $InstalledComponents.Add(


### PR DESCRIPTION
Fixes `Update-Icinga` which now supports to update from a snapshot branch and to downgrade properly from snapshot to stable to the latest release packages again.

**NOTE:** It is still **not** entirely supported to downgrade from snapshot to stable, as possible migrations for later versions will **not** be rolled back.