### PR TITLE
Fix: Useless testing for directories if agent is not installed

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -30,6 +30,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#562](https://github.com/Icinga/icinga-powershell-framework/pull/562) Fixes corrupt Performance Data, in case plugins were executed inside a JEA context without the REST-Api
 * [#563](https://github.com/Icinga/icinga-powershell-framework/pull/563) Fixes checks like MSSQL using arguments of type `SecureString` not being usable with the Icinga for Windows REST-Api
 * [#565](https://github.com/Icinga/icinga-powershell-framework/pull/565) Fixes internal cache file writer and reader to store changes inside a `.tmp` file first and validating the file state and content, before applying it to the actual file to prevent data corruption
+* [#566](https://github.com/Icinga/icinga-powershell-framework/pull/566) Fixes useless testing and printing of error messages, in case the Icinga Agent is not installed during installation and Icinga for Windows printing plenty of errors, because the ACL checks cannot be completed because of the missing Agent
 
 ### Enhancements
 

--- a/lib/core/icingaagent/tests/Test-IcingaAgent.psm1
+++ b/lib/core/icingaagent/tests/Test-IcingaAgent.psm1
@@ -10,6 +10,8 @@ function Test-IcingaAgent()
         Write-IcingaTestOutput -Severity 'Failed' -Message 'Icinga Agent service is still present, while Icinga Agent itself is not installed.';
     } elseif ($IcingaAgentData.Installed -eq $FALSE -And $null -eq $AgentServicePresent) {
         Write-IcingaTestOutput -Severity 'Passed' -Message 'Icinga Agent is not installed and service is not present.';
+
+        return;
     }
 
     Test-IcingaAgentServicePermission | Out-Null;


### PR DESCRIPTION
Fixes useless testing and printing of error messages, in case the Icinga Agent is not installed during installation and Icinga for Windows printing plenty of errors, because the ACL checks cannot be completed.