### PR TITLE
Fix: Removes RootModule from Manifest file

### DIFF
--- a/lib/core/dev/New-IcingaForWindowsComponent.psm1
+++ b/lib/core/dev/New-IcingaForWindowsComponent.psm1
@@ -205,7 +205,6 @@ function New-IcingaForWindowsComponent()
     Write-IcingaForWindowsComponentManifest -Name $Name -ModuleConfig @{
         '$MODULENAME$'        = ([string]::Format('Windows {0}', $Name));
         '$GUID$'              = (New-Guid);
-        '$ROOTMODULE$'        = ([string]::Format('{0}.psm1', $ModuleName));
         '$AUTHOR$'            = $Author;
         '$COMPANYNAME$'       = $CompanyName;
         '$COPYRIGHT$'         = $Copyright;

--- a/templates/Manifest.psd1.template
+++ b/templates/Manifest.psd1.template
@@ -1,6 +1,5 @@
 @{
     ModuleVersion     = '$MODULEVERSION$'
-    RootModule        = '$ROOTMODULE$'
     GUID              = '$GUID$'
     Author            = '$AUTHOR$'
     CompanyName       = '$COMPANYNAME$'


### PR DESCRIPTION
With the new module isolation, we no longer require the `RootModule` entry for manifest files.