### PR TITLE
Fix: Automated Icinga Director installation for custom hostname

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -17,6 +17,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#476](https://github.com/Icinga/icinga-powershell-framework/pull/476) Fixes exception `You cannot call a method on va null-valued expression` during installation in case no background daemon is configured
 * [#482](https://github.com/Icinga/icinga-powershell-framework/pull/482) Fixes encoding problems with special chars or German umlauts during plugin execution and unescaped whitespace in plugin argument strings like `Icinga for Windows`, which was previously wrongly rended as `Icinga` for example
 * [#489](https://github.com/Icinga/icinga-powershell-framework/issues/489) Fixes error message `This argument does not support the % unit` in case a `BaseValue` is set, but the actual value is `0`
+* [#505](https://github.com/Icinga/icinga-powershell-framework/issues/505) Fixes certificate generation and host registration, in case a custom hostname was set during usage of `Install-Icinga` automation
 * [#529](https://github.com/Icinga/icinga-powershell-framework/pull/529) Fixes package manifest reader for Icinga for Windows components on Windows 2012 R2 and older
 * [#523](https://github.com/Icinga/icinga-powershell-framework/pull/523) Fixes errors on encapsulated PowerShell calls for missing Cmdlets `Write-IcingaConsoleError` and `Optimize-IcingaForWindowsMemory`
 * [#524](https://github.com/Icinga/icinga-powershell-framework/issues/524) Fixes uninstallation process by improving the location handling of PowerShell instances with Icinga IMC or Shell

--- a/lib/core/installer/menu/installation/director/DirectorTemplate.psm1
+++ b/lib/core/installer/menu/installation/director/DirectorTemplate.psm1
@@ -4,9 +4,11 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
         [switch]$Register = $FALSE
     );
 
-    $DirectorUrl    = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorUrl';
-    $SelfServiceKey = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceKey';
-    $UsedEnteredKey = $SelfServiceKey;
+    $DirectorUrl         = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorUrl';
+    $SelfServiceKey      = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceKey';
+    $HostRegisterSetting = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectHostname';
+    $CustomHostname      = Get-IcingaForWindowsInstallerValuesFromStep -InstallerStep 'Show-IcingaForWindowsInstallationMenuEnterCustomHostname';
+    $UsedEnteredKey      = $SelfServiceKey;
 
     # Once we run this menu, we require to reset everything to have a proper state
     if ($Register -eq $FALSE) {
@@ -14,6 +16,13 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
 
         Add-IcingaForWindowsInstallerConfigEntry -Selection 'c' -Values $DirectorUrl -OverwriteValues -OverwriteMenu 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorUrl';
         Add-IcingaForWindowsInstallerConfigEntry -Selection 'c' -Values $SelfServiceKey -OverwriteValues -OverwriteMenu 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceKey';
+
+        if ($null -ne $HostRegisterSetting) {
+            Add-IcingaForWindowsInstallerConfigEntry -Selection $HostRegisterSetting -OverwriteValues -OverwriteMenu 'Show-IcingaForWindowsInstallerMenuSelectHostname'
+            if ($HostRegisterSetting -eq '6') {
+                Add-IcingaForWindowsInstallerConfigEntry -Selection 'c' -Values $CustomHostname -OverwriteValues -OverwriteMenu 'Show-IcingaForWindowsInstallationMenuEnterCustomHostname';
+            }
+        }
     } else {
         $Global:Icinga.InstallWizard.DirectorRegisteredHost = $TRUE;
         $HostnameType   = Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsInstallerMenuSelectHostname';


### PR DESCRIPTION
Fixes certificate generation and host registration, in case a custom hostname was set during usage of `Install-Icinga` automation

Fixes #505