### PR TITLE
Fix: Missing permission update for certificate directory

### DIFF
--- a/lib/core/icingaagent/setters/Set-IcingaUserPermissions.psm1
+++ b/lib/core/icingaagent/setters/Set-IcingaUserPermissions.psm1
@@ -5,8 +5,9 @@ function Set-IcingaUserPermissions()
         [switch]$Remove     = $FALSE
     );
 
-    Set-IcingaAcl "$Env:ProgramData\icinga2\etc" -IcingaUser $IcingaUser -Remove:$Remove;
-    Set-IcingaAcl "$Env:ProgramData\icinga2\var" -IcingaUser $IcingaUser -Remove:$Remove;
-    Set-IcingaAcl (Get-IcingaCacheDir) -IcingaUser $IcingaUser -Remove:$Remove;
+    Set-IcingaAcl -Directory "$Env:ProgramData\icinga2\etc" -IcingaUser $IcingaUser -Remove:$Remove;
+    Set-IcingaAcl -Directory "$Env:ProgramData\icinga2\var" -IcingaUser $IcingaUser -Remove:$Remove;
+    Set-IcingaAcl -Directory (Get-IcingaCacheDir) -IcingaUser $IcingaUser -Remove:$Remove;
     Set-IcingaAcl -Directory (Get-IcingaPowerShellConfigDir) -IcingaUser $IcingaUser -Remove:$Remove;
+    Set-IcingaAcl -Directory (Join-Path -Path (Get-IcingaFrameworkRootPath) -ChildPath 'certificate') -IcingaUser $IcingaUser -Remove:$Remove;
 }


### PR DESCRIPTION
Fixes missing certificate folder permission update on every change for the Icinga Agent user, as the folder wasn't present by default before, which changed with v1.10.0