### PR TITLE
Fix: MsiExec should not cause automatic host reboot

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -15,6 +15,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#659](https://github.com/Icinga/icinga-powershell-framework/pull/659) Fixes configuration writer which publishes invalid Icinga plain configuration files
 * [#660](https://github.com/Icinga/icinga-powershell-framework/pull/660) Fixes `Update-Icinga` not updating to the latest available version for a component and specifying `-Version` is updating to the latest one instead of the given one instead
+* [#661](https://github.com/Icinga/icinga-powershell-framework/pull/661) Fixes Icinga Agent installation and uninstallation, which could cause unintended automatic reboots
 * [#662](https://github.com/Icinga/icinga-powershell-framework/pull/662) Fixes JEA-Profiles always being updated during `Update-Icinga` calls, even when no component or non JEA related components were updated
 
 ## 1.11.0 (2023-08-01)

--- a/lib/core/icingaagent/installer/Install-IcingaAgent.psm1
+++ b/lib/core/icingaagent/installer/Install-IcingaAgent.psm1
@@ -78,7 +78,7 @@ function Install-IcingaAgent()
 
         $IcingaInstaller = $args[0];
         $InstallTarget   = $args[1];
-        $InstallProcess  = Start-IcingaProcess -Executable 'MsiExec.exe' -Arguments ([string]::Format('/quiet /i "{0}" {1}', $IcingaInstaller.InstallerPath, $InstallTarget)) -FlushNewLines;
+        $InstallProcess  = Start-IcingaProcess -Executable 'MsiExec.exe' -Arguments ([string]::Format('/quiet /norestart /i "{0}" {1}', $IcingaInstaller.InstallerPath, $InstallTarget)) -FlushNewLines;
 
         Start-Sleep -Seconds 2;
         Optimize-IcingaForWindowsMemory;

--- a/lib/core/icingaagent/installer/Uninstall-IcingaAgent.psm1
+++ b/lib/core/icingaagent/installer/Uninstall-IcingaAgent.psm1
@@ -26,7 +26,7 @@ function Uninstall-IcingaAgent()
         Use-Icinga -Minimal;
 
         $IcingaData  = $args[0];
-        $Uninstaller = Start-IcingaProcess -Executable 'MsiExec.exe' -Arguments ([string]::Format('{0} /q', $IcingaData.Uninstaller)) -FlushNewLine;
+        $Uninstaller = Start-IcingaProcess -Executable 'MsiExec.exe' -Arguments ([string]::Format('{0} /q /norestart', $IcingaData.Uninstaller)) -FlushNewLine;
 
         Start-Sleep -Seconds 2;
         Optimize-IcingaForWindowsMemory;

--- a/lib/core/repository/Install-IcingaComponent.psm1
+++ b/lib/core/repository/Install-IcingaComponent.psm1
@@ -378,7 +378,7 @@ function Install-IcingaComponent()
 
             $DownloadDestination = $args[0];
             $InstallTarget       = $args[1];
-            $InstallProcess      = Start-IcingaProcess -Executable 'MsiExec.exe' -Arguments ([string]::Format('/quiet /i "{0}" {1}', $DownloadDestination, $InstallTarget)) -FlushNewLines;
+            $InstallProcess      = Start-IcingaProcess -Executable 'MsiExec.exe' -Arguments ([string]::Format('/quiet /norestart /i "{0}" {1}', $DownloadDestination, $InstallTarget)) -FlushNewLines;
 
             Start-Sleep -Seconds 2;
             Optimize-IcingaForWindowsMemory;


### PR DESCRIPTION
Fixes Icinga Agent installation and uninstallation, which could cause unintended automatic reboots