### PR TITLE
Sum up TotalLoad over all CPUs and divide it by number of threads

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -21,6 +21,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Enhancements
 
 * [#631](https://github.com/Icinga/icinga-powershell-framework/pull/631) Deduplicates `-C try { Use-Icinga ...` boilerplate by adding it to the `PowerShell Base` template and removing it from every single command
+* [#669](https://github.com/Icinga/icinga-powershell-framework/pull/669) Adds new metric to the CPU provider, allowing for distinguishing between the average total load as well as the sum of it
 * [#679](https://github.com/Icinga/icinga-powershell-framework/pull/679) Adds a new data provider for fetching process information of Windows systems, while sorting all objects based on a process name and their process id
 * [#688](https://github.com/Icinga/icinga-powershell-framework/pull/688) Adds new handling to add scheduled tasks in Windows for interacting with Icinga for Windows core functionality as well as an auto renewal task for the Icinga for Windows certificate generation
 * [#690](https://github.com/Icinga/icinga-powershell-framework/pull/690) Adds automatic renewal of the `icingaforwindows.pfx` certificate for the REST-Api daemon in case the certificate is not yet present, valid or changed during the runtime of the daemon while also making the `icingaforwindows.pfx` mandatory for all installations, regardless of JEA being used or not


### PR DESCRIPTION
On uncommon system configurations (number of sockets > 1) the TotalLoad perfdata of Invoke-IcingaCheckCpu was to high due to it being just summed up over all sockets.

This patch changes this computation, the load weighted by the number of sockets is summed up and then divided by the total number of CPUs.