### PR TITLE
Fix: Add-IcingaRepository removes and adds repository with -Force

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -40,6 +40,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#458](https://github.com/Icinga/icinga-powershell-framework/pull/458) Fixes `Install-IcingaSecurity` which should only run in an administrative shell
 * [#459](https://github.com/Icinga/icinga-powershell-framework/pull/459) Fixes `Update-Icinga` which was not working to downgrade snapshot packages pack to release (**NOTE:** It can still happen that migrations of the `Framework` might break your environment. Not recommended in production environments for the `Framework` component)
 * [#460](https://github.com/Icinga/icinga-powershell-framework/issues/460) Fixes Icinga Agent installation over IMC and Director Self-Service, in case the Self-Service is configured to not install the Icinga Agent or the user manually set `Do not install Icinga Agent` inside the IMC, which results in most configurations not being applied to the Agent, in case it is already installed
+* [#461](https://github.com/Icinga/icinga-powershell-framework/issues/461) Fixes `Add-IcingaRepository` which now only overrides the `RemotePath` by using `-Force` instead of removing and adding the repository again, causing problems with installation orders over IMC for example
 
 ### Enhancements
 

--- a/lib/core/repository/Add-IcingaRepository.psm1
+++ b/lib/core/repository/Add-IcingaRepository.psm1
@@ -30,10 +30,18 @@ function Add-IcingaRepository()
         Write-IcingaConsoleError 'A repository with the given name "{0}" does already exist. Use "-Force" to overwrite the current repository' -Objects $Name;
         return;
     } elseif ($RepoExists -And $Force) {
-        Write-IcingaConsoleNotice 'Repository "{0}" is already registered. Forcing removal and re-adding it.' -Objects $Name;
-        Remove-IcingaRepository -Name $Name;
+        Write-IcingaConsoleNotice 'Repository "{0}" is already registered. Forcing override of data.' -Objects $Name;
 
-        $CurrentRepositories = Get-IcingaPowerShellConfig -Path 'Framework.Repository.Repositories';
+        foreach ($entry in $CurrentRepositories.PSObject.Properties) {
+            if ($Name.ToLower() -eq $entry.Name.ToLower()) {
+                $entry.Value.RemotePath = $RemotePath;
+                break;
+            }
+        }
+
+        Set-IcingaPowerShellConfig -Path 'Framework.Repository.Repositories' -Value $CurrentRepositories;
+
+        return;
     }
 
     [array]$RepoCount = $CurrentRepositories.PSObject.Properties.Count;


### PR DESCRIPTION
Fixes `Add-IcingaRepository` which now only overrides the `RemotePath` by using `-Force` instead of removing and adding the repository again, causing problems with installation orders over IMC for example

Fixes #461