### PR TITLE
Fix: Icinga Agent not configured properly if not installed over IMC and installation disabled there

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -39,6 +39,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#456](https://github.com/Icinga/icinga-powershell-framework/pull/456) Fixes JEA service error count not resetting itself after a certain amount of time without errors
 * [#458](https://github.com/Icinga/icinga-powershell-framework/pull/458) Fixes `Install-IcingaSecurity` which should only run in an administrative shell
 * [#459](https://github.com/Icinga/icinga-powershell-framework/pull/459) Fixes `Update-Icinga` which was not working to downgrade snapshot packages pack to release (**NOTE:** It can still happen that migrations of the `Framework` might break your environment. Not recommended in production environments for the `Framework` component)
+* [#460](https://github.com/Icinga/icinga-powershell-framework/issues/460) Fixes Icinga Agent installation over IMC and Director Self-Service, in case the Self-Service is configured to not install the Icinga Agent or the user manually set `Do not install Icinga Agent` inside the IMC, which results in most configurations not being applied to the Agent, in case it is already installed
 
 ### Enhancements
 

--- a/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
+++ b/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
@@ -180,20 +180,15 @@ function Start-IcingaForWindowsInstallation()
     if ($InstallAgent) {
         Set-IcingaPowerShellConfig -Path 'Framework.Icinga.AgentLocation' -Value $AgentInstallDir;
         Install-IcingaComponent -Name 'agent' -Version $AgentVersion -Confirm -Release;
-
-        # Only continue this, if our installation was successful
-        if ((Get-IcingaAgentInstallation).Installed) {
-            Reset-IcingaAgentConfigFile;
-            Move-IcingaAgentDefaultConfig;
-            Set-IcingaAgentNodeName -Hostname $Hostname;
-            Set-IcingaServiceUser -User $ServiceUser -Password (ConvertTo-IcingaSecureString $ServicePassword) -SetPermission | Out-Null;
-            Install-IcingaAgentBaseFeatures;
-            Write-IcingaAgentApiConfig -Port $IcingaPort;
-        }
     }
 
     # Only continue this, if our installation was successful
     if ((Get-IcingaAgentInstallation).Installed) {
+        Set-IcingaAgentNodeName -Hostname $Hostname;
+        Set-IcingaServiceUser -User $ServiceUser -Password (ConvertTo-IcingaSecureString $ServicePassword) -SetPermission | Out-Null;
+        Install-IcingaAgentBaseFeatures;
+        Write-IcingaAgentApiConfig -Port $IcingaPort;
+
         if ((Install-IcingaAgentCertificates -Hostname $Hostname -Endpoint $IcingaCAServer -Port $IcingaPort -CACert $CertificateCAFile -Ticket $CertificateTicket -Force:$ForceCertificateGen) -eq $FALSE) {
             Disable-IcingaAgentFeature 'api';
             Write-IcingaConsoleWarning `
@@ -239,7 +234,7 @@ function Start-IcingaForWindowsInstallation()
     Write-IcingaFrameworkCodeCache;
     Test-IcingaAgent;
 
-    if ($InstallAgent) {
+    if ((Get-IcingaAgentInstallation).Installed) {
         Restart-IcingaService 'icinga2';
     }
 

--- a/lib/core/repository/Install-IcingaComponent.psm1
+++ b/lib/core/repository/Install-IcingaComponent.psm1
@@ -328,6 +328,8 @@ function Install-IcingaComponent()
             Set-IcingaPowerShellConfig -Path 'Framework.Icinga.ServiceUser' -Value $ServiceUser;
         }
 
+        Set-IcingaPowerShellConfig -Path 'Framework.Icinga.AgentLocation' -Value $InstallTarget;
+
         [string]$InstallFolderMsg = $InstallTarget;
 
         if ([string]::IsNullOrEmpty($InstallTarget) -eq $FALSE) {
@@ -372,6 +374,9 @@ function Install-IcingaComponent()
             Write-IcingaConsoleError -Message 'Failed to install component "agent": {0}{1}' -Objects $InstallProcess.Message, $InstallProcess.Error;
             return $FALSE;
         }
+
+        Reset-IcingaAgentConfigFile;
+        Move-IcingaAgentDefaultConfig;
 
         Set-IcingaServiceUser -User $ServiceUser -SetPermission | Out-Null;
         Update-IcingaServiceUser;


### PR DESCRIPTION
Fixes Icinga Agent installation over IMC and Director Self-Service, in case the Self-Service is configured to not install the Icinga Agent or the user manually set `Do not install Icinga Agent` inside the IMC, which results in most configurations not being applied to the Agent, in case it is already installed

Fixes #460