### PR TITLE
Fix: Exceptions on encapsulated PowerShell calls for missing Cmdlets

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#529](https://github.com/Icinga/icinga-powershell-framework/pull/529) Fixes package manifest reader for Icinga for Windows components on Windows 2012 R2 and older
+* [#523](https://github.com/Icinga/icinga-powershell-framework/pull/523) Fixes errors on encapsulated PowerShell calls for missing Cmdlets `Write-IcingaConsoleError` and `Optimize-IcingaForWindowsMemory`
 
 ### Enhancements
 

--- a/lib/core/framework/Install-IcingaFrameworkComponent.psm1
+++ b/lib/core/framework/Install-IcingaFrameworkComponent.psm1
@@ -112,7 +112,7 @@ function Install-IcingaFrameworkComponent()
 
     if ([string]::IsNullOrEmpty((Get-IcingaJEAContext)) -eq $FALSE) {
         Write-IcingaConsoleNotice 'Updating Icinga JEA profile';
-        & powershell.exe -Command { Use-Icinga; Install-IcingaJEAProfile; } | Out-Null;
+        & powershell.exe -Command { Use-Icinga -Minimal; Install-IcingaJEAProfile; } | Out-Null;
     }
 
     # Unload the module if it was loaded before

--- a/lib/core/framework/Install-IcingaFrameworkUpdate.psm1
+++ b/lib/core/framework/Install-IcingaFrameworkUpdate.psm1
@@ -109,7 +109,7 @@ function Install-IcingaFrameworkUpdate()
     if ([string]::IsNullOrEmpty((Get-IcingaJEAContext)) -eq $FALSE) {
         Remove-IcingaFrameworkDependencyFile;
         Write-IcingaConsoleNotice 'Updating Icinga JEA profile';
-        & powershell.exe -Command { Use-Icinga; Install-IcingaJEAProfile; } | Out-Null;
+        & powershell.exe -Command { Use-Icinga -Minimal; Install-IcingaJEAProfile; } | Out-Null;
     }
 
     Write-IcingaConsoleNotice 'Framework update has been completed. Please start a new PowerShell instance now to complete the update';

--- a/lib/core/framework/Restart-IcingaService.psm1
+++ b/lib/core/framework/Restart-IcingaService.psm1
@@ -28,6 +28,8 @@ function Restart-IcingaService()
         Write-IcingaConsoleNotice ([string]::Format('Restarting service "{0}"', $Service));
 
         & powershell.exe -Command {
+            Use-Icinga -Minimal;
+
             $Service = $args[0];
             try {
                 Restart-Service "$Service" -ErrorAction Stop;

--- a/lib/core/framework/Start-IcingaService.psm1
+++ b/lib/core/framework/Start-IcingaService.psm1
@@ -28,6 +28,8 @@ function Start-IcingaService()
         Write-IcingaConsoleNotice -Message 'Starting service "{0}"' -Objects $Service;
 
         & powershell.exe -Command {
+            Use-Icinga -Minimal;
+
             $Service = $args[0];
             try {
                 Start-Service "$Service" -ErrorAction Stop;

--- a/lib/core/framework/Stop-IcingaService.psm1
+++ b/lib/core/framework/Stop-IcingaService.psm1
@@ -28,6 +28,8 @@ function Stop-IcingaService()
         Write-IcingaConsoleNotice -Message 'Stopping service "{0}"' -Objects $Service;
 
         & powershell.exe -Command {
+            Use-Icinga -Minimal;
+
             $Service = $args[0];
             try {
                 Stop-Service "$Service" -ErrorAction Stop;

--- a/lib/core/icingaagent/installer/Install-IcingaAgent.psm1
+++ b/lib/core/icingaagent/installer/Install-IcingaAgent.psm1
@@ -74,6 +74,8 @@ function Install-IcingaAgent()
     }
 
     $InstallProcess = & powershell.exe -Command {
+        Use-Icinga -Minimal;
+
         $IcingaInstaller = $args[0];
         $InstallTarget   = $args[1];
         $InstallProcess  = Start-IcingaProcess -Executable 'MsiExec.exe' -Arguments ([string]::Format('/quiet /i "{0}" {1}', $IcingaInstaller.InstallerPath, $InstallTarget)) -FlushNewLines;

--- a/lib/core/icingaagent/installer/Uninstall-IcingaAgent.psm1
+++ b/lib/core/icingaagent/installer/Uninstall-IcingaAgent.psm1
@@ -23,6 +23,8 @@ function Uninstall-IcingaAgent()
     Stop-IcingaService -Service 'icinga2';
 
     $Uninstaller = & powershell.exe -Command {
+        Use-Icinga -Minimal;
+
         $IcingaData  = $args[0];
         $Uninstaller = Start-IcingaProcess -Executable 'MsiExec.exe' -Arguments ([string]::Format('{0} /q', $IcingaData.Uninstaller)) -FlushNewLine;
 

--- a/lib/core/repository/Install-IcingaComponent.psm1
+++ b/lib/core/repository/Install-IcingaComponent.psm1
@@ -349,6 +349,8 @@ function Install-IcingaComponent()
         }
 
         $MSIData = & powershell.exe -Command {
+            Use-Icinga -Minimal;
+
             $DownloadDestination = $args[0];
             return (Read-IcingaMSIMetadata -File $DownloadDestination);
         } -Args $DownloadDestination;
@@ -369,6 +371,8 @@ function Install-IcingaComponent()
         }
 
         $InstallProcess = & powershell.exe -Command {
+            Use-Icinga -Minimal;
+
             $DownloadDestination = $args[0];
             $InstallTarget       = $args[1];
             $InstallProcess      = Start-IcingaProcess -Executable 'MsiExec.exe' -Arguments ([string]::Format('/quiet /i "{0}" {1}', $DownloadDestination, $InstallTarget)) -FlushNewLines;


### PR DESCRIPTION
Fixes errors on encapsulated PowerShell calls for missing Cmdlets `Write-IcingaConsoleError` and `Optimize-IcingaForWindowsMemory`, while trying to restart services or appling configurations which require a new PowerShell session.

Fixes #523