### PR TITLE
Feature: Adds progress bar to repository interaction instead of text output

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -27,6 +27,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#635](https://github.com/Icinga/icinga-powershell-framework/pull/635) Adds support for `Write-IcingaAgentApiConfig` function to configure the Icinga Agent TLS cipher list setting by new argument `-CipherList`
 * [#640](https://github.com/Icinga/icinga-powershell-framework/issues/640) Adds support to set the flag `-NoSSLValidation` for Cmdlets `icinga` and `Install-Icinga`, to ignore errors on self-signed certificates within the environment
 * [#643](https://github.com/Icinga/icinga-powershell-framework/pull/643) Adds support for `-RebuildCache` flag on `icinga` cmd to rebuild component cache as well
+* [#644](https://github.com/Icinga/icinga-powershell-framework/pull/644) Adds progress bar output to repository interaction (sync, update, new) instead of plain text output
 
 ## 1.10.1 (2022-12-20)
 

--- a/lib/core/repository/New-IcingaRepository.psm1
+++ b/lib/core/repository/New-IcingaRepository.psm1
@@ -35,7 +35,7 @@ function New-IcingaRepository()
         return;
     }
 
-    $IcingaRepository = New-IcingaRepositoryFile -Path $Path -RemotePath $RemotePath;
+    $IcingaRepository = New-IcingaRepositoryFile -Path $Path -RemotePath $RemotePath -Name $Name;
 
     [array]$ConfigCount = $IcingaRepository.Packages.PSObject.Properties.Count;
 

--- a/lib/core/repository/New-IcingaRepositoryFile.psm1
+++ b/lib/core/repository/New-IcingaRepositoryFile.psm1
@@ -2,7 +2,8 @@ function New-IcingaRepositoryFile()
 {
     param (
         [string]$Path       = $null,
-        [string]$RemotePath = $null
+        [string]$RemotePath = $null,
+        [string]$Name       = ''
     );
 
     $RepoFile = 'ifw.repo.json';
@@ -23,10 +24,14 @@ function New-IcingaRepositoryFile()
 
     $RepositoryFolder = Get-ChildItem -Path $Path -Recurse -Include '*.msi', '*.zip';
 
+    New-IcingaProgressStatus -Name 'Updating Repository' -Message ([string]::Format('Update Icinga for Windows repository ({0}). Processed files', $Name)) -MaxValue $RepositoryFolder.Count -Details;
+
     foreach ($entry in $RepositoryFolder) {
         $RepoFilePath            = $entry.FullName.Replace($Path, '');
         $FileHash                = Get-FileHash -Path $entry.FullName -Algorithm SHA256;
         $ComponentName           = '';
+
+        Write-IcingaProgressStatus -Name 'Updating Repository';
 
         $IcingaForWindowsPackage = New-Object -TypeName PSObject;
         $IcingaForWindowsPackage | Add-Member -MemberType NoteProperty -Name 'Hash'         -Value $FileHash.Hash;
@@ -84,6 +89,8 @@ function New-IcingaRepositoryFile()
 
         $IcingaRepository.Info.RepoHash = Get-IcingaRepositoryHash -Path $Path;
     }
+
+    Complete-IcingaProgressStatus -Name 'Updating Repository';
 
     Write-IcingaFileSecure -File $RepoPath -Value (ConvertTo-Json -InputObject $IcingaRepository -Depth 100);
 

--- a/lib/core/repository/Update-IcingaRepository.psm1
+++ b/lib/core/repository/Update-IcingaRepository.psm1
@@ -67,7 +67,7 @@ function Update-IcingaRepository()
             $SetRemotePath = $RemotePath;
         }
 
-        $IcingaRepository = New-IcingaRepositoryFile -Path $Path -RemotePath $SetRemotePath;
+        $IcingaRepository = New-IcingaRepositoryFile -Path $Path -RemotePath $SetRemotePath -Name $Name;
 
         if ($CreateNew) {
             return $IcingaRepository;
@@ -97,7 +97,7 @@ function Update-IcingaRepository()
             $SetRemotePath = $RemotePath;
         }
 
-        Write-IcingaConsoleNotice 'Syncing repository "{0}"' -Objects $definedRepo.Name;
+        Write-IcingaConsoleDebug 'Syncing repository "{0}"' -Objects $definedRepo.Name;
 
         if ([string]::IsNullOrEmpty($definedRepo.Value.CloneSource) -eq $FALSE) {
             Sync-IcingaRepository `


### PR DESCRIPTION
Instead of writing every file processed within the console output, we now use the progress bar handling to provide a better idea on how many files have been processed during a sync and update.

![image](https://github.com/Icinga/icinga-powershell-framework/assets/5050288/8feb8727-b515-4325-9a11-40be36e76c0b)

In addition, creating new repositories will now give an overview on how many files have been processed so far including the remaining files, instead of waiting for the shell to complete the task without any output.

![image](https://github.com/Icinga/icinga-powershell-framework/assets/5050288/00d309ea-fe33-4b30-a43b-5fb12fa66c9e)