### PR TITLE
Fix: StackTrace in plugin output, when plugin is not installed

### DIFF
--- a/lib/core/tools/ConvertTo-IcingaPowerShellArguments.psm1
+++ b/lib/core/tools/ConvertTo-IcingaPowerShellArguments.psm1
@@ -25,7 +25,12 @@ function ConvertTo-IcingaPowerShellArguments()
         return @{ };
     }
 
-    $CommandHelp = Get-Help -Name $Command -Full;
+    $CommandHelp = Get-Help -Name $Command -Full -ErrorAction SilentlyContinue;
+
+    # Ensure we do not cause exceptions along the border in case the plugin is not installed
+    if ($null -eq $CommandHelp) {
+        return @{ };
+    }
 
     [hashtable]$IcingaArguments = @{ };
     [int]$ArgumentIndex         = 0;


### PR DESCRIPTION
Caused by newly introduced `Get-Help` check to fetch argument types