### PR TITLE
Get-IcingaCheckCommandConfig: fix copy&paste error

### DIFF
--- a/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
+++ b/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
@@ -102,7 +102,7 @@ function Get-IcingaCheckCommandConfig()
                 '-NoProfile'       = @{
                     'order'    = '-3';
                     'skip_key' = $TRUE;
-                    'value'    = '-NoLogo';
+                    'value'    = '-NoProfile';
                 };
                 '-NoLogo'          = @{
                     'order'    = '-2';


### PR DESCRIPTION
Pass -NoLogo and -NoProfile once, not -NoLogo twice.