### PR TITLE
Fix: Plugin failure for switch args with ThresholdInterval

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -13,8 +13,9 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
-* [#603](https://github.com/Icinga/icinga-powershell-framework/issues/603) Fixed service filter to handle exclude with wildcards instead of requiring the full service name (*not* applying to the display name)
-* [#609](https://github.com/Icinga/icinga-powershell-framework/issues/609) Fixed config generator to never use `set_if = true` on Icinga 2/Icinga Director configuration
+* [#603](https://github.com/Icinga/icinga-powershell-framework/issues/603) Fixes service filter to handle exclude with wildcards instead of requiring the full service name (*not* applying to the display name)
+* [#609](https://github.com/Icinga/icinga-powershell-framework/issues/609) Fixes config generator to never use `set_if = true` on Icinga 2/Icinga Director configuration
+* [#617](https://github.com/Icinga/icinga-powershell-framework/issues/617) Fixes failing calls for plugins which use a switch argument like `-NoPerfData`, which is followed directly by the `-ThresholdInterval` argument
 
 ## 1.10.1 (2022-12-20)
 

--- a/lib/core/tools/ConvertTo-IcingaPowerShellArguments.psm1
+++ b/lib/core/tools/ConvertTo-IcingaPowerShellArguments.psm1
@@ -31,6 +31,10 @@ function ConvertTo-IcingaPowerShellArguments()
     # Ensure we do not cause exceptions along the border in case the plugin is not installed
     if ($null -eq $CmdAllowedArgs) {
         return @{ };
+    } else {
+        # We need to manually add the "-ThresholdInterval" argument, as this is an artificial
+        # one we do need to take care off
+        $CmdAllowedArgs += 'ThresholdInterval';
     }
 
     # Ensure we not only add the parameter name to our allow list but also possible aliases


### PR DESCRIPTION
Fixes failing calls for plugins which use a switch argument like `-NoPerfData`, which is followed directly by the `-ThresholdInterval` argument

Fixes #617