### PR TITLE
Fix: Clear-Host throwing exceptions during automation tasks

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -20,6 +20,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#615](https://github.com/Icinga/icinga-powershell-framework/issues/615) Fixes the framework migration tasks which fails in case multiple versions of the framework are installed, printing warnings in case there is
 * [#617](https://github.com/Icinga/icinga-powershell-framework/issues/617) Fixes failing calls for plugins which use a switch argument like `-NoPerfData`, which is followed directly by the `-ThresholdInterval` argument
 * [#621](https://github.com/Icinga/icinga-powershell-framework/pull/621) Fixes `-ThresholdInterval` key detection on newer systems
+* [#634](https://github.com/Icinga/icinga-powershell-framework/pull/634) Fixes an issue with `Clear-Host` which could cause an exception during certain automation tasks, causing it to fail
 * [#645](https://github.com/Icinga/icinga-powershell-framework/pull/645) Fixes error and exception handling while using API-Checks, which now will in most cases always return a proper check-result object and also abort while running into plugin execution errors, in case a server is not reachable by the time sync plugin for example
 * [#646](https://github.com/Icinga/icinga-powershell-framework/pull/646) Fixes REST-Api to allow arguments for check execution with and without leading `-`
 * [#648](https://github.com/Icinga/icinga-powershell-framework/pull/648) Fixes some memory management while using the REST-Api to clear connection objects once they are no longer required
@@ -29,6 +30,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#544](https://github.com/Icinga/icinga-powershell-framework/issues/544) Adds support to configure the Icinga Director JSON string for registering hosts via self-service API
 * [#572](https://github.com/Icinga/icinga-powershell-framework/issues/572) Adds support to write the name of the repository synced/created into the local `ifw.repo.json` file
 * [#573](https://github.com/Icinga/icinga-powershell-framework/issues/573) Adds support to run command `icinga` with new argument `-NoNewInstance`, to use `-RebuildCache` as example to update the current PowerShell instance with all applied changes
+* [#613](https://github.com/Icinga/icinga-powershell-framework/pull/613) Adds a `-Version` parameter to the `Update-Icinga` command, to be able to update a component to a specified version [@log1-c]
 * [#619](https://github.com/Icinga/icinga-powershell-framework/pull/619) Adds feature to securely read enum provider values with new function `Get-IcingaProviderEnumData`
 * [#623](https://github.com/Icinga/icinga-powershell-framework/issues/623) Adds support to provide the Icinga service user written as `user@domain`
 * [#633](https://github.com/Icinga/icinga-powershell-framework/pull/633) Adds support for Icinga 2.14.0 native Icinga for Windows API communication
@@ -40,10 +42,6 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#644](https://github.com/Icinga/icinga-powershell-framework/pull/644) Adds progress bar output to repository interaction (sync, update, new) instead of plain text output
 * [#655](https://github.com/Icinga/icinga-powershell-framework/pull/655) Adds [IWKB](https://icinga.com/docs/icinga-for-windows/latest/doc/knowledgebase/IWKB000016/) and test/manage Cmdlets for SCOM intercept counters
 * [#656](https://github.com/Icinga/icinga-powershell-framework/pull/656) Adds new feature to write document content easier by storing it in memory first and then allowing to write it to disk at once with proper UTF8 encoding
-
-### Enhancements
-
-* [#613](https://github.com/Icinga/icinga-powershell-framework/pull/613) Adds a `-Version` parameter to the `Update-Icinga` command, to be able to update a component to a specified version [@log1-c]
 
 ## 1.10.1 (2022-12-20)
 

--- a/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
+++ b/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
@@ -5,7 +5,7 @@ function Start-IcingaForWindowsInstallation()
     );
 
     if ($global:Icinga.InstallWizard.DirectorInstallError -eq $FALSE -And (Get-IcingaFrameworkDebugMode) -eq $FALSE) {
-        Clear-Host;
+        Clear-CLIConsole;
     }
 
     Write-IcingaConsoleNotice 'Starting Icinga for Windows installation';

--- a/lib/core/installer/menu/manage/shell/StartIcingaShell.psm1
+++ b/lib/core/installer/menu/manage/shell/StartIcingaShell.psm1
@@ -1,6 +1,6 @@
 function Invoke-IcingaForWindowsMenuStartIcingaShell()
 {
-    Clear-Host;
+    Clear-CLIConsole;
     $global:Icinga.InstallWizard.Closing = $TRUE;
     Invoke-IcingaCommand -Shell;
 }

--- a/lib/core/installer/tools/Clear-CLIConsole.psm1
+++ b/lib/core/installer/tools/Clear-CLIConsole.psm1
@@ -1,0 +1,8 @@
+function Clear-CLIConsole()
+{
+    try {
+        Clear-Host -ErrorAction Stop;
+    } catch {
+        # Nothing to do
+    }
+}

--- a/lib/core/installer/tools/ShowInstallerMenu.psm1
+++ b/lib/core/installer/tools/ShowInstallerMenu.psm1
@@ -23,7 +23,7 @@ function Show-IcingaForWindowsInstallerMenu()
     );
 
     if ($global:Icinga.InstallWizard.DirectorInstallError -eq $FALSE -And (Test-IcingaForWindowsInstallationHeaderPrint) -eq $FALSE -And (Get-IcingaFrameworkDebugMode) -eq $FALSE) {
-        Clear-Host;
+        Clear-CLIConsole;
     }
 
     $PSCallStack   = Get-PSCallStack;
@@ -295,7 +295,7 @@ function Show-IcingaForWindowsInstallerMenu()
 
     switch ($Result) {
         'x' {
-            Clear-Host;
+            Clear-CLIConsole;
             $global:Icinga.InstallWizard.Closing = $TRUE;
             return;
         };

--- a/lib/icinga/plugin/Write-IcingaPluginOutput.psm1
+++ b/lib/icinga/plugin/Write-IcingaPluginOutput.psm1
@@ -6,7 +6,7 @@ function Write-IcingaPluginOutput()
 
     if ($Global:Icinga.Protected.RunAsDaemon -eq $FALSE -And $Global:Icinga.Protected.JEAContext -eq $FALSE) {
         if ($Global:Icinga.Protected.Minimal) {
-            Clear-Host;
+            Clear-CLIConsole;
         }
         Write-IcingaConsolePlain $Output;
     } else {


### PR DESCRIPTION
Fixes an issue with `Clear-Host` which could cause an exception during certain automation tasks, causing it to fail