### PR TITLE
Fix: JEA installer not including REST-Api on first run

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -17,6 +17,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#660](https://github.com/Icinga/icinga-powershell-framework/pull/660) Fixes `Update-Icinga` not updating to the latest available version for a component and specifying `-Version` is updating to the latest one instead of the given one instead
 * [#661](https://github.com/Icinga/icinga-powershell-framework/pull/661) Fixes Icinga Agent installation and uninstallation, which could cause unintended automatic reboots
 * [#662](https://github.com/Icinga/icinga-powershell-framework/pull/662) Fixes JEA-Profiles always being updated during `Update-Icinga` calls, even when no component or non JEA related components were updated
+* [#664](https://github.com/Icinga/icinga-powershell-framework/pull/664) Fixes JEA profile compiler not including REST-Api configuration during first installation
 
 ## 1.11.0 (2023-08-01)
 

--- a/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
+++ b/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
@@ -252,22 +252,6 @@ function Start-IcingaForWindowsInstallation()
         Restart-IcingaWindowsService;
     }
 
-    switch ($InstallJEAProfile) {
-        '0' {
-            Install-IcingaJEAProfile;
-            $InstallJEA = $TRUE;
-            break;
-        };
-        '1' {
-            Install-IcingaSecurity;
-            $InstallJEA = $TRUE;
-            break;
-        };
-        '2' {
-            # Do not install JEA profile
-        };
-    }
-
     switch ($InstallApiChecks) {
         '0' {
             Disable-IcingaFrameworkApiChecks;
@@ -298,9 +282,26 @@ function Start-IcingaForWindowsInstallation()
         };
     }
 
+    switch ($InstallJEAProfile) {
+        '0' {
+            Install-IcingaJEAProfile;
+            $InstallJEA = $TRUE;
+            break;
+        };
+        '1' {
+            Install-IcingaSecurity;
+            $InstallJEA = $TRUE;
+            break;
+        };
+        '2' {
+            # Do not install JEA profile
+        };
+    }
+
     # Install Icinga for Windows certificate if both, JEA and REST is installed
     if ($InstallJEA -And $InstallRESTApi) {
         Install-IcingaForWindowsCertificate;
+        Restart-IcingaWindowsService;
     }
 
     # Update configuration and clear swap


### PR DESCRIPTION
Fixes JEA profile compiler not including REST-Api configuration during first installation

Fixes #664