### PR TITLE
 Fix: Framework migration error on multi framework installation

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -15,8 +15,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#603](https://github.com/Icinga/icinga-powershell-framework/issues/603) Fixes service filter to handle exclude with wildcards instead of requiring the full service name (*not* applying to the display name)
 * [#609](https://github.com/Icinga/icinga-powershell-framework/issues/609) Fixes config generator to never use `set_if = true` on Icinga 2/Icinga Director configuration
+* [#615](https://github.com/Icinga/icinga-powershell-framework/issues/615) Fixes the framework migration tasks which fails in case multiple versions of the framework are installed, printing warnings in case there is
 * [#617](https://github.com/Icinga/icinga-powershell-framework/issues/617) Fixes failing calls for plugins which use a switch argument like `-NoPerfData`, which is followed directly by the `-ThresholdInterval` argument
 * [#621](https://github.com/Icinga/icinga-powershell-framework/pull/621) Fixes `-ThresholdInterval` key detection on newer systems
+
 
 ### Enhancements
 

--- a/lib/core/framework/Test-IcingaForWindowsMigration.psm1
+++ b/lib/core/framework/Test-IcingaForWindowsMigration.psm1
@@ -8,9 +8,25 @@ function Test-IcingaForWindowsMigration()
         return $FALSE;
     }
 
-    [Version]$CurrentFrameworkVersion = (Get-Module -ListAvailable -Name icinga-powershell-framework).Version;
+    [string]$CurrentFrameworkRoot     = Get-IcingaFrameworkRootPath;
+    [array]$ListOfFrameworks          = (Get-Module -ListAvailable -Name icinga-powershell-framework);
+    [Version]$CurrentFrameworkVersion = $ListOfFrameworks[0].Version;
     [string]$MigrationConfigPath      = [string]::Format('Framework.Migrations.{0}', $MigrationVersion.ToString().Replace('.', ''));
     $VersionMigrationApplied          = Get-IcingaPowerShellConfig -Path $MigrationConfigPath;
+
+    if ($ListOfFrameworks.Count -gt 1) {
+        Write-IcingaConsoleWarning -Message 'Found multiple installations of the module "icinga-powershell-framework". Please check the list below and cleanup your installation to ensure system integrity'
+        foreach ($entry in $ListOfFrameworks) {
+            Write-Host ([string]::Format(' => Path "{0}" with version "{1}"', $entry.ModuleBase, $entry.Version));
+
+            # Ensure we use the correct version of the framework loaded within this session
+            if ($CurrentFrameworkRoot -eq $entry.ModuleBase) {
+                $CurrentFrameworkVersion = $entry.Version;
+            }
+        }
+
+        Write-IcingaConsoleWarning -Message 'This instance of Icinga for Windows will run with Framework version "{0}"' -Objects $CurrentFrameworkVersion.ToString();
+    }
 
     # Migration for this version is already applied
     if ($VersionMigrationApplied) {


### PR DESCRIPTION
Fixes the framework migration tasks which fails in case multiple versions of the framework are installed, printing warnings in case there is

Fixes #615