### PR TITLE
Fix: icinga command always resetting cache

### DIFF
--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -321,7 +321,7 @@ function Invoke-IcingaCommand()
             return "> "
         }
 
-    } -Args $ScriptBlock, $PSScriptRoot, $IcingaFrameworkData.PrivateData.Version, ([bool]$Shell), $ArgumentList, $DeveloperMode;
+    } -Args $ScriptBlock, $PSScriptRoot, $IcingaFrameworkData.PrivateData.Version, ([bool]$Shell), $ArgumentList, ([bool]$DeveloperMode);
 
     # In case we close the newly created PowerShell, ensure we set the script root back to the Framework folder
     if (Test-Path $PSScriptRoot) {


### PR DESCRIPTION
Fixes the `icinga` command which always resets the Framework cache, caused by newly introduced `Developer Mode`