### PR TITLE
Fix: Config generator should not use set_if = true

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#603](https://github.com/Icinga/icinga-powershell-framework/issues/603) Fixed service filter to handle exclude with wildcards instead of requiring the full service name (*not* applying to the display name)
+* [#609](https://github.com/Icinga/icinga-powershell-framework/issues/609) Fixed config generator to never use `set_if = true` on Icinga 2/Icinga Director configuration
 
 ## 1.10.1 (2022-12-20)
 

--- a/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
+++ b/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
@@ -100,12 +100,14 @@ function Get-IcingaCheckCommandConfig()
         @{
             'arguments'       = @{
                 '-NoProfile'       = @{
-                    'order'  = '-3';
-                    'set_if' = $TRUE;
+                    'order'    = '-3';
+                    'skip_key' = $TRUE;
+                    'value'    = '-NoLogo';
                 };
                 '-NoLogo'          = @{
-                    'order'  = '-2';
-                    'set_if' = $TRUE;
+                    'order'    = '-2';
+                    'skip_key' = $TRUE;
+                    'value'    = '-NoLogo';
                 };
                 '-ExecutionPolicy' = @{
                     'order' = '-1';


### PR DESCRIPTION
We should nbever use `set_if` = true inside the Icinga Configuration or Director Baskets. This will result in the Icinga Director always flagging a certain object as modified.