### PR TITLE
Fix: RemoteSouce being cleared during Update-IcingaRepository

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -19,6 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#529](https://github.com/Icinga/icinga-powershell-framework/pull/529) Fixes package manifest reader for Icinga for Windows components on Windows 2012 R2 and older
 * [#523](https://github.com/Icinga/icinga-powershell-framework/pull/523) Fixes errors on encapsulated PowerShell calls for missing Cmdlets `Write-IcingaConsoleError` and `Optimize-IcingaForWindowsMemory`
 * [#524](https://github.com/Icinga/icinga-powershell-framework/issues/524) Fixes uninstallation process by improving the location handling of PowerShell instances with Icinga IMC or Shell
+* [#545](https://github.com/Icinga/icinga-powershell-framework/issues/545) Fixes `RemoteSource` being cleared within repository `.json` files during `Update-IcingaRepository` tasks
 
 ### Enhancements
 

--- a/lib/core/repository/Update-IcingaRepository.psm1
+++ b/lib/core/repository/Update-IcingaRepository.psm1
@@ -59,7 +59,15 @@ function Update-IcingaRepository()
             Write-IcingaConsoleNotice 'Updating Icinga for Windows repository "{0}"' -Objects $definedRepo.Name;
         }
 
-        $IcingaRepository = New-IcingaRepositoryFile -Path $Path -RemotePath $RemotePath;
+        # Ensure we use the default RemotePath within our IMC config, unless we specify a different path during update
+        [string]$SetRemotePath = $definedRepo.Value.RemotePath;
+
+        if ([string]::IsNullOrEmpty($RemotePath) -eq $FALSE) {
+            Set-IcingaPowerShellConfig -Path ([string]::Format('Framework.Repository.Repositories.{0}.RemotePath', $definedRepo.Name)) -Value $RemotePath;
+            $SetRemotePath = $RemotePath;
+        }
+
+        $IcingaRepository = New-IcingaRepositoryFile -Path $Path -RemotePath $SetRemotePath;
 
         if ($CreateNew) {
             return $IcingaRepository;


### PR DESCRIPTION
Fixes `RemoteSource` being cleared within repository `.json` files during `Update-IcingaRepository` tasks

Fixes #545