### PR TITLE
Fix: Encoding problems with special chars or German umlauts

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -15,6 +15,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#473](https://github.com/Icinga/icinga-powershell-framework/pull/473) Fixes an issue with current string rendering config implementation, as string values containing whitespaces or `$` are rendered wrong by default, if not set in single quotes `''`
 * [#476](https://github.com/Icinga/icinga-powershell-framework/pull/476) Fixes exception `You cannot call a method on va null-valued expression` during installation in case no background daemon is configured
+* [#482](https://github.com/Icinga/icinga-powershell-framework/pull/482) Fixes encoding problems with special chars or German umlauts during plugin execution and unescaped whitespace in plugin argument strings like `Icinga for Windows`, which was previously wrongly rended as `Icinga` for example
 * [#529](https://github.com/Icinga/icinga-powershell-framework/pull/529) Fixes package manifest reader for Icinga for Windows components on Windows 2012 R2 and older
 * [#523](https://github.com/Icinga/icinga-powershell-framework/pull/523) Fixes errors on encapsulated PowerShell calls for missing Cmdlets `Write-IcingaConsoleError` and `Optimize-IcingaForWindowsMemory`
 * [#524](https://github.com/Icinga/icinga-powershell-framework/issues/524) Fixes uninstallation process by improving the location handling of PowerShell instances with Icinga IMC or Shell

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -108,7 +108,7 @@ function Write-IcingaFrameworkCodeCache()
     # Load modules from directory
     Get-ChildItem -Path $directory -Recurse -Filter '*.psm1' |
         ForEach-Object {
-            $CacheContent += (Get-Content -Path $_.FullName -Raw);
+            $CacheContent += (Get-Content -Path $_.FullName -Raw -Encoding 'UTF8');
             $CacheContent += "`r`n";
         }
 
@@ -122,7 +122,7 @@ function Write-IcingaFrameworkCodeCache()
         return;
     }
 
-    Set-Content -Path $CacheFile -Value $CacheContent;
+    Set-Content -Path $CacheFile -Value $CacheContent -Encoding 'UTF8';
 
     Remove-IcingaFrameworkDependencyFile;
 

--- a/lib/core/icingaagent/readers/Read-IcingaAgentDebugLogFile.psm1
+++ b/lib/core/icingaagent/readers/Read-IcingaAgentDebugLogFile.psm1
@@ -6,5 +6,5 @@ function Read-IcingaAgentDebugLogFile()
         return;
     }
 
-    Get-Content -Path $Logfile -Tail 20 -Wait;
+    Get-Content -Path $Logfile -Tail 20 -Wait -Encoding 'UTF8';
 }

--- a/lib/core/icingaagent/readers/Read-IcingaAgentLogFile.psm1
+++ b/lib/core/icingaagent/readers/Read-IcingaAgentLogFile.psm1
@@ -11,6 +11,6 @@ function Read-IcingaAgentLogFile()
             return;
         }
 
-        Get-Content -Path $Logfile -Tail 20 -Wait;
+        Get-Content -Path $Logfile -Tail 20 -Wait -Encoding 'UTF8';
     }
 }

