### PR TITLE
Doc: Updates metric over time docs for intervals

### DIFF
--- a/doc/110-Installation/06-Collect-Metrics-over-Time.md
+++ b/doc/110-Installation/06-Collect-Metrics-over-Time.md
@@ -36,7 +36,7 @@ In order to add service check to our daemon, we can use `Register-IcingaServiceC
 | CheckCommand | String    | The plugin you want to execute inside the daemon |
 | Arguments    | Hashtable | Plugin arguments which are added to the internal check |
 | Interval     | Integer   | The time interval in seconds on how often the check is executed |
-| TimeIndexes  | Array     | A list of Integer time indexes, for which time frames metrics should be collected |
+| TimeIndexes  | Array     | A list of Integer time indexes, for which time frames metrics should be collected. Always ensure to add the proper time unit to the values: s, m, d, M, y. A value without a unit always means seconds by default |
 
 #### Examples
 
@@ -48,12 +48,14 @@ We will register our CPU plugin to run every 30 seconds and collect the average 
 Register-IcingaServiceCheck `
     -CheckCommand 'Invoke-IcingaCheckCPU' `
     -Interval 30 `
-    -TimeIndexes 1, 3, 5, 15;
+    -TimeIndexes 1m, 3m, 5m, 15m;
 ```
+
+**Note:** The handling for `-TimeIndexes` has changed with the latest Icinga for Windows version, as you now have to specify the unit for the time value to build the average for. This enables more flexible support to collect averages for hours or days as example.
 
 ##### Register Partition Space Plugin
 
-Lets register our used partition space plugin, to run every 15 seconds, collect the average metrics for 1,3,5,20 and 60 minutes and only include drive C:
+Lets register our used partition space plugin, to run every 15 seconds, collect the average metrics for 1m, 3m,5m, 20m and 1h and only include drive C:
 
 ```powershell
 Register-IcingaServiceCheck `
@@ -62,7 +64,7 @@ Register-IcingaServiceCheck `
         '-Include' = 'C';
     } `
     -Interval 15 `
-    -TimeIndexes 1, 3, 5, 20, 60;
+    -TimeIndexes 1m, 3m, 5m, 20m, 1h;
 ```
 
 ##### Register Performance Counter Plugin with Multi-Values
@@ -80,7 +82,7 @@ Register-IcingaServiceCheck `
         );
     } `
     -Interval 15 `
-    -TimeIndexes 1, 3, 5, 10, 15, 20;
+    -TimeIndexes 1m, 3m, 5m, 10m, 15m, 20m;
 ```
 
 ### Show Registered Service Checks
@@ -101,7 +103,7 @@ Arguments    => -PerfCounter '\Processor(*)\% Processor Time', '\Memory\% commit
 CheckCommand => Invoke-IcingaCheckPerfCounter
 Id           => 1332191811682909517982372151451071972043015735175
 Interval     => 15
-TimeIndexes  => 1, 3, 5, 10, 15, 20
+TimeIndexes  => 1m, 3m, 5m, 10m, 15m, 20m
 
 ```
 


### PR DESCRIPTION
Icinga for Windows changed the behavior on how metrics over time `-TimeIndexes` argument works, as you now have to add the unit for the time to build the average for.