### PR TITLE
Feature: Improves IMC update and uninstall handling for Framework

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -36,6 +36,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#531](https://github.com/Icinga/icinga-powershell-framework/pull/531) Adds `Test-IcingaStateFile` and `Repair-IcingaStateFile`, which is integrated into `Test-IcingaAgent`, to ensure the Icinga Agent state file is healthy and not corrupt, causing the Icinga Agent to fail on start
 * [#534](https://github.com/Icinga/icinga-powershell-framework/pull/534) Improves Icinga and Director configuration generator, by wrapping PowerShell arrays inside `@()` instead of simply writing them comma separated
 * [#536](https://github.com/Icinga/icinga-powershell-framework/pull/536) Adds new function `Test-IcingaArrayFilter` for easier include and exclude filtering during plugin runtime and to allow filtering of array content for intended values only
+* [#560](https://github.com/Icinga/icinga-powershell-framework/pull/560) Improves handling for Icinga Management Console which will now terminate itself during full uninstallation and restarts after updating the Icinga PowerShell Framework, to apply changes directly
 
 ## 1.9.2 (2022-06-03)
 

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -252,6 +252,9 @@ function Invoke-IcingaCommand()
         -FileName 'icinga-powershell-framework.psd1' `
         -BindingVariable IcingaFrameworkData;
 
+    # Ensure we always remove the update file in case present
+    Set-IcingaForWindowsManagementConsoleUpdating -Completed;
+
     # Print a header informing our user that loaded the Icinga Framework with a specific
     # version. We can also skip the header by using $SKipHeader
     if ([string]::IsNullOrEmpty($ScriptBlock) -And $SkipHeader -eq $FALSE -And $Shell) {
@@ -334,6 +337,24 @@ function Invoke-IcingaCommand()
     # In case we close the newly created PowerShell, ensure we set the script root back to the Framework folder
     if (Test-Path $PSScriptRoot) {
         Set-Location $PSScriptRoot;
+    }
+
+    # In case we applied updates to the Framework while inside the IMC -> reopen it
+    if (Test-IcingaForWindowsManagementConsoleUpdating) {
+        Set-IcingaForWindowsManagementConsoleUpdating -Completed;
+
+        # Use the same arguments again to open the IMC
+        $IMCReopenArguments = @{
+            'ScriptBlock'   = $ScriptBlock;
+            'SkipHeader'    = $SkipHeader;
+            'Manage'        = $Manage;
+            'Shell'         = $Shell;
+            'RebuildCache'  = $RebuildCache;
+            'DeveloperMode' = $DeveloperMode;
+            'ArgumentList'  = $ArgumentList;
+        };
+
+        Invoke-IcingaCommand @IMCReopenArguments;
     }
 }
 

--- a/lib/core/framework/Uninstall-IcingaForWindows.psm1
+++ b/lib/core/framework/Uninstall-IcingaForWindows.psm1
@@ -55,6 +55,8 @@ function Uninstall-IcingaForWindows()
     if ($ComponentsOnly -eq $FALSE) {
         Write-IcingaConsoleNotice 'Uninstalling Icinga for Windows EventLog';
         Unregister-IcingaEventLog;
+        # Ensure we close the IMC in case being open and we uninstall the Framework
+        Set-IcingaForWindowsManagementConsoleClosing;
     }
     Write-IcingaConsoleNotice 'Uninstalling Icinga for Windows service';
     Uninstall-IcingaForWindowsService -RemoveFiles | Out-Null;

--- a/lib/core/installer/Install-Icinga.psm1
+++ b/lib/core/installer/Install-Icinga.psm1
@@ -175,4 +175,8 @@ function Install-Icinga()
             }
         }
     }
+
+    if ($null -ne (Get-Command -Name 'Set-IcingaForWindowsManagementConsoleClosing' -ErrorAction SilentlyContinue)) {
+        Set-IcingaForWindowsManagementConsoleClosing -Completed;
+    }
 }

--- a/lib/core/installer/tools/SetCloseIMC.psm1
+++ b/lib/core/installer/tools/SetCloseIMC.psm1
@@ -1,0 +1,20 @@
+function Set-IcingaForWindowsManagementConsoleClosing()
+{
+    param (
+        [switch]$Completed = $FALSE
+    );
+
+    if ($null -eq $Global:Icinga) {
+        return;
+    }
+
+    if ($Global:Icinga.ContainsKey('InstallWizard') -eq $FALSE) {
+        return;
+    }
+
+    if ($Global:Icinga.InstallWizard.ContainsKey('Closing') -eq $FALSE) {
+        return;
+    }
+
+    $global:Icinga.InstallWizard.Closing = (-Not ([bool]$Completed));
+}

--- a/lib/core/installer/tools/SetUpdatingIMC.psm1
+++ b/lib/core/installer/tools/SetUpdatingIMC.psm1
@@ -1,0 +1,15 @@
+function Set-IcingaForWindowsManagementConsoleUpdating()
+{
+    param (
+        [switch]$Completed = $FALSE
+    );
+
+    Set-IcingaForWindowsManagementConsoleClosing;
+
+    $UpdateFile = Join-Path -Path (Get-IcingaCacheDir) -ChildPath 'framework.update';
+    if ($Completed) {
+        Remove-ItemSecure -Path $UpdateFile -Force -Retries 5 | Out-Null;
+    } else {
+        New-Item -Path $UpdateFile -ItemType File -Force | Out-Null;
+    }
+}

--- a/lib/core/installer/tools/TestUpdatingIMC.psm1
+++ b/lib/core/installer/tools/TestUpdatingIMC.psm1
@@ -1,0 +1,6 @@
+function Test-IcingaForWindowsManagementConsoleUpdating()
+{
+    $UpdateFile = Join-Path -Path (Get-IcingaCacheDir) -ChildPath 'framework.update';
+
+    return (Test-Path -Path $UpdateFile);
+}

--- a/lib/core/repository/Install-IcingaComponent.psm1
+++ b/lib/core/repository/Install-IcingaComponent.psm1
@@ -165,6 +165,9 @@ function Install-IcingaComponent()
                     Stop-IcingaService 'icinga2';
                     Start-Sleep -Seconds 1;
                 }
+
+                # Ensure we close the IMC in case we do some updates on the Framework
+                Set-IcingaForWindowsManagementConsoleUpdating;
             }
 
             if ((Test-Path $ComponentFolder) -eq $FALSE) {


### PR DESCRIPTION
Improves the Icinga Management Console (IMC) during uninstallation of Icinga for Windows entirely and during updates of the Icinga PowerShell Framework.

The IMC will during uninstallation now properly close and not being stuck inside a loop or errors messages, while after updates the current IMC will close and restart itself with the new configuration.