### PR TITLE
Fix: Service exclude filter for wildcards

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
+## 1.11.0 (2023-05-16)
+
+[Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/26)
+
+### Bugfixes
+
+* [#603](https://github.com/Icinga/icinga-powershell-framework/issues/603) Fixed service filter to handle exclude with wildcards instead of requiring the full service name (*not* applying to the display name)
+
 ## 1.10.1 (2022-12-20)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/27?closed=1)
@@ -16,7 +24,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#578](https://github.com/Icinga/icinga-powershell-framework/issues/578) Fixes installation and uninstallation commands changing PowerShell location even when not necessary
 * [#582](https://github.com/Icinga/icinga-powershell-framework/issues/582) Fixes background service registration caused by migration task for v1.10.0 being executed even when no services were defined before
 * [#588](https://github.com/Icinga/icinga-powershell-framework/issues/588) Fixes threshold values causing an error because of too aggressive regex expression
-* [#599](https://github.com/Icinga/icinga-powershell-plugins/issues/599) Fixes plugin argument parser to proceed with real argument names and possible provided aliases
+* [#599](https://github.com/Icinga/icinga-powershell-framework/issues/599) Fixes plugin argument parser to proceed with real argument names and possible provided aliases
 
 ## 1.10.0 (2022-08-30)
 

--- a/lib/core/tools/Get-IcingaServices.psm1
+++ b/lib/core/tools/Get-IcingaServices.psm1
@@ -37,7 +37,7 @@ function Get-IcingaServices()
         [int]$StartModeId         = 5;
         [string]$StartMode        = 'Unknown';
 
-        if ($Exclude -contains $service.ServiceName) {
+        if ((Test-IcingaArrayFilter -InputObject $Service.ServiceName -Exclude $Exclude) -eq $FALSE) {
             continue;
         }
 


### PR DESCRIPTION
Fixes service filter to handle exclude with wildcards instead of requiring the full service name (*not* applying to the display name)

#Fixes 603