### PR TITLE
Fix: Null-value exception on missing background daemons

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#476](https://github.com/Icinga/icinga-powershell-framework/pull/476) Fixes exception `You cannot call a method on va null-valued expression` during installation in case no background daemon is configured
 * [#529](https://github.com/Icinga/icinga-powershell-framework/pull/529) Fixes package manifest reader for Icinga for Windows components on Windows 2012 R2 and older
 * [#523](https://github.com/Icinga/icinga-powershell-framework/pull/523) Fixes errors on encapsulated PowerShell calls for missing Cmdlets `Write-IcingaConsoleError` and `Optimize-IcingaForWindowsMemory`
 * [#524](https://github.com/Icinga/icinga-powershell-framework/issues/524) Fixes uninstallation process by improving the location handling of PowerShell instances with Icinga IMC or Shell

--- a/lib/daemon/Get-IcingaBackgroundDaemons.psm1
+++ b/lib/daemon/Get-IcingaBackgroundDaemons.psm1
@@ -1,12 +1,11 @@
 function Get-IcingaBackgroundDaemons()
 {
-    $Daemons = Get-IcingaPowerShellConfig -Path 'BackgroundDaemon.EnabledDaemons';
+    $Daemons           = Get-IcingaPowerShellConfig -Path 'BackgroundDaemon.EnabledDaemons';
+    [hashtable]$Output = @{ };
 
     if ($null -eq $Daemons) {
-        return $null;
+        return $Output;
     }
-
-    [hashtable]$Output = @{ };
 
     foreach ($daemon in $Daemons.PSObject.Properties) {
         $Arguments = @{ };


### PR DESCRIPTION
Fixes `You cannot call a method on va null-valued expression` during installation or while enabling JEA, in case no background daemons have been configured.

Fixes #476
Fixes #487