### PR TITLE
#324-hostname-for-old-installer-method

### DIFF
--- a/lib/core/icingaagent/misc/Start-IcingaAgentDirectorWizard.psm1
+++ b/lib/core/icingaagent/misc/Start-IcingaAgentDirectorWizard.psm1
@@ -5,7 +5,8 @@ function Start-IcingaAgentDirectorWizard()
         [string]$SelfServiceAPIKey = $null,
         $OverrideDirectorVars      = $null,
         [bool]$RunInstaller        = $FALSE,
-        [switch]$ForceTemplateKey  = $FALSE
+        [switch]$ForceTemplateKey  = $FALSE,
+	    [string]$Hostname = $null
     );
 
     [hashtable]$DirectorOverrideArgs        = @{ }
@@ -64,6 +65,7 @@ function Start-IcingaAgentDirectorWizard()
                 -DirectorUrl $DirectorUrl `
                 -SelfServiceAPIKey $TemplateKey `
                 -OverrideDirectorVars $OverrideDirectorVars `
+				-Hostname $Hostname `
                 -ForceTemplateKey;
         }
     } else {
@@ -74,7 +76,7 @@ function Start-IcingaAgentDirectorWizard()
 
             return Start-IcingaAgentDirectorWizard `
                 -SelfServiceAPIKey ((Get-IcingaAgentInstallerAnswerInput -Prompt 'Please re-enter your SelfService API Key for the Host-Template in case the key is no longer assigned to your host' -Default 'v' -DefaultInput $SelfServiceAPIKey).answer) `
-                -OverrideDirectorVars $OverrideDirectorVars;
+                -OverrideDirectorVars $OverrideDirectorVars -Hostname $Hostname;
         }
     }
 
@@ -88,7 +90,9 @@ function Start-IcingaAgentDirectorWizard()
             }
         }
     }
-
+    if($Hostname -ne $null){
+        $Arguments.Add('Hostname',$Hostname);
+    }
     if ($HostKnown -eq $FALSE) {
         while ($TRUE) {
             [bool]$RegisterFailed = $FALSE;

--- a/lib/core/icingaagent/misc/Start-IcingaAgentInstallWizard.psm1
+++ b/lib/core/icingaagent/misc/Start-IcingaAgentInstallWizard.psm1
@@ -211,6 +211,7 @@ function Start-IcingaAgentInstallWizard()
                 -DirectorUrl $DirectorUrl `
                 -SelfServiceAPIKey $SelfServiceAPIKey `
                 -OverrideDirectorVars $OverrideDirectorVars `
+                -Hostname $Hostname `
                 -RunInstaller $RunInstaller;
 
             $Result              = Set-IcingaWizardArgument -DirectorArgs $DirectorArgs -WizardArg 'DirectorUrl' -Value $DirectorUrl -InstallerArguments $InstallerArguments;


### PR DESCRIPTION
This small patches allow to successfully override a hostname in the old installer method