### PR TITLE
Fix: Sync-IcingaRepository not saving SSH settings

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -16,6 +16,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#579](https://github.com/Icinga/icinga-powershell-framework/issues/579) Fixes error message during config generation with `Get-IcingaCheckCommandConfig` to make it more clear, in case the custom variables generated are too long for the Icinga Director import
 * [#603](https://github.com/Icinga/icinga-powershell-framework/issues/603) Fixes service filter to handle exclude with wildcards instead of requiring the full service name (*not* applying to the display name)
 * [#609](https://github.com/Icinga/icinga-powershell-framework/issues/609) Fixes config generator to never use `set_if = true` on Icinga 2/Icinga Director configuration
+* [#611](https://github.com/Icinga/icinga-powershell-framework/issues/611) Fixes `Sync-IcingaRepository` which did not save the SSH user and host inside the repository configuration, preventing `Update-IcingaRepository` to work properly and added missing scp progress
 * [#615](https://github.com/Icinga/icinga-powershell-framework/issues/615) Fixes the framework migration tasks which fails in case multiple versions of the framework are installed, printing warnings in case there is
 * [#617](https://github.com/Icinga/icinga-powershell-framework/issues/617) Fixes failing calls for plugins which use a switch argument like `-NoPerfData`, which is followed directly by the `-ThresholdInterval` argument
 * [#621](https://github.com/Icinga/icinga-powershell-framework/pull/621) Fixes `-ThresholdInterval` key detection on newer systems

--- a/lib/core/repository/Sync-IcingaRepository.psm1
+++ b/lib/core/repository/Sync-IcingaRepository.psm1
@@ -247,13 +247,17 @@ function Sync-IcingaRepository()
 
         Write-IcingaConsoleNotice 'Syncing new repository files to "{0}"' -Objects $Path;
 
-        $Result = Start-IcingaProcess -Executable 'scp' -Arguments ([string]::Format('-r "{0}" "{1}:{2}"', $CopySource, $SSHAuth, $Path));
+        $SSHRemotePath = ([string]::Format('{0}:{1}', $SSHAuth, $Path));
 
-        if ($Result.ExitCode -ne 0) {
-            Write-IcingaConsoleError 'SCP Error while copying repository files: {0}' -Objects $Result.Error;
+        & scp -r "$CopySource" "$SSHRemotePath";
+
+        if ($LASTEXITCODE -ne 0) {
+            Write-IcingaConsoleError 'SCP Error while copying repository files';
             $Success = Remove-Item -Path $TmpDir -Recurse -Force;
             return;
         }
+
+        $Path = $SSHRemotePath;
     }
 
     $Success = Remove-Item -Path $TmpDir -Recurse -Force;


### PR DESCRIPTION
Fixes `Sync-IcingaRepository` which did not save the SSH user and host inside the repository configuration, preventing `Update-IcingaRepository` to work properly and added missing scp progress

Fixes #611