### PR TITLE
Fix: Option "Connecting from parent system" is not asking for ca.crt

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#472](https://github.com/Icinga/icinga-powershell-framework/pull/472) Fixes random errors while dynamically compiling Add-Type code by now writing a DLL inside `cache/dll` for later usage
+* [#478](https://github.com/Icinga/icinga-powershell-framework/pull/478) Fixes connection option "Connecting from parent system" which is not asking for ca.crt location
 
 ### Enhancements
 

--- a/lib/core/installer/menu/installation/AdvancedEntries.psm1
+++ b/lib/core/installer/menu/installation/AdvancedEntries.psm1
@@ -11,7 +11,11 @@ function Add-IcingaForWindowsInstallationAdvancedEntries()
 
     Show-IcingaForWindowsInstallationMenuEnterIcingaPort -Automated -Advanced;
     Show-IcingaForWindowsInstallerMenuSelectOpenWindowsFirewall -DefaultInput $OpenFirewall -Automated -Advanced;
-    Show-IcingaForWindowsInstallerMenuSelectCertificate -Automated -Advanced;
+    # Only apply the certificate menu in case it was not selected previously, if
+    # we choose IfW-Connection 1 for example, which tells the Parent to connect to Agent only
+    if ($null -eq (Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectCertificate')) {
+        Show-IcingaForWindowsInstallerMenuSelectCertificate -Automated -Advanced;
+    }
     Show-IcingaForWindowsInstallerMenuSelectForceCertificateGeneration -Automated -Advanced;
     Show-IcingaForWindowsInstallerMenuSelectGlobalZones -Automated -Advanced;
     Show-IcingaForWindowsInstallationMenuEnterCustomGlobalZones -Automated -Advanced;

--- a/lib/core/installer/menu/installation/certificate/EnterIcingaCAFile.psm1
+++ b/lib/core/installer/menu/installation/certificate/EnterIcingaCAFile.psm1
@@ -27,6 +27,14 @@ function Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile()
         -ConfigElement `
         -Automated:$Automated `
         -Advanced:$Advanced;
+
+    # By default, we are never prompt to enter the CA target path, unless we are connecting
+    # from Parent->Agent, which is option 1 von IfW-Connection
+    # In case we run this configuration, we are forwarded from that menu to here and require
+    # to enter the hostname in addition
+    if ((Test-IcingaForWindowsManagementConsoleContinue) -And $JumpToSummary -eq $FALSE) {
+        $global:Icinga.InstallWizard.NextCommand = 'Show-IcingaForWindowsInstallerMenuSelectHostname';
+    }
 }
 
 Set-Alias -Name 'IfW-CAFile' -Value 'Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile';

--- a/lib/core/installer/menu/installation/certificate/SelectCertificate.psm1
+++ b/lib/core/installer/menu/installation/certificate/SelectCertificate.psm1
@@ -49,6 +49,17 @@ function Show-IcingaForWindowsInstallerMenuSelectCertificate()
             break;
         };
     }
+
+    # By Default, we are not jumping to the Summary on this menu but will require this in case
+    # we choose CAFile selection and are on the summary page, as then we do not want to be prompted
+    # for the Hostname again and require to tell the CA menu, that we should directly move to the
+    # summary page again
+    $LastInput = Get-IcingaForWindowsManagementConsoleLastInput;
+
+    if ($LastInput -eq '2' -And $JumpToSummary) {
+        $global:Icinga.InstallWizard.NextCommand   = 'Show-IcingaForWindowsInstallerMenuEnterIcingaCAFile';
+        $global:Icinga.InstallWizard.NextArguments = @{ 'JumpToSummary' = $TRUE; };
+    }
 }
 
 Set-Alias -Name 'IfW-Certificate' -Value 'Show-IcingaForWindowsInstallerMenuSelectCertificate';


### PR DESCRIPTION
While using the IMC with the connection option "Connecting from parent system", the wizard is not asking for the location of the ca.crt, which is required in order to complete the Icinga Agent process and ensure the API feature can be enabled afterwards.

Before, the user had to manually configure this step, which required knowledge on how this process works for Icinga.