### PR TITLE
Fix: Icinga CA port handling on installation

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -16,6 +16,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#683](https://github.com/Icinga/icinga-powershell-framework/pull/683) Fixes JEA installer to exclude domain from user name length check, which can easily exceed the Windows 20 digits username limit
 * [#685](https://github.com/Icinga/icinga-powershell-framework/pull/685) Fixes an issue while trying to stop the JEA process in certain cases, which results in an error during installation but has no other effect on the environment
 * [#686](https://github.com/Icinga/icinga-powershell-framework/pull/686) Fixes certutil error handling and message output in case the icingaforwindows.pfx could not be created
+* [#687](https://github.com/Icinga/icinga-powershell-framework/pull/687) Fixes Icinga for Windows port handling on installation, which will now use the proper defined port for communicating with the Icinga CA
 
 ### Enhancements
 

--- a/lib/core/icingaagent/installer/Install-IcingaAgentCertificates.psm1
+++ b/lib/core/icingaagent/installer/Install-IcingaAgentCertificates.psm1
@@ -93,6 +93,15 @@ function Install-IcingaAgentCertificates()
     }
 
     if (-Not [string]::IsNullOrEmpty($Endpoint)) {
+
+        # In case we use a custom configuration for our CA endpoint server with address and port, ensure we establish
+        # a connection to this endpoint as well as the port
+        $ConnectionConfig = Get-IPConfigFromString -IPConfig $Endpoint;
+        $Endpoint         = $ConnectionConfig.address;
+        if ([string]::IsNullOrEmpty($ConnectionConfig.port) -eq $FALSE) {
+            $Port = $ConnectionConfig.port;
+        }
+
         if (-Not (Test-IcingaAgentCertificates -CertDirectory $CertificateDirectory -Hostname $Hostname -TestTrustedParent -Force $Force)) {
 
             Write-IcingaConsoleNotice ([string]::Format('Fetching trusted master certificate from "{0}"', $Endpoint));


### PR DESCRIPTION
Fixes Icinga for Windows port handling on installation, which will now use the proper defined port for communicating with the Icinga CA

Fixes #687