### PR TITLE
fix/hostname-override-hostname#505

### DIFF
--- a/lib/core/installer/Install-Icinga.psm1
+++ b/lib/core/installer/Install-Icinga.psm1
@@ -79,6 +79,17 @@ function Install-Icinga()
         if ($IcingaConfiguration.ContainsKey('IfW-DirectorSelfServiceKey') -And $IcingaConfiguration.ContainsKey('IfW-DirectorUrl')) {
             Enable-IcingaFrameworkConsoleOutput;
             Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate;
+            Disable-IcingaFrameworkConsoleOutput;
+            
+            # Now apply our configuration again to ensure the defaults are overwritten again
+            # Suite a mess, but we can improve this later
+            $Success = Invoke-IcingaForWindowsManagementConsoleCustomConfig -IcingaConfiguration $IcingaConfiguration;
+
+            if ($Success -eq $FALSE) {
+                return;
+            }
+            
+            Enable-IcingaFrameworkConsoleOutput;
             Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate -Register;
             Disable-IcingaFrameworkConsoleOutput;
         } else {


### PR DESCRIPTION
voodoo solution but it was not possible for me to get the vars inside with only one run.

ConfigFunction = Invoke-IcingaForWindowsManagementConsoleCustomConfig
DirectorFunction = Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate

First Run of ConfigFunction, hostname vars are in config but empty once the DirectorFunction function called it

Second Run of ConfigFunction hostname vars set and availiable in DirectorFunction