### PR TITLE
Feature: Rewrite check kernel

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -15,6 +15,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#529](https://github.com/Icinga/icinga-powershell-framework/pull/529) Fixes package manifest reader for Icinga for Windows components on Windows 2012 R2 and older
 * [#523](https://github.com/Icinga/icinga-powershell-framework/pull/523) Fixes errors on encapsulated PowerShell calls for missing Cmdlets `Write-IcingaConsoleError` and `Optimize-IcingaForWindowsMemory`
+* [#524](https://github.com/Icinga/icinga-powershell-framework/pull/524) Fixes checker kernel to properly compile check objects, cause less overhead and correctly detect units and convert values
 
 ### Enhancements
 


### PR DESCRIPTION
The current handling for compiling Icinga for Windows checks causes various issues in certain situations. These include:

* Wrongly detected units and therefor wrong conversion of values
* Negative thresholds sometimes not being applied properly
* Slow execution of check compiling
* Wrong report of warning/critical value comparison, determining if the thresholds are properly configured

To resolve this, the entire check kernel backend is re-written and redesigned with less overhead and proper evaluation.

Fixes #131
Fixes #435
Fixes #503
Fixes #528