### PR TITLE
Feature: Adds support to allow Agent cipher list configuration

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -22,6 +22,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Enhancements
 
 * [#623](https://github.com/Icinga/icinga-powershell-framework/issues/623) Adds support to provide the Icinga service user written as `user@domain`
+* [#635](https://github.com/Icinga/icinga-powershell-framework/pull/635) Adds support for `Write-IcingaAgentApiConfig` function to configure the Icinga Agent TLS cipher list setting by new argument `-CipherList`
 
 ### Enhancements
 

--- a/lib/core/icingaagent/writers/Write-IcingaAgentApiConfig.psm1
+++ b/lib/core/icingaagent/writers/Write-IcingaAgentApiConfig.psm1
@@ -1,7 +1,8 @@
 function Write-IcingaAgentApiConfig()
 {
-    param(
-        [int]$Port = 5665
+    param (
+        [int]$Port          = 5665,
+        [string]$CipherList = $null
     );
 
     [string]$ApiConf = '';
@@ -11,6 +12,9 @@ function Write-IcingaAgentApiConfig()
     $ApiConf = [string]::Format('{0}    accept_config = true;{1}', $ApiConf, "`r`n");
     $ApiConf = [string]::Format('{0}    bind_host = "::";{1}', $ApiConf, "`r`n");
     $ApiConf = [string]::Format('{0}    bind_port = {1};{2}', $ApiConf, $Port, "`r`n");
+    if ([string]::IsNullOrEmpty($CipherList) -eq $FALSE) {
+        $ApiConf = [string]::Format('{0}    cipher_list = "{1}";{2}', $ApiConf, $CipherList, "`r`n");
+    }
     $ApiConf = [string]::Format('{0}{1}{2}{2}', $ApiConf, '}', "`r`n");
 
     $ApiConf = $ApiConf.Substring(0, $ApiConf.Length - 4);


### PR DESCRIPTION
Adds support for `Write-IcingaAgentApiConfig` function to configure the Icinga Agent TLS cipher list setting.