### PR TITLE
Get-IcingaCheckCommandConfig: set vars.ifw_api_command in all commands

### DIFF
--- a/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
+++ b/lib/core/tools/Get-IcingaCheckCommandConfig.psm1
@@ -212,6 +212,7 @@ function Get-IcingaCheckCommandConfig()
                 'object_name' = $check;
                 'object_type' = 'object';
                 'vars'        = @{
+                    'ifw_api_command'   = $check;
                     'ifw_api_arguments' = @{ };
                 };
             }


### PR DESCRIPTION
Useful in case someone renames the commands in Director.

Otherwise, in this case, all commands would be broken with ifw-api as vars.ifw_api_command defaults to $command.name$.

**Unless** a specific command could inherit/import another specific command, I see no problems with this.