### PR TITLE
Fix: Update compatibility with Icinga for Windows v1.11.0

### DIFF
--- a/lib/core/repository/Install-IcingaComponent.psm1
+++ b/lib/core/repository/Install-IcingaComponent.psm1
@@ -21,7 +21,7 @@ function Install-IcingaComponent()
 
     Set-IcingaTLSVersion;
 
-    if ($Version -eq 'release') {
+    if ($Version.ToLower() -eq 'release' -Or $Version.ToLower() -eq 'latest') {
         $Version = $null;
     }
 

--- a/lib/core/repository/Update-Icinga.psm1
+++ b/lib/core/repository/Update-Icinga.psm1
@@ -2,7 +2,7 @@ function Update-Icinga()
 {
     param (
         [string]$Name     = $null,
-        [string]$Version  = $null,
+        [string]$Version  = 'release',
         [switch]$Release  = $FALSE,
         [switch]$Snapshot = $FALSE,
         [switch]$Confirm  = $FALSE,
@@ -26,7 +26,10 @@ function Update-Icinga()
         $NewVersion = $Component.LatestVersion;
 
         if ([string]::IsNullOrEmpty($Version) -eq $FALSE) {
-            $NewVersion = $Version;
+            # Ensure we are backwards compatible with Icinga for Windows v1.11.0 which broke the version update feature
+            if ($Version.ToLower() -ne 'release' -And $Version.ToLower() -ne 'latest') {
+                $NewVersion = $Version;
+            }
         }
 
         if ([string]::IsNullOrEmpty($NewVersion)) {


### PR DESCRIPTION
Ensures the backwards compatibility with Icinga for Windows v1.11.0, which broke the update mechanism for version checks.