### PR TITLE
Fix: Missing component import func on dev tools

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/24?closed=1)
 
 * [#519](https://github.com/Icinga/icinga-powershell-framework/pull/519) Fixes missing loading of Icinga for Windows modules, which is required to ensure an Icinga for Windows environment is providing all commands and variables to a session, allowing other modules to access these information
+* [#520](https://github.com/Icinga/icinga-powershell-framework/pull/520) Adds missing `Import-IcingaPowerShellComponent` function while creating new components by using the developer tools
 
 ## 1.9.0 (2022-05-03)
 

--- a/lib/core/dev/New-IcingaForWindowsComponent.psm1
+++ b/lib/core/dev/New-IcingaForWindowsComponent.psm1
@@ -71,6 +71,13 @@ function New-IcingaForWindowsComponent()
     New-Item -ItemType File -Path (Join-Path -Path $ModuleDir -ChildPath 'README.md') | Out-Null;
     New-Item -ItemType File -Path (Join-Path -Path $ModuleDir -ChildPath ([string]::Format('{0}.psm1', $ModuleName))) | Out-Null;
 
+    $ModuleMainFile = Join-Path -Path $ModuleDir -ChildPath ([string]::Format('{0}.psm1', $ModuleName));
+
+    Set-Content -Path $ModuleMainFile -Value ([string]::Format('function Import-IcingaPowerShellComponent{0}()', $TextInfo.ToTitleCase($Name)));
+    Add-Content -Path $ModuleMainFile -Value '{';
+    Add-Content -Path $ModuleMainFile -Value '';
+    Add-Content -Path $ModuleMainFile -Value '}';
+
     switch ($ComponentType) {
         'plugins' {
             New-Item -ItemType Directory -Path (Join-Path -Path $ModuleDir -ChildPath 'plugins') | Out-Null;


### PR DESCRIPTION
Adds missing `Import-IcingaPowerShellComponent` function while creating new components by using the developer tools