### PR TITLE
Fix: Null value exceptions on checks with units

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -19,6 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 * [#673](https://github.com/Icinga/icinga-powershell-framework/pull/673) Fixes a memory leak while fetching Windows EventLog information by using CLI tools and inside the Hyper-V provide
 * [#678](https://github.com/Icinga/icinga-powershell-framework/pull/678) Fixes various memory leaks in Icinga for Windows API core and check handler
+* [#680](https://github.com/Icinga/icinga-powershell-framework/pull/680) Fixes exception in some cases, when provider or metrics return values as `null` instead of `0` while units are being used for check objects
 
 ## 1.11.1 (2023-11-07)
 

--- a/lib/icinga/plugin/New-IcingaCheck.psm1
+++ b/lib/icinga/plugin/New-IcingaCheck.psm1
@@ -21,7 +21,13 @@ function New-IcingaCheck()
     $IcingaCheck.Name         = $Name;
     $IcingaCheck.__ObjectType = 'IcingaCheck';
 
-    $IcingaCheck | Add-Member -MemberType NoteProperty -Name 'Value'             -Value $Value;
+    # Ensure we always set our current value to 0 in case it is null and we set a unit, to prevent conversion exceptions
+    if ([string]::IsNullOrEmpty($Unit) -eq $FALSE -And $null -eq $Value) {
+        $IcingaCheck | Add-Member -MemberType NoteProperty -Name 'Value' -Value 0;
+    } else {
+        $IcingaCheck | Add-Member -MemberType NoteProperty -Name 'Value' -Value $Value;
+    }
+
     $IcingaCheck | Add-Member -MemberType NoteProperty -Name 'BaseValue'         -Value $BaseValue;
     $IcingaCheck | Add-Member -MemberType NoteProperty -Name 'Unit'              -Value $Unit;
     $IcingaCheck | Add-Member -MemberType NoteProperty -Name 'MetricIndex'       -Value $MetricIndex;


### PR DESCRIPTION
Fixes exception in some cases, when provider or metrics return values as `null` instead of `0` while units are being used for check objects.

This affects the Process plugin as one example