### PR TITLE
Fix: JEA profile always modified during update process

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -15,6 +15,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#659](https://github.com/Icinga/icinga-powershell-framework/pull/659) Fixes configuration writer which publishes invalid Icinga plain configuration files
 * [#660](https://github.com/Icinga/icinga-powershell-framework/pull/660) Fixes `Update-Icinga` not updating to the latest available version for a component and specifying `-Version` is updating to the latest one instead of the given one instead
+* [#662](https://github.com/Icinga/icinga-powershell-framework/pull/662) Fixes JEA-Profiles always being updated during `Update-Icinga` calls, even when no component or non JEA related components were updated
 
 ## 1.11.0 (2023-08-01)
 

--- a/lib/core/repository/Update-Icinga.psm1
+++ b/lib/core/repository/Update-Icinga.psm1
@@ -14,6 +14,7 @@ function Update-Icinga()
     }
 
     $CurrentInstallation = Get-IcingaInstallation -Release:$Release -Snapshot:$Snapshot;
+    [bool]$UpdateJEA     = $FALSE;
 
     foreach ($entry in $CurrentInstallation.Keys) {
         $Component = $CurrentInstallation[$entry];
@@ -44,11 +45,15 @@ function Update-Icinga()
             continue;
         }
 
+        if ($entry.ToLower() -ne 'agent' -And $entry.ToLower() -ne 'service') {
+            $UpdateJEA = $TRUE;
+        }
+
         Install-IcingaComponent -Name $entry -Version $NewVersion -Release:$Release -Snapshot:$Snapshot -Confirm:$Confirm -Force:$Force;
     }
 
     # Update JEA profile if JEA is enabled once the update is complete
-    if ([string]::IsNullOrEmpty((Get-IcingaJEAContext)) -eq $FALSE) {
+    if ([string]::IsNullOrEmpty((Get-IcingaJEAContext)) -eq $FALSE -And $UpdateJEA) {
         Update-IcingaJEAProfile;
         Restart-IcingaWindowsService;
     }


### PR DESCRIPTION
Fixes JEA-Profiles always being updated during `Update-Icinga` calls, even when no component or non JEA related components were updated