### PR TITLE
Fix: Wrong regex for threshold detection

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#582](https://github.com/Icinga/icinga-powershell-framework/issues/582) Fixes background service registration caused by migration task for v1.10.0 being executed even when no services were defined before
+* [#588](https://github.com/Icinga/icinga-powershell-framework/issues/588) Fixes threshold values causing an error because of too aggressive regex expression
 
 ## 1.10.0 (2022-08-30)
 

--- a/lib/core/tools/Convert-Bytes.psm1
+++ b/lib/core/tools/Convert-Bytes.psm1
@@ -8,13 +8,13 @@ function Convert-Bytes()
     # Ensure we always use proper formatting of values
     $Value = $Value.Replace(',', '.');
 
-    If (($Value -Match "(^-?[0-9].*)+((\.|\,)+[0-9])?(B|KB|MB|GB|TB|PT|KiB|MiB|GiB|TiB|PiB)") -eq $FALSE) {
+    If (($Value -Match "(^-?[0-9]+)((\.|\,)[0-9]+)?(B|KB|MB|GB|TB|PT|KiB|MiB|GiB|TiB|PiB)$") -eq $FALSE) {
         $Value = [string]::Format('{0}B', $Value);
     }
 
-    If (($Value -Match "(^[\d\.]*) ?(B|KB|MB|GB|TB|PT|KiB|MiB|GiB|TiB|PiB)")) {
+    If (($Value -Match "(^-?[0-9]+)((\.|\,)[0-9]+)?(B|KB|MB|GB|TB|PT|KiB|MiB|GiB|TiB|PiB)$")) {
         [single]$CurrentValue = $Matches[1];
-        [string]$CurrentUnit = $Matches[2];
+        [string]$CurrentUnit = $Matches[4];
 
         switch ($CurrentUnit) {
             { 'KiB', 'MiB', 'GiB', 'TiB', 'PiB' -contains $_ } { $CurrentValue = ConvertTo-ByteIEC $CurrentValue $CurrentUnit; $boolOption = $true; }

--- a/lib/core/tools/Convert-IcingaPluginThresholds.psm1
+++ b/lib/core/tools/Convert-IcingaPluginThresholds.psm1
@@ -134,14 +134,14 @@ function Convert-IcingaPluginThresholds()
             $ThresholdValue = $ThresholdValue.Substring(1, $ThresholdValue.Length - 1);
         }
 
-        If (($ThresholdValue -Match "(^-?[0-9].*)+((\.|\,)+[0-9])?(B|KB|MB|GB|TB|PT|KiB|MiB|GiB|TiB|PiB)")) {
+        if (($ThresholdValue -Match "(^-?[0-9]+)((\.|\,)[0-9]+)?(B|KB|MB|GB|TB|PT|KiB|MiB|GiB|TiB|PiB)$")) {
             $WorkUnit = 'B';
             if ([string]::IsNullOrEmpty($RetValue.Unit) -eq $FALSE -And $RetValue.Unit -ne $WorkUnit) {
                 Exit-IcingaThrowException -ExceptionType 'Input' -ExceptionThrown $IcingaExceptions.Inputs.MultipleUnitUsage -Force;
             }
             $Value         = (Convert-Bytes -Value $ThresholdValue -Unit $WorkUnit).Value;
             $RetValue.Unit = $WorkUnit;
-        } elseif (($ThresholdValue -Match "(^-?[0-9].*)+((\.|\,)+[0-9])?(ms|s|m|h|d|w|M|y)")) {
+        } elseif (($ThresholdValue -Match "(^-?[0-9]+)((\.|\,)[0-9]+)?(ms|s|m|h|d|w|M|y)$")) {
             $WorkUnit = 's';
             if ([string]::IsNullOrEmpty($RetValue.Unit) -eq $FALSE -And $RetValue.Unit -ne $WorkUnit) {
                 Exit-IcingaThrowException -ExceptionType 'Input' -ExceptionThrown $IcingaExceptions.Inputs.MultipleUnitUsage -Force;
@@ -152,6 +152,9 @@ function Convert-IcingaPluginThresholds()
             $WorkUnit      = '%';
             $Value         = ([string]$ThresholdValue).Replace(' ', '').Replace('%', '');
             $RetValue.Unit = $WorkUnit;
+        } elseif (($ThresholdValue -Match "(^-?[0-9]+)((\.|\,)[0-9]+)?(Kbit|Mbit|Gbit|Tbit|Pbit|Ebit|Zbit|Ybit)$")) {
+            $Value         = $Matches[1];
+            $RetValue.Unit = $Matches[4];
         } else {
             # Load all other units/values generically
             [string]$StrNumeric = '';
@@ -206,7 +209,7 @@ function Convert-IcingaPluginThresholds()
     }
 
     # Always ensure we are using correct digits
-    $Value = ([string]$Value).Replace(',', '.');
+    $Value          = ([string]$Value).Replace(',', '.');
     $RetValue.Value = $Value;
 
     return $RetValue;

--- a/lib/core/tools/Convert-IcingaPluginValueToString.psm1
+++ b/lib/core/tools/Convert-IcingaPluginValueToString.psm1
@@ -24,7 +24,7 @@ function Convert-IcingaPluginValueToString()
 
     switch ($OriginalUnit) {
         { ($_ -eq "Kbit") -or ($_ -eq "Mbit") -or ($_ -eq "Gbit") -or ($_ -eq "Tbit") -or ($_ -eq "Pbit") -or ($_ -eq "Ebit") -or ($_ -eq "Zbit") -or ($_ -eq "Ybit") } {
-            $TransferSpeed = Get-IcingaNetworkInterfaceUnits -Value $Value;
+            $TransferSpeed = Get-IcingaNetworkInterfaceUnits -Value $Value -Unit $Unit;
             return ([string]::Format('{0}{1}', $TransferSpeed.LinkSpeed, $TransferSpeed.Unit)).Replace(',', '.');
         };
         { ($_ -eq "B") -or ($_ -eq "KiB") -or ($_ -eq "MiB") -or ($_ -eq "GiB") -or ($_ -eq "TiB") -or ($_ -eq "PiB") -or ($_ -eq "EiB") -or ($_ -eq "ZiB") -or ($_ -eq "YiB") } {

--- a/lib/core/tools/Get-IcingaNetworkInterfaceUnits.psm1
+++ b/lib/core/tools/Get-IcingaNetworkInterfaceUnits.psm1
@@ -1,7 +1,8 @@
 function Get-IcingaNetworkInterfaceUnits()
 {
     param (
-        [long]$Value
+        [decimal]$Value = 0,
+        [string]$Unit   = ''
     );
 
     [hashtable]$InterfaceData = @{
@@ -9,6 +10,13 @@ function Get-IcingaNetworkInterfaceUnits()
         'LinkSpeed' = 0;
         'Unit'      = 'Mbit'
     };
+
+    if ([string]::IsNullOrEmpty($Unit) -eq $FALSE) {
+        $InterfaceData.LinkSpeed = $Value;
+        $InterfaceData.Unit      = $Unit;
+
+        return $InterfaceData;
+    }
 
     [decimal]$result = ($Value / [Math]::Pow(10, 6));
 


### PR DESCRIPTION
Fixes threshold values causing an error because of too aggressive regex expression

Fixes #588