### PR TITLE
Fix: Recursive loop on first loading of Framework

### DIFF
--- a/cache/framework_cache.psm1
+++ b/cache/framework_cache.psm1
@@ -8,6 +8,21 @@
     Manually enabling the feature is no longer required.
 #>
 
+# Ensure we only load this module once
+if ($null -ne $Global:Icinga -And $Global:Icinga.ContainsKey('CacheBuilding') -And $Global:Icinga['CacheBuilding']) {
+    return;
+}
+
+if ($null -eq $Global:Icinga) {
+    $Global:Icinga = @{ };
+}
+
+if ($Global:Icinga.ContainsKey('CacheBuilding') -eq $FALSE) {
+    $Global:Icinga.Add('CacheBuilding', $TRUE);
+} else {
+    $Global:Icinga.CacheBuilding = $TRUE;
+}
+
 # Ensures that VS Code is not generating the cache file
 if ($null -ne $env:TERM_PROGRAM) {
     Write-IcingaFrameworkCodeCache -DeveloperMode;
@@ -22,3 +37,5 @@ Import-Module icinga-powershell-framework -Force;
 if ($null -ne $env:TERM_PROGRAM -Or $Global:Icinga.Protected.DeveloperMode) {
     Copy-IcingaFrameworkCacheTemplate;
 }
+
+$Global:Icinga.CacheBuilding = $FALSE;

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -132,7 +132,11 @@ function Write-IcingaFrameworkCodeCache()
 
     [System.IO.File]::WriteAllLines($CacheFile, $CacheContent, (New-Object System.Text.UTF8Encoding $TRUE));
 
-    Remove-IcingaFrameworkDependencyFile;
+    $DependencyFile = Join-Path -Path (Get-IcingaCacheDir) -ChildPath 'framework_dependencies.json';
+
+    if ((Test-Path $DependencyFile)) {
+        Remove-Item -Path $DependencyFile -Force | Out-Null;
+    }
 
     if ($Global:Icinga.Protected.DeveloperMode) {
         Copy-IcingaFrameworkCacheTemplate;

--- a/lib/core/framework/New-IcingaEnvironmentVariable.psm1
+++ b/lib/core/framework/New-IcingaEnvironmentVariable.psm1
@@ -15,6 +15,10 @@ function New-IcingaEnvironmentVariable()
         $Global:Icinga = @{ };
     }
 
+    if ($Global:Icinga.ContainsKey('CacheBuilding') -eq $FALSE) {
+        $Global:Icinga.Add('CacheBuilding', $FALSE);
+    }
+
     # Session specific configuration for this shell
     if ($Global:Icinga.ContainsKey('Private') -eq $FALSE) {
         $Global:Icinga.Add('Private', @{ });

--- a/templates/framework_cache.psm1.template
+++ b/templates/framework_cache.psm1.template
@@ -8,6 +8,21 @@
     Manually enabling the feature is no longer required.
 #>
 
+# Ensure we only load this module once
+if ($null -ne $Global:Icinga -And $Global:Icinga.ContainsKey('CacheBuilding') -And $Global:Icinga['CacheBuilding']) {
+    return;
+}
+
+if ($null -eq $Global:Icinga) {
+    $Global:Icinga = @{ };
+}
+
+if ($Global:Icinga.ContainsKey('CacheBuilding') -eq $FALSE) {
+    $Global:Icinga.Add('CacheBuilding', $TRUE);
+} else {
+    $Global:Icinga.CacheBuilding = $TRUE;
+}
+
 # Ensures that VS Code is not generating the cache file
 if ($null -ne $env:TERM_PROGRAM) {
     Write-IcingaFrameworkCodeCache -DeveloperMode;
@@ -22,3 +37,5 @@ Import-Module icinga-powershell-framework -Force;
 if ($null -ne $env:TERM_PROGRAM -Or $Global:Icinga.Protected.DeveloperMode) {
     Copy-IcingaFrameworkCacheTemplate;
 }
+
+$Global:Icinga.CacheBuilding = $FALSE;


### PR DESCRIPTION
Prevents the Icinga for Windows framework to recursively import itself on first startup or after reseting the cache file.