### PR TITLE
Fix: Negative thresholds interpreted as argument

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -19,6 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#529](https://github.com/Icinga/icinga-powershell-framework/pull/529) Fixes package manifest reader for Icinga for Windows components on Windows 2012 R2 and older
 * [#523](https://github.com/Icinga/icinga-powershell-framework/pull/523) Fixes errors on encapsulated PowerShell calls for missing Cmdlets `Write-IcingaConsoleError` and `Optimize-IcingaForWindowsMemory`
 * [#524](https://github.com/Icinga/icinga-powershell-framework/issues/524) Fixes uninstallation process by improving the location handling of PowerShell instances with Icinga IMC or Shell
+* [#528](https://github.com/Icinga/icinga-powershell-framework/issues/528) Fixes negative thresholds being interpreted wrongly as argument instead of an value for an argument
 * [#545](https://github.com/Icinga/icinga-powershell-framework/issues/545) Fixes `RemoteSource` being cleared within repository `.json` files during `Update-IcingaRepository` tasks
 
 ### Enhancements

--- a/lib/icinga/plugin/Exit-IcingaExecutePlugin.psm1
+++ b/lib/icinga/plugin/Exit-IcingaExecutePlugin.psm1
@@ -5,7 +5,7 @@ function Exit-IcingaExecutePlugin()
     );
 
     # We need to fix the argument encoding hell
-    [hashtable]$ConvertedArgs      = ConvertTo-IcingaPowerShellArguments -Arguments $args;
+    [hashtable]$ConvertedArgs      = ConvertTo-IcingaPowerShellArguments -Command $Command -Arguments $args;
     [string]$JEAProfile            = Get-IcingaJEAContext;
     [bool]$CheckByIcingaForWindows = $FALSE;
     [bool]$CheckByJEAShell         = $FALSE;


### PR DESCRIPTION
Fixes negative thresholds being interpreted wrongly as argument instead of an value for an argument

Fixes #528