### PR TITLE
Fix: Uninstaller removal errors by improving location handling

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -7,7 +7,7 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
-## 1.10.0 (2022-08-16)
+## 1.10.0 (2022-08-30)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/23?closed=1)
 
@@ -15,6 +15,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#529](https://github.com/Icinga/icinga-powershell-framework/pull/529) Fixes package manifest reader for Icinga for Windows components on Windows 2012 R2 and older
 * [#523](https://github.com/Icinga/icinga-powershell-framework/pull/523) Fixes errors on encapsulated PowerShell calls for missing Cmdlets `Write-IcingaConsoleError` and `Optimize-IcingaForWindowsMemory`
+* [#524](https://github.com/Icinga/icinga-powershell-framework/issues/524) Fixes uninstallation process by improving the location handling of PowerShell instances with Icinga IMC or Shell
 
 ### Enhancements
 

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -279,6 +279,9 @@ function Invoke-IcingaCommand()
         return;
     }
 
+    # Ensure we set the path to another folder to prevent locking the Framework Root Folder
+    Set-Location (Get-IcingaForWindowsRootPath);
+
     powershell.exe -NoExit -Command {
         $Script          = $args[0];
         $RootPath        = $args[1];
@@ -319,6 +322,11 @@ function Invoke-IcingaCommand()
         }
 
     } -Args $ScriptBlock, $PSScriptRoot, $IcingaFrameworkData.PrivateData.Version, ([bool]$Shell), $ArgumentList, $DeveloperMode;
+
+    # In case we close the newly created PowerShell, ensure we set the script root back to the Framework folder
+    if (Test-Path $PSScriptRoot) {
+        Set-Location $PSScriptRoot;
+    }
 }
 
 function Start-IcingaShellAsUser()

--- a/lib/core/framework/Uninstall-IcingaForWindows.psm1
+++ b/lib/core/framework/Uninstall-IcingaForWindows.psm1
@@ -45,11 +45,7 @@ function Uninstall-IcingaForWindows()
         }
     }
 
-    $CurrentLocation = Get-Location;
-
-    if ($CurrentLocation -eq (Get-IcingaFrameworkRootPath)) {
-        Set-Location -Path (Get-IcingaForWindowsRootPath);
-    }
+    Set-Location -Path (Get-IcingaForWindowsRootPath);
 
     Write-IcingaConsoleNotice 'Uninstalling Icinga for Windows from this host';
     Write-IcingaConsoleNotice 'Uninstalling Icinga Security configuration if applied';

--- a/lib/core/installer/Install-Icinga.psm1
+++ b/lib/core/installer/Install-Icinga.psm1
@@ -146,7 +146,7 @@ function Install-Icinga()
                     @{
                         'Caption' = 'Icinga Shell';
                         'Command' = 'Invoke-IcingaForWindowsMenuStartIcingaShell';
-                        'Help'    = 'Shows you an overview of your current Icinga for Windows installation, including installed components and system informations.';
+                        'Help'    = 'Starts an interactive PowerShell with all loaded Icinga for Windows components.';
                     }
                 ) `
                 -DefaultIndex 0;

--- a/lib/core/repository/Uninstall-IcingaComponent.psm1
+++ b/lib/core/repository/Uninstall-IcingaComponent.psm1
@@ -27,11 +27,16 @@ function Uninstall-IcingaComponent()
         return $FALSE;
     }
 
+    # Set our current location to the PowerShell modules folder, to prevent possible folder lock during uninstallation
+    Set-Location (Get-IcingaForWindowsRootPath);
+
     Write-IcingaConsoleNotice -Message 'Uninstalling Icinga for Windows component "{0}" from "{1}"' -Objects $UninstallComponent, $UninstallPath;
     if (Remove-ItemSecure -Path $UninstallPath -Recurse -Force) {
         Write-IcingaConsoleNotice -Message 'Successfully removed Icinga for Windows component "{0}" from "{1}"' -Objects $UninstallComponent, $UninstallPath;
         if ($UninstallComponent -ne 'icinga-powershell-framework') {
             Remove-Module $UninstallComponent -Force -ErrorAction SilentlyContinue;
+            # In case we are not removing the framework itself, set the location to the Icinga for Windows Folder
+            Set-Location (Get-IcingaFrameworkRootPath);
         }
         return $TRUE;
     } else {


### PR DESCRIPTION
Improves internal component uninstaller and Icinga for Windows uninstaller to ensure folders are not locked during uninstallation with the current PowerShell sessions

Fixes #524