### PR TITLE
Feature: Adds support to ignore SSL errors on IMC, Shell and Installer

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -21,12 +21,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Enhancements
 
+* [#619](https://github.com/Icinga/icinga-powershell-framework/pull/619) Adds feature to securely read enum provider values with new function `Get-IcingaProviderEnumData`
 * [#623](https://github.com/Icinga/icinga-powershell-framework/issues/623) Adds support to provide the Icinga service user written as `user@domain`
 * [#635](https://github.com/Icinga/icinga-powershell-framework/pull/635) Adds support for `Write-IcingaAgentApiConfig` function to configure the Icinga Agent TLS cipher list setting by new argument `-CipherList`
-
-### Enhancements
-
-* [#619](https://github.com/Icinga/icinga-powershell-framework/pull/619) Adds feature to securely read enum provider values with new function `Get-IcingaProviderEnumData`
+* [#640](https://github.com/Icinga/icinga-powershell-framework/issues/640) Adds support to set the flag `-NoSSLValidation` for Cmdlets `icinga` and `Install-Icinga`, to ignore errors on self-signed certificates within the environment
 
 ## 1.10.1 (2022-12-20)
 

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -243,12 +243,13 @@ function Invoke-IcingaCommand()
     [CmdletBinding()]
     param (
         $ScriptBlock,
-        [switch]$SkipHeader    = $FALSE,
-        [switch]$Manage        = $FALSE, # Only for backwards compatibility, has no use at all
-        [switch]$Shell         = $FALSE,
-        [switch]$RebuildCache  = $FALSE,
-        [switch]$DeveloperMode = $FALSE,
-        [array]$ArgumentList   = @()
+        [switch]$SkipHeader      = $FALSE,
+        [switch]$Manage          = $FALSE, # Only for backwards compatibility, has no use at all
+        [switch]$Shell           = $FALSE,
+        [switch]$NoSSLValidation = $FALSE,
+        [switch]$RebuildCache    = $FALSE,
+        [switch]$DeveloperMode   = $FALSE,
+        [array]$ArgumentList     = @()
     );
 
     Import-LocalizedData `
@@ -304,9 +305,18 @@ function Invoke-IcingaCommand()
         $Shell           = $args[3];
         $IcingaShellArgs = $args[4];
         $DeveloperMode   = $args[5];
+        $NoSSLValidation = $args[6];
 
         # Load our Icinga Framework
         Use-Icinga;
+
+        # Always ensure we use the proper TLS Version
+        Set-IcingaTLSVersion;
+
+        # Ignore SSL validation in case we set the flag
+        if ($NoSSLValidation) {
+            Enable-IcingaUntrustedCertificateValidation;
+        }
 
         if ($DeveloperMode) {
             $Global:Icinga.Protected.DeveloperMode = $TRUE;
@@ -336,7 +346,7 @@ function Invoke-IcingaCommand()
             return "> "
         }
 
-    } -Args $ScriptBlock, $PSScriptRoot, $IcingaFrameworkData.PrivateData.Version, ([bool]$Shell), $ArgumentList, ([bool]$DeveloperMode);
+    } -Args $ScriptBlock, $PSScriptRoot, $IcingaFrameworkData.PrivateData.Version, ([bool]$Shell), $ArgumentList, ([bool]$DeveloperMode), ([bool]$NoSSLValidation);
 
     # In case we close the newly created PowerShell, ensure we set the script root back to the Framework folder
     if (Test-Path $PSScriptRoot) {
@@ -349,13 +359,14 @@ function Invoke-IcingaCommand()
 
         # Use the same arguments again to open the IMC
         $IMCReopenArguments = @{
-            'ScriptBlock'   = $ScriptBlock;
-            'SkipHeader'    = $SkipHeader;
-            'Manage'        = $Manage;
-            'Shell'         = $Shell;
-            'RebuildCache'  = $RebuildCache;
-            'DeveloperMode' = $DeveloperMode;
-            'ArgumentList'  = $ArgumentList;
+            'ScriptBlock'     = $ScriptBlock;
+            'SkipHeader'      = $SkipHeader;
+            'Manage'          = $Manage;
+            'Shell'           = $Shell;
+            'NoSSLValidation' = $NoSSLValidation;
+            'RebuildCache'    = $RebuildCache;
+            'DeveloperMode'   = $DeveloperMode;
+            'ArgumentList'    = $ArgumentList;
         };
 
         Invoke-IcingaCommand @IMCReopenArguments;

--- a/lib/core/installer/Install-Icinga.psm1
+++ b/lib/core/installer/Install-Icinga.psm1
@@ -1,12 +1,21 @@
 function Install-Icinga()
 {
     param (
-        [string]$InstallCommand = $null,
-        [string]$InstallFile    = ''
+        [string]$InstallCommand  = $null,
+        [string]$InstallFile     = '',
+        [switch]$NoSSLValidation = $FALSE
     );
 
     if ($null -eq $global:Icinga) {
         $global:Icinga = @{ };
+    }
+
+    # Always ensure we use the proper TLS Version
+    Set-IcingaTLSVersion;
+
+    # Ignore SSL validation in case we set the flag
+    if ($NoSSLValidation) {
+        Enable-IcingaUntrustedCertificateValidation;
     }
 
     if ($global:Icinga.ContainsKey('InstallWizard') -eq $FALSE) {


### PR DESCRIPTION
Adds support to set the flag `-NoSSLValidation` for Cmdlets `icinga` and `Install-Icinga`, to ignore errors on self-signed certificates within the environment.

Example:

```powershell
icinga -NoSSLValidation
```
Icinga Shell:

```powershell
icinga -Shell -NoSSLValidation
```

Fixes #640