### PR TITLE
Fix: REST-Api SSL certificate lookup on custom hostname or domain/dns domain mismatch

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -17,6 +17,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#478](https://github.com/Icinga/icinga-powershell-framework/pull/478) Fixes connection option "Connecting from parent system" which is not asking for ca.crt path
 * [#479](https://github.com/Icinga/icinga-powershell-framework/pull/479) Fixes possible exceptions while trying to remove downloaded repository temp files which might still contain a file lock from virusscanners or other tasks
 * [#480](https://github.com/Icinga/icinga-powershell-framework/pull/480) Fixes service locking during Icinga Agent upgrade and ensures errors on service management are caught and printed with internal error handling
+* [#483](https://github.com/Icinga/icinga-powershell-framework/issues/483) Fixes REST-Api SSL certificate lookup from the Icinga Agent, in case a custom hostname was used or in certain domain environments were domain is not matching DNS domain
 * [#490](https://github.com/Icinga/icinga-powershell-framework/pull/490) Fixes the command `Uninstall-IcingaComponent` for the `service` component which is not doing anything
 
 ### Enhancements

--- a/lib/core/icingaagent/getters/Get-IcingaAgentHostCertificate.psm1
+++ b/lib/core/icingaagent/getters/Get-IcingaAgentHostCertificate.psm1
@@ -11,7 +11,7 @@ function Get-IcingaAgentHostCertificate()
     # Default for Icinga 2.8.0 and above
     [string]$CertDirectory = (Join-Path -Path $Env:ProgramData -ChildPath 'icinga2\var\lib\icinga2\certs\*');
     $FolderContent         = Get-ChildItem -Path $CertDirectory -Filter '*.crt' -Exclude 'ca.crt';
-    $Hostname              = Get-IcingaHostname -LowerCase $TRUE;
+    $Hostname              = Get-IcingaHostname -ReadConstants;
     $CertPath              = $null;
 
     foreach ($certFile in $FolderContent) {

--- a/lib/core/icingaagent/getters/Get-IcingaHostname.psm1
+++ b/lib/core/icingaagent/getters/Get-IcingaHostname.psm1
@@ -5,10 +5,41 @@ function Get-IcingaHostname()
         [bool]$AutoUseFQDN     = $FALSE,
         [bool]$AutoUseHostname = $FALSE,
         [bool]$UpperCase       = $FALSE,
-        [bool]$LowerCase       = $FALSE
+        [bool]$LowerCase       = $FALSE,
+        [switch]$ReadConstants = $FALSE
     );
 
     [string]$UseHostname = '';
+
+    if ($ReadConstants) {
+        if (Test-Path -Path (Join-Path -Path $Env:ProgramData -ChildPath 'icinga2\etc\icinga2\constants.conf')) {
+            # Read the constants conf
+            $FileContent = Get-Content -Path (Join-Path -Path $Env:ProgramData -ChildPath 'icinga2\etc\icinga2\constants.conf') -Encoding 'UTF8';
+
+            foreach ($line in $FileContent) {
+                if ($line.Contains('NodeName') -eq $FALSE) {
+                    continue;
+                }
+
+                if ($line.Contains('const') -eq $FALSE -Or $line.Contains('=') -eq $FALSE -Or $line.Contains('"') -eq $FALSE) {
+                    continue;
+                }
+
+                [int]$ValueIndex = $line.IndexOf('"') + 1;
+
+                $UseHostname = $line.SubString($ValueIndex, $line.Length - $ValueIndex);
+
+                if ($UseHostname[-1] -eq '"') {
+                    $UseHostname = $UseHostname.Substring(0, $UseHostname.Length - 1);
+                }
+
+                break;
+            }
+
+            return $UseHostname
+        }
+    }
+
     if ([string]::IsNullOrEmpty($Hostname) -eq $FALSE) {
         $UseHostname = $Hostname;
     } elseif ($AutoUseFQDN) {

--- a/lib/webserver/Get-IcingaSSLCertForSocket.psm1
+++ b/lib/webserver/Get-IcingaSSLCertForSocket.psm1
@@ -34,7 +34,7 @@ function Get-IcingaSSLCertForSocket()
         }
     }
 
-    # If no cert file or thumbprint was specified or simpy as fallback,
+    # If no cert file or thumbprint was specified or simply as fallback,
     # we should use the Icinga 2 Agent certificates
     $AgentCertificate = Get-IcingaAgentHostCertificate;
 


### PR DESCRIPTION
Fixes REST-Api SSL certificate lookup from the Icinga Agent, in case a custom hostname was used or in certain domain environments were domain is not matching DNS domain

Fixes #483