### PR TITLE
Fix: Update-Icinga not updating to latest or specified version

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -14,6 +14,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#659](https://github.com/Icinga/icinga-powershell-framework/pull/659) Fixes configuration writer which publishes invalid Icinga plain configuration files
+* [#660](https://github.com/Icinga/icinga-powershell-framework/pull/660) Fixes `Update-Icinga` not updating to the latest available version for a component and specifying `-Version` is updating to the latest one instead of the given one instead
 
 ## 1.11.0 (2023-08-01)
 

--- a/lib/core/repository/Update-Icinga.psm1
+++ b/lib/core/repository/Update-Icinga.psm1
@@ -22,9 +22,9 @@ function Update-Icinga()
             continue;
         }
 
-        if ([string]::IsNullOrEmpty($Version) -eq $FALSE){
-            $NewVersion = $Component.LatestVersion;
-        } else {
+        $NewVersion = $Component.LatestVersion;
+
+        if ([string]::IsNullOrEmpty($Version) -eq $FALSE) {
             $NewVersion = $Version;
         }
 


### PR DESCRIPTION
Fixes `Update-Icinga` not updating to the latest available version for a component and specifying `-Version` is updating to the latest one instead of the given one instead