### PR TITLE
Fix: Uninstaller for service component not working

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -17,6 +17,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#478](https://github.com/Icinga/icinga-powershell-framework/pull/478) Fixes connection option "Connecting from parent system" which is not asking for ca.crt path
 * [#479](https://github.com/Icinga/icinga-powershell-framework/pull/479) Fixes possible exceptions while trying to remove downloaded repository temp files which might still contain a file lock from virusscanners or other tasks
 * [#480](https://github.com/Icinga/icinga-powershell-framework/pull/480) Fixes service locking during Icinga Agent upgrade and ensures errors on service management are caught and printed with internal error handling
+* [#490](https://github.com/Icinga/icinga-powershell-framework/pull/490) Fixes the command `Uninstall-IcingaComponent` for the `service` component which is not doing anything
 
 ### Enhancements
 

--- a/lib/core/repository/Uninstall-IcingaComponent.psm1
+++ b/lib/core/repository/Uninstall-IcingaComponent.psm1
@@ -11,11 +11,11 @@ function Uninstall-IcingaComponent()
     }
 
     if ($Name.ToLower() -eq 'agent') {
-        return Uninstall-IcingaAgent -RemoveDataFolder:$RemovePackageFiles;
+        return (Uninstall-IcingaAgent -RemoveDataFolder:$RemovePackageFiles);
     }
 
     if ($Name.ToLower() -eq 'service') {
-        return; Uninstall-IcingaForWindowsService -RemoveFiles:$RemovePackageFiles;
+        return (Uninstall-IcingaForWindowsService -RemoveFiles:$RemovePackageFiles);
     }
 
     $ModuleBase         = Get-IcingaForWindowsRootPath;


### PR DESCRIPTION
Fixes the command `Uninstall-IcingaComponent` for the `service` component which is not working.