### PR TITLE
Fix: Adds DSL parser to string arguments to fix whitespace and $ escaping

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#473](https://github.com/Icinga/icinga-powershell-framework/pull/473) Fixes an issue with current string rendering config implementation, as string values containing whitespaces or `$` are rendered wrong by default, if not set in single quotes `''`
 * [#476](https://github.com/Icinga/icinga-powershell-framework/pull/476) Fixes exception `You cannot call a method on va null-valued expression` during installation in case no background daemon is configured
 * [#529](https://github.com/Icinga/icinga-powershell-framework/pull/529) Fixes package manifest reader for Icinga for Windows components on Windows 2012 R2 and older
 * [#523](https://github.com/Icinga/icinga-powershell-framework/pull/523) Fixes errors on encapsulated PowerShell calls for missing Cmdlets `Write-IcingaConsoleError` and `Optimize-IcingaForWindowsMemory`


### PR DESCRIPTION
Fixes an issue with current implementation, as string values containing whitespaces or `$` are rendered wrong by default, if not set in single quotes `''`

Example:

Using `My Service`

will output

`My`
`Service`

This issue is already fixed for arrays, but plain string values on arguments require this workaround.

As Icinga 2 will always set arguments if a DSL is specified, regardless if a value is present or not, we have to use a `set_if` expression for this, but can't as the Icinga Director baskets currently ignore `set_if_format` which requires to be an expression instead of a string.

https://github.com/Icinga/icingaweb2-module-director/issues/2291

This PR is pending as long as the Director issue is not fixed and released within a release.