### PR TITLE
Fix: Unintended PS path change

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#578](https://github.com/Icinga/icinga-powershell-framework/issues/578) Fixes installation and uninstallation commands changing PowerShell location even when not necessary
 * [#582](https://github.com/Icinga/icinga-powershell-framework/issues/582) Fixes background service registration caused by migration task for v1.10.0 being executed even when no services were defined before
 * [#588](https://github.com/Icinga/icinga-powershell-framework/issues/588) Fixes threshold values causing an error because of too aggressive regex expression
 * [#599](https://github.com/Icinga/icinga-powershell-plugins/issues/599) Fixes plugin argument parser to proceed with real argument names and possible provided aliases

--- a/lib/core/dev/Write-IcingaForWindowsComponentCompilationFile.psm1
+++ b/lib/core/dev/Write-IcingaForWindowsComponentCompilationFile.psm1
@@ -5,6 +5,8 @@ function Write-IcingaForWindowsComponentCompilationFile()
         [string]$CompiledFilePath = ''
     );
 
+    # Store our current shell location
+    [string]$OldLocation = Get-Location;
     # Get the current location and leave this folder
     Set-Location -Path $ScriptRootPath;
     Set-Location -Path '..';
@@ -57,4 +59,7 @@ function Write-IcingaForWindowsComponentCompilationFile()
 
     Import-Module -Name $ModulePath -Force;
     Import-Module -Name $ModulePath -Force -Global;
+
+    # Set our location back to the previous folder
+    Set-Location -Path $OldLocation;
 }

--- a/lib/core/framework/Uninstall-IcingaForWindows.psm1
+++ b/lib/core/framework/Uninstall-IcingaForWindows.psm1
@@ -45,7 +45,7 @@ function Uninstall-IcingaForWindows()
         }
     }
 
-    Set-Location -Path (Get-IcingaForWindowsRootPath);
+    Set-IcingaPSLocation;
 
     Write-IcingaConsoleNotice 'Uninstalling Icinga for Windows from this host';
     Write-IcingaConsoleNotice 'Uninstalling Icinga Security configuration if applied';

--- a/lib/core/repository/Uninstall-IcingaComponent.psm1
+++ b/lib/core/repository/Uninstall-IcingaComponent.psm1
@@ -28,7 +28,7 @@ function Uninstall-IcingaComponent()
     }
 
     # Set our current location to the PowerShell modules folder, to prevent possible folder lock during uninstallation
-    Set-Location (Get-IcingaForWindowsRootPath);
+    Set-IcingaPSLocation -Path $UninstallPath;
 
     Write-IcingaConsoleNotice -Message 'Uninstalling Icinga for Windows component "{0}" from "{1}"' -Objects $UninstallComponent, $UninstallPath;
     if (Remove-ItemSecure -Path $UninstallPath -Recurse -Force) {
@@ -36,7 +36,7 @@ function Uninstall-IcingaComponent()
         if ($UninstallComponent -ne 'icinga-powershell-framework') {
             Remove-Module $UninstallComponent -Force -ErrorAction SilentlyContinue;
             # In case we are not removing the framework itself, set the location to the Icinga for Windows Folder
-            Set-Location (Get-IcingaFrameworkRootPath);
+            Set-IcingaPSLocation -Path $UninstallPath;
         }
         return $TRUE;
     } else {

--- a/lib/core/tools/Set-IcingaPSLocation.psm1
+++ b/lib/core/tools/Set-IcingaPSLocation.psm1
@@ -1,0 +1,21 @@
+function Set-IcingaPSLocation()
+{
+    param (
+        [string]$Path = (Get-Location)
+    );
+
+    if ([string]::IsNullOrEmpty($Path)) {
+        return;
+    }
+
+    if ((Test-Path $Path) -eq $FALSE) {
+        return;
+    }
+
+    [string]$IfWRootPath = Get-IcingaForWindowsRootPath;
+    [string]$CurrentPath = Get-Location;
+
+    if ($CurrentPath -Like ([string]::Format('{0}*', $Path))) {
+        Set-Location -Path $IfWRootPath;
+    }
+}


### PR DESCRIPTION
Fixes installation and uninstallation commands changing PowerShell location even when not necessary

Fixes #578