### PR TITLE
Feature: Adds support to configure Director Self-Service config string

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -21,6 +21,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Enhancements
 
+* [#544](https://github.com/Icinga/icinga-powershell-framework/issues/544) Adds support to configure the Icinga Director JSON string for registering hosts via self-service API
 * [#619](https://github.com/Icinga/icinga-powershell-framework/pull/619) Adds feature to securely read enum provider values with new function `Get-IcingaProviderEnumData`
 * [#623](https://github.com/Icinga/icinga-powershell-framework/issues/623) Adds support to provide the Icinga service user written as `user@domain`
 * [#635](https://github.com/Icinga/icinga-powershell-framework/pull/635) Adds support for `Write-IcingaAgentApiConfig` function to configure the Icinga Agent TLS cipher list setting by new argument `-CipherList`

--- a/lib/core/installer/Install-Icinga.psm1
+++ b/lib/core/installer/Install-Icinga.psm1
@@ -21,34 +21,35 @@ function Install-Icinga()
     if ($global:Icinga.ContainsKey('InstallWizard') -eq $FALSE) {
         $global:Icinga.Add(
             'InstallWizard', @{
-                'AdminShell'             = (Test-AdministrativeShell);
-                'LastInput'              = '';
-                'LastNotice'             = '';
-                'LastWarning'            = @();
-                'LastError'              = @();
-                'DirectorError'          = '';
-                'HeaderPreview'          = '';
-                'DirectorSelfService'    = $FALSE;
-                'DirectorRegisteredHost' = $FALSE;
-                'DirectorInstallError'   = $FALSE;
-                'LastParent'             = [System.Collections.ArrayList]@();
-                'LastValues'             = @();
-                'DisabledEntries'        = @{ };
-                'Config'                 = @{ };
-                'ConfigSwap'             = @{ };
-                'ParentConfig'           = $null;
-                'Menu'                   = 'Install-Icinga';
-                'NextCommand'            = '';
-                'NextArguments'          = $null;
-                'HeaderSelection'        = $null;
-                'DisplayAdvanced'        = $FALSE;
-                'ShowAdvanced'           = $FALSE;
-                'ShowHelp'               = $FALSE;
-                'ShowCommand'            = $FALSE;
-                'DeleteValues'           = $FALSE;
-                'HeaderPrint'            = $FALSE;
-                'JumpToSummary'          = $FALSE;
-                'Closing'                = $FALSE;
+                'AdminShell'                = (Test-AdministrativeShell);
+                'LastInput'                 = '';
+                'LastNotice'                = '';
+                'LastWarning'               = @();
+                'LastError'                 = @();
+                'DirectorError'             = '';
+                'HeaderPreview'             = '';
+                'DirectorSelfServiceConfig' = $null;
+                'DirectorSelfService'       = $FALSE;
+                'DirectorRegisteredHost'    = $FALSE;
+                'DirectorInstallError'      = $FALSE;
+                'LastParent'                = [System.Collections.ArrayList]@();
+                'LastValues'                = @();
+                'DisabledEntries'           = @{ };
+                'Config'                    = @{ };
+                'ConfigSwap'                = @{ };
+                'ParentConfig'              = $null;
+                'Menu'                      = 'Install-Icinga';
+                'NextCommand'               = '';
+                'NextArguments'             = $null;
+                'HeaderSelection'           = $null;
+                'DisplayAdvanced'           = $FALSE;
+                'ShowAdvanced'              = $FALSE;
+                'ShowHelp'                  = $FALSE;
+                'ShowCommand'               = $FALSE;
+                'DeleteValues'              = $FALSE;
+                'HeaderPrint'               = $FALSE;
+                'JumpToSummary'             = $FALSE;
+                'Closing'                   = $FALSE;
             }
         );
     } else {

--- a/lib/core/installer/menu/installation/AdvancedEntries.psm1
+++ b/lib/core/installer/menu/installation/AdvancedEntries.psm1
@@ -31,6 +31,7 @@ function Add-IcingaForWindowsInstallationAdvancedEntries()
     Show-IcingaForWindowsInstallationMenuEnterIcingaCAServer -Automated -Advanced;
     Show-IcingaForWindowsInstallerMenuSelectInstallApiChecks -Automated -Advanced;
     Show-IcingaForWindowsInstallerMenuSelectServiceRecovery -Automated -Advanced;
+    Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceConfig -Automated -Advanced;
 
     Enable-IcingaFrameworkConsoleOutput;
 

--- a/lib/core/installer/menu/installation/director/SelfServiceConfig.psm1
+++ b/lib/core/installer/menu/installation/director/SelfServiceConfig.psm1
@@ -1,0 +1,65 @@
+function Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceConfig()
+{
+    param (
+        [array]$Value          = @(),
+        [string]$DefaultInput  = 'c',
+        [switch]$JumpToSummary = $FALSE,
+        [switch]$Automated     = $FALSE,
+        [switch]$Advanced      = $FALSE
+    );
+
+    # Ensure we simply set the global variable for the Config in case we run in automation mode
+    if ($Automated) {
+        if ($null -ne $Value -And $null -ne $Value[0]) {
+            $Global:Icinga.InstallWizard.DirectorSelfServiceConfig = ConvertFrom-Json -InputObject $Value[0] -ErrorAction Stop;
+            return;
+        }
+    }
+
+    # Set the default if no value ist set
+    if ($Value -IsNot [array] -Or $null -eq $Value -or $Value.Count -eq 0) {
+        $Value.Clear();
+        if ($null -eq $Global:Icinga.InstallWizard.DirectorSelfServiceConfig) {
+            $Value += '{ "address": "$ifw.hostaddress$" }';
+        } else {
+            $Value += ConvertTo-Json -InputObject $Global:Icinga.InstallWizard.DirectorSelfServiceConfig -Depth 100 -Compress;
+        }
+    }
+
+    Show-IcingaForWindowsInstallerMenu `
+        -Header 'You can update the Icinga Director Self-Service config in this section. USE WITH CARE!' `
+        -Entries @(
+            @{
+                'Command' = 'Show-IcingaForWindowsInstallerConfigurationSummary';
+                'Help'    = 'This is the configuration JSON-Object for the Icinga Director Self-Service API. You can set a custom IP-Address or define the display name of an object with "display_name" as key. Use this methid with caution! Not all configuration elements in general possible are accessible by using the Self-Service keys.';
+            }
+        ) `
+        -DefaultIndex $DefaultInput `
+        -AddConfig `
+        -ConfigLimit 1 `
+        -DefaultValues @( $Value ) `
+        -MandatoryValue `
+        -JumpToSummary:$JumpToSummary `
+        -ConfigElement `
+        -Automated:$Automated `
+        -Advanced:$Advanced;
+
+    # Fetch the current JSON-String inserted by the user
+    [string]$ConfigString = Get-IcingaForWindowsInstallerValuesFromStep;
+
+    if ([string]::IsNullOrEmpty($ConfigString) -eq $FALSE) {
+        try {
+            # Validate that our JSON is correct
+            $Global:Icinga.InstallWizard.DirectorSelfServiceConfig = ConvertFrom-Json -InputObject $ConfigString -ErrorAction Stop;
+        } catch {
+            # Set some defaults to ensure we don't break the installer
+            Write-IcingaConsoleError ([string]::Format('The provided Icinga Director Self Service configuration "{0}" does not appear to be a valid JSON-String. E.g.: {{ "address": "$ifw.hostaddress$" }} without leading and ending "" before and after {{ }}', $ConfigString));
+            $Global:Icinga.InstallWizard.DirectorSelfServiceConfig = $null;
+            Set-IcingaForWindowsInstallerValuesFromStep -Values @( '{ }' );
+        }
+    } else {
+        $Global:Icinga.InstallWizard.DirectorSelfServiceConfig = $null;
+    }
+}
+
+Set-Alias -Name 'IfW-DirectorSelfServiceConfig' -Value 'Show-IcingaForWindowsManagementConsoleInstallationEnterDirectorSelfServiceConfig';

--- a/lib/core/installer/tools/CustomConfig.psm1
+++ b/lib/core/installer/tools/CustomConfig.psm1
@@ -16,7 +16,7 @@ function Invoke-IcingaForWindowsManagementConsoleCustomConfig()
         }
 
         if ($cmdConfig.ContainsKey('Values') -And $null -ne $cmdConfig.Values) {
-            $cmdArguments.Add('Value', $cmdConfig.Values)
+            $cmdArguments.Add('Value', $cmdConfig.Values);
         }
         if ($cmdConfig.ContainsKey('Selection') -And $null -ne $cmdConfig.Selection) {
             $cmdArguments.Add('DefaultInput', $cmdConfig.Selection)

--- a/lib/core/installer/tools/SetValuesFromStep.psm1
+++ b/lib/core/installer/tools/SetValuesFromStep.psm1
@@ -1,0 +1,20 @@
+function Set-IcingaForWindowsInstallerValuesFromStep()
+{
+    param (
+        [string]$InstallerStep,
+        [string]$Parent,
+        [array]$Values         = @()
+    );
+
+    $Step = Get-IcingaForWindowsManagementConsoleMenu;
+
+    if ([string]::IsNullOrEmpty($InstallerStep) -eq $FALSE) {
+        $Step = Get-IcingaForWindowsManagementConsoleAlias -Command $InstallerStep;
+
+        if ([string]::IsNullOrEmpty($Parent) -eq $FALSE) {
+            $Step = [string]::Format('{0}:{1}', $Step, $Parent);
+        }
+    }
+
+    $global:Icinga.InstallWizard.Config[$Step].Values = $Values;
+}


### PR DESCRIPTION
This new feature allows to configure the Icinga Director Self-Service call during registration, by modifing the JSON-String. This will only apply to the first time registration of a host and is not modified again, unless the host and director keys for this specific host object are removed.

This works directly inside the IMC installation wizard as well as for the exported installation command or file.

By doing so, you can manually define the IP-Address with `address` key in your JSON as well as the display name of an object with `display_name`. Example:

```json
{ "address": "127.0.0.1", "display_name": "Example Host" }
```

The following constants are available inside the configuration:

`$ifw.hostaddress$`: Will use the default IP-Address automatically fetched from the system
`$ifw.hostname$`: The current hostname of the host, without FQDN and not modiying upper/lowercase
`$ifw.hostfqdn$`: The current FQDN of the host, without case modification

For lower and upper case modification, you can use `.tolower` or `.toupper` for the hostname and FQDN, example:

```json
{ "address": "127.0.0.1", "display_name": "$ifw.hostname.tolower$" }
```

Fixes #292
Fixes #544