### PR TITLE
Fix: Improves REST-Api default timeout

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -24,6 +24,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#469](https://github.com/Icinga/icinga-powershell-framework/pull/469) Improves plugin doc generator to allow multi-lines in code examples and updates plugin overview as table, adding a short description on what the plugin is for
 * [#495](https://github.com/Icinga/icinga-powershell-framework/pull/495) Adds feature to check the sign status for the local Icinga Agent certificate and notifying the user, in case the certificate is not yet signed by the Icinga CA
+* [#496](https://github.com/Icinga/icinga-powershell-framework/pull/496) Improves REST-Api default timeout for internal plugin execution calls from 30s to 120s
 
 ## 1.8.0 (2022-02-08)
 

--- a/lib/core/framework/Invoke-IcingaInternalServiceCall.psm1
+++ b/lib/core/framework/Invoke-IcingaInternalServiceCall.psm1
@@ -31,7 +31,7 @@ function Invoke-IcingaInternalServiceCall()
     }
 
     $RestApiPort  = 5668;
-    [int]$Timeout = 30;
+    [int]$Timeout = 120;
     $Daemon       = $BackgroundDaemons['Start-IcingaWindowsRESTApi'];
 
     # Fetch our deamon configuration

--- a/lib/daemons/RestAPI/daemon/Start-IcingaWindowsRESTApi.psm1
+++ b/lib/daemons/RestAPI/daemon/Start-IcingaWindowsRESTApi.psm1
@@ -51,7 +51,7 @@ function Start-IcingaWindowsRESTApi()
         [string]$CertThumbprint = $null,
         [bool]$RequireAuth      = $FALSE,
         [int]$ConcurrentThreads = 5,
-        [int]$Timeout           = 30
+        [int]$Timeout           = 120
     );
 
     New-IcingaForWindowsRESTEnvironment -ThreadCount $ConcurrentThreads;


### PR DESCRIPTION
Improves REST-Api default timeout for internal plugin execution calls from 30s to 120s