--- a/lib/core/tools/ConvertTo-IcingaPowerShellArguments.psm1
+++ b/lib/core/tools/ConvertTo-IcingaPowerShellArguments.psm1
@@ -1,0 +1,133 @@
+<#
+.SYNOPSIS
+    Fixes the current encoding hell for arguments by taking every argument
+    parsed from Icinga and converting it from PowerShell native encoding
+    to UTF8
+.DESCRIPTION
+    Fixes the current encoding hell for arguments by taking every argument
+    parsed from Icinga and converting it from PowerShell native encoding
+    to UTF8
+.PARAMETER Arguments
+    The array of arguments for re-encoding. By default, this could be $args
+    for calls from Exit-IcingaExecutePlugin
+.EXAMPLE
+    PS> [hashtable]$ConvertedArgs = ConvertTo-IcingaPowerShellArguments -Arguments $args;
+#>
+
+function ConvertTo-IcingaPowerShellArguments()
+{
+    param (
+        [array]$Arguments = @()
+    );
+
+    [hashtable]$IcingaArguments = @{ };
+    [int]$ArgumentIndex         = 0;
+
+    while ($ArgumentIndex -lt $Arguments.Count) {
+        # Check if the current position is a string
+        if ($Arguments[$ArgumentIndex] -IsNot [string]) {
+            # Continue if we are not a string (argument)
+            $ArgumentIndex += 1;
+            continue;
+        }
+
+        # check_by_icingaforwindows arguments -> not required for any plugin execution
+        if ($Arguments[$ArgumentIndex] -eq '-IcingaForWindowsRemoteExecution' -Or $Arguments[$ArgumentIndex] -eq '-IcingaForWindowsJEARemoteExecution') {
+            $ArgumentIndex += 1;
+            continue;
+        }
+
+        # Check if it starts with '-', which should indicate it being an argument
+        if ($Arguments[$ArgumentIndex][0] -ne '-') {
+             # Continue if we are not an argument
+             $ArgumentIndex += 1;
+             continue;
+        }
+
+        # First convert our argument
+        [string]$Argument = ConvertTo-IcingaUTF8Value -InputObject $Arguments[$ArgumentIndex];
+        # Cut the first '-'
+        $Argument         = $Argument.Substring(1, $Argument.Length - 1);
+
+        # Check if there is anything beyond this argument, if not
+        # -> We are a switch argument, adding TRUE;
+        if (($ArgumentIndex + 1) -ge $Arguments.Count) {
+            $IcingaArguments.Add($Argument, $TRUE);
+            $ArgumentIndex += 1;
+            continue;
+        }
+
+        # Check if our next value in the array is a string
+        if ($Arguments[$ArgumentIndex + 1] -Is [string]) {
+            [string]$NextValue = $Arguments[$ArgumentIndex + 1];
+
+            # If our next value on the index starts with '-', we found another argument
+            # -> The current argument seems to be a switch argument
+            if ($NextValue[0] -eq '-') {
+                $IcingaArguments.Add($Argument, $TRUE);
+                $ArgumentIndex += 1;
+                continue;
+            }
+
+            # It could be that we parse strings without quotation which is broken because on how
+            # Icinga is actually writing the arguments, let's fix this by building the string ourselves
+            [int]$ReadStringIndex = $ArgumentIndex;
+            $StringValue          = New-Object -TypeName 'System.Text.StringBuilder';
+            while ($TRUE) {
+                # Check if we read beyond our array
+                if (($ReadStringIndex + 1) -ge $Arguments.Count) {
+                    break;
+                }
+
+                # Check if the next element is no longer a string element
+                if ($Arguments[$ReadStringIndex + 1] -IsNot [string]) {
+                    break;
+                }
+
+                [string]$NextValue = $Arguments[$ReadStringIndex + 1];
+
+                # In case the next string element starts with '-', this could be an argument
+                if ($NextValue[0] -eq '-') {
+                    break;
+                }
+
+                # If we already added elements to our string builder before, add a whitespace
+                if ($StringValue.Length -ne 0) {
+                    $StringValue.Append(' ') | Out-Null;
+                }
+
+                # Append our string value to the string builder
+                $StringValue.Append($NextValue) | Out-Null;
+                $ReadStringIndex += 1;
+            }
+
+            # Add our argument with the string builder value, in case we had something to add there
+            if ($StringValue.Length -ne 0) {
+                $IcingaArguments.Add($Argument, (ConvertTo-IcingaUTF8Value -InputObject $StringValue.ToString()));
+                $ArgumentIndex += 1;
+                continue;
+            }
+        }
+
+        # All Remaining values
+
+        # If we are an array object, handle empty arrays
+        if ($Arguments[$ArgumentIndex + 1] -Is [array]) {
+            if ($null -eq $Arguments[$ArgumentIndex + 1] -Or ($Arguments[$ArgumentIndex + 1]).Count -eq 0) {
+                $IcingaArguments.Add($Argument, @());
+                $ArgumentIndex += 1;
+                continue;
+            }
+        }
+
+        # Add everything else
+        $IcingaArguments.Add(
+            $Argument,
+            (ConvertTo-IcingaUTF8Value -InputObject $Arguments[$ArgumentIndex + 1])
+        );
+
+        $ArgumentIndex += 1;
+    }
+
+    return $IcingaArguments;
+}

--- a/lib/core/tools/ConvertTo-IcingaUTF8Value.psm1
+++ b/lib/core/tools/ConvertTo-IcingaUTF8Value.psm1
@@ -1,0 +1,50 @@
+<#
+.SYNOPSIS
+    Converts strings and all  objects within an array from Default PowerShell encoding
+    to UTF8
+.DESCRIPTION
+    Converts strings and all  objects within an array from Default PowerShell encoding
+    to UTF8
+.PARAMETER InputObject
+    A string or array object to convert
+.EXAMPLE
+    PS> [array]$ConvertedArgs = ConvertTo-IcingaUTF8Arguments -Arguments $args;
+#>
+
+function ConvertTo-IcingaUTF8Value()
+{
+    param (
+        $InputObject = $null
+    );
+
+    if ($null -eq $InputObject) {
+        return $InputObject;
+    }
+
+    if ($InputObject -Is [string]) {
+        # If german umlauts are contained, do not convert the value
+        # Fixing issues for running checks locally on CLI vs. Icinga Agent
+        if ($InputObject -Match "[äöüÄÖÜß]") {
+            return $InputObject;
+        }
+
+        $InputInBytes = [System.Text.Encoding]::Default.GetBytes($InputObject);
+
+        return ([string]([System.Text.Encoding]::UTF8.GetString($InputInBytes)));
+    } elseif ($InputObject -Is [array]) {
+        [array]$ArrayObject = @();
+
+        foreach ($entry in $InputObject) {
+            if ($entry -Is [array]) {
+                $ArrayObject += , (ConvertTo-IcingaUTF8Value -InputObject $entry);
+            } else {
+                $ArrayObject += ConvertTo-IcingaUTF8Value -InputObject $entry;
+            }
+        }
+
+        return $ArrayObject;
+    }
+
+    # If we are not a string or a array, just return the object
+    return $InputObject;
+}


### PR DESCRIPTION
Fixes Icinga for Windows plugin execution, by converting all parsed arguments and values from Icinga 2 from the `Default` of the PowerShell to `UTF8`.

This resolves issues during plugin execution on which arguments like `-Path`, `-TaskName` or anything else contained characters like `äöüß`.

In addition, we created an internal `StringBuilder` to resolve current issues on which unescaped strings within the Icinga configuration like `Icinga for Windows` instead of `'Icinga for Windows'`, are interpreted as `Icinga` instead of `Icinga for Windows` because of the whitespaces.

The new argument parser will test for this and create a proper string output value.