### PR TITLE
Feature: Adds support for -RebuildCache flag on icinga cmd to rebuild component cache

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -26,6 +26,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#623](https://github.com/Icinga/icinga-powershell-framework/issues/623) Adds support to provide the Icinga service user written as `user@domain`
 * [#635](https://github.com/Icinga/icinga-powershell-framework/pull/635) Adds support for `Write-IcingaAgentApiConfig` function to configure the Icinga Agent TLS cipher list setting by new argument `-CipherList`
 * [#640](https://github.com/Icinga/icinga-powershell-framework/issues/640) Adds support to set the flag `-NoSSLValidation` for Cmdlets `icinga` and `Install-Icinga`, to ignore errors on self-signed certificates within the environment
+* [#643](https://github.com/Icinga/icinga-powershell-framework/pull/643) Adds support for `-RebuildCache` flag on `icinga` cmd to rebuild component cache as well
 
 ## 1.10.1 (2022-12-20)
 

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -281,6 +281,7 @@ function Invoke-IcingaCommand()
     }
 
     if ($RebuildCache -Or $DeveloperMode) {
+        Copy-IcingaFrameworkCacheTemplate;
         Write-IcingaFrameworkCodeCache -DeveloperMode:$DeveloperMode;
     }
 


### PR DESCRIPTION
Adds support to simply use `-RebuildCache` for

```powershell
icinga -RebuildCache;
```

or

```powershell
icinga -Shell -RebuildCache;
```

to generate a new cache file not only for the Framework (like before), but also for all installed components of Icinga for Windows.

This makes it easier for regular use and error handling, as users will not have to remember a different Cmdlet or use the `-DeveloperMode` to force Icinga for Windows to rebuild everything.