### PR TITLE
Fix: PerfData writer in JEA context without REST-Api

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -27,6 +27,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#552](https://github.com/Icinga/icinga-powershell-framework/pull/552) Fixes file encoding for Icinga for Windows v1.10.0 to ensure the cache is always properly created with the correct encoding
 * [#553](https://github.com/Icinga/icinga-powershell-framework/pull/553) Fixes an exception caused by service recovery setting, if the required service was not installed before
 * [#556](https://github.com/Icinga/icinga-powershell-framework/pull/556) Fixes the certificate folder not present during first installation, preventing permissions properly set from the start which might cause issues once required
+* [#562](https://github.com/Icinga/icinga-powershell-framework/pull/562) Fixes corrupt Performance Data, in case plugins were executed inside a JEA context without the REST-Api
 
 ### Enhancements
 

--- a/lib/icinga/plugin/Write-IcingaPluginResult.psm1
+++ b/lib/icinga/plugin/Write-IcingaPluginResult.psm1
@@ -8,15 +8,7 @@ function Write-IcingaPluginResult()
     [string]$CheckResult = $PluginOutput;
 
     if ($PluginPerfData.Count -ne 0) {
-        [string]$PerfDataContent = '';
-        foreach ($PerfData in $PluginPerfData) {
-            $PerfDataContent += $PerfData;
-        }
-
-        if ([string]::IsNullOrEmpty($PerfDataContent) -eq $FALSE) {
-            $CheckResult += "`n`r| ";
-            $CheckResult += $PerfDataContent;
-        }
+        $CheckResult = [string]::Format('{0}{1}| {2}', $CheckResult, "`r`n", ([string]::Join(' ', $PluginPerfData)));
     }
 
     Write-IcingaConsolePlain $CheckResult;


### PR DESCRIPTION
Fixes corrupt Performance Data, in case plugins were executed inside a JEA context without the REST-Api.