### PR TITLE
Fix: Misleading SID error during uninstallation

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -31,6 +31,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#563](https://github.com/Icinga/icinga-powershell-framework/pull/563) Fixes checks like MSSQL using arguments of type `SecureString` not being usable with the Icinga for Windows REST-Api
 * [#565](https://github.com/Icinga/icinga-powershell-framework/pull/565) Fixes internal cache file writer and reader to store changes inside a `.tmp` file first and validating the file state and content, before applying it to the actual file to prevent data corruption
 * [#566](https://github.com/Icinga/icinga-powershell-framework/pull/566) Fixes useless testing and printing of error messages, in case the Icinga Agent is not installed during installation and Icinga for Windows printing plenty of errors, because the ACL checks cannot be completed because of the missing Agent
+* [#568](https://github.com/Icinga/icinga-powershell-framework/pull/568) Fixes misleading SID error during uninstallation of Icinga for Windows or the Agent component
 
 ### Enhancements
 

--- a/lib/core/windows/Uninstall-IcingaServiceUser.psm1
+++ b/lib/core/windows/Uninstall-IcingaServiceUser.psm1
@@ -22,7 +22,10 @@ function Uninstall-IcingaServiceUser()
     Set-IcingaUserPermissions -IcingaUser $IcingaUser -Remove;
 
     $UserConfig = Remove-IcingaWindowsUser -IcingaUser $IcingaUser;
-    Update-IcingaWindowsUserPermission -SID $UserConfig.SID -Remove;
+
+    if ($null -ne $UserConfig -And ([string]::IsNullOrEmpty($UserConfig.SID) -eq $FALSE)) {
+        Update-IcingaWindowsUserPermission -SID $UserConfig.SID -Remove;
+    }
 
     Restart-IcingaService 'icinga2';
     Restart-IcingaWindowsService;


### PR DESCRIPTION
Fixes misleading SID error during uninstallation of Icinga for Windows or the Agent component