### PR TITLE
Fix: Package manifest reader on Win 2012 R2

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -11,6 +11,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/23?closed=1)
 
+### Bugfixes
+
+* [#529](https://github.com/Icinga/icinga-powershell-framework/pull/529) Fixes package manifest reader for Icinga for Windows components on Windows 2012 R2 and older
+
 ### Enhancements
 
 * [#40](https://github.com/Icinga/icinga-powershell-framework/issues/40) Adds support to set service recovery for the Icinga Agent and Icinga for Windows service, to restart them in case of a crash or error

--- a/lib/core/repository/Read-IcingaPackageManifest.psm1
+++ b/lib/core/repository/Read-IcingaPackageManifest.psm1
@@ -34,7 +34,7 @@ function Read-IcingaPackageManifest()
                 $FileName                   = $entry.Name.Replace('.psd1', '');
                 $FilePath                   = $entry.FullName.Replace($entry.Name, '');
                 $FileStream                 = $entry.Open();
-                $FileReader                 = [System.IO.StreamReader]::new($FileStream);
+                $FileReader                 = New-Object 'System.IO.StreamReader'($FileStream);
                 $PackageManifestContent     = $FileReader.ReadToEnd();
                 $FileReader.Dispose();
 


### PR DESCRIPTION
Fixes package manifest reader for Icinga for Windows components on Windows 2012 R2 and older.