### PR TITLE
Feature: Renames "Restart-IcingaWindowsService" to "Restart-IcingaForWindows" and adds alias for backwards compatibility

### DIFF
--- a/doc/100-General/01-Upgrading.md
+++ b/doc/100-General/01-Upgrading.md
@@ -28,7 +28,7 @@ Import-Module icinga-powershell-framework -Force;
 Import-Module icinga-powershell-framework -Global -Force;
 
 # Restart the Icinga for Windows service in case installed, to ensure the functionality
-Restart-IcingaWindowsService;
+Restart-IcingaForWindows;
 
 # Add your own update procedure code
 ```

--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -26,6 +26,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#679](https://github.com/Icinga/icinga-powershell-framework/pull/679) Adds a new data provider for fetching process information of Windows systems, while sorting all objects based on a process name and their process id
 * [#688](https://github.com/Icinga/icinga-powershell-framework/pull/688) Adds new handling to add scheduled tasks in Windows for interacting with Icinga for Windows core functionality as well as an auto renewal task for the Icinga for Windows certificate generation
 * [#690](https://github.com/Icinga/icinga-powershell-framework/pull/690) Adds automatic renewal of the `icingaforwindows.pfx` certificate for the REST-Api daemon in case the certificate is not yet present, valid or changed during the runtime of the daemon while also making the `icingaforwindows.pfx` mandatory for all installations, regardless of JEA being used or not
+* [#692](https://github.com/Icinga/icinga-powershell-framework/pull/692) Renames `Restart-IcingaWindowsService` to `Restart-IcingaForWindows` and adds alias for backwards compatibility to start unifying the Icinga for Windows cmdlets
 
 ## 1.11.2 (tbd)
 

--- a/doc/100-General/20-Eventlog.md
+++ b/doc/100-General/20-Eventlog.md
@@ -84,7 +84,7 @@ Below you will find a list of EventId's which are exported by this module. The s
 
 | Category | Short Message | Detailed Message |
 | --- | --- | --- |
-| Error | Unable to start Icinga for Windows service | Unable to start Icinga for Windows service, as the JEA session created by the service is still active. Run "Restart-IcingaWindowsService" to restart the Icinga for Windows service, while running in JEA context to prevent this issue. |
+| Error | Unable to start Icinga for Windows service | Unable to start Icinga for Windows service, as the JEA session created by the service is still active. Run "Restart-IcingaForWindows" to restart the Icinga for Windows service, while running in JEA context to prevent this issue. |
 
 ## Event Id 1504
 

--- a/doc/110-Installation/05-Background-Daemons.md
+++ b/doc/110-Installation/05-Background-Daemons.md
@@ -77,5 +77,5 @@ No arguments defined
 In order to apply any changes on background daemons, you will always to restart the Icinga for Windows PowerShell service. You can do so with the following command:
 
 ```powershell
-Restart-IcingaWindowsService;
+Restart-IcingaForWindows;
 ```

--- a/doc/110-Installation/06-Collect-Metrics-over-Time.md
+++ b/doc/110-Installation/06-Collect-Metrics-over-Time.md
@@ -122,5 +122,5 @@ Unregister-IcingaServiceCheck -ServiceId 133219181168290951798237215145107197204
 Finally to apply all your changes, we have to restart the Icinga for Windows Powershell Daemon
 
 ```powershell
-Restart-IcingaWindowsService;
+Restart-IcingaForWindows;
 ```

--- a/doc/110-Installation/30-API-Check-Forwarder.md
+++ b/doc/110-Installation/30-API-Check-Forwarder.md
@@ -75,7 +75,7 @@ Enable-IcingaFrameworkApiChecks;
 Last but not least restart the Icinga for Windows service:
 
 ```powershell
-Restart-IcingaWindowsService;
+Restart-IcingaForWindows;
 ```
 
 As long as the feature is enabled, the Icinga for Windows service is running and the REST-Api daemon is registered, checks will be forwarded to the REST-Api and executed, if whitelisted.
@@ -98,7 +98,7 @@ For quick installation, here the list of commands to get everything running:
 Register-IcingaBackgroundDaemon -Command 'Start-IcingaWindowsRESTApi';
 Add-IcingaRESTApiCommand -Command 'Invoke-IcingaCheck*' -Endpoint 'apichecks';
 
-Restart-IcingaWindowsService;
+Restart-IcingaForWindows;
 
 Enable-IcingaFrameworkApiChecks;
 ```

--- a/doc/900-Developer-Guide/10-Custom-Daemons.md
+++ b/doc/900-Developer-Guide/10-Custom-Daemons.md
@@ -301,7 +301,7 @@ Register-IcingaBackgroundDaemon -Command 'Start-IcingaAgentServiceTest';
 Once registered, you will have to restart the PowerShell service itself to apply the changes
 
 ```powershell
-Restart-IcingaWindowsService;
+Restart-IcingaForWindows;
 ```
 
 Thats it! Now the daemon is loaded with every start, checking for the Agent state and restart it if it is not running.

--- a/doc/900-Developer-Guide/12-Custom-API-Endpoints.md
+++ b/doc/900-Developer-Guide/12-Custom-API-Endpoints.md
@@ -237,7 +237,7 @@ If our module is providing different endpoints, you will have to create multiple
 As everything is now ready, we can restart our Icinga PowerShell Framework service by using
 
 ```powershell
-Restart-IcingaWindowsService;
+Restart-IcingaForWindows;
 ```
 
 and access our API endpoint by browsing to our API location (in our example we assume you use `5668` as default port):

--- a/doc/knowledgebase/IWKB000005.md
+++ b/doc/knowledgebase/IWKB000005.md
@@ -83,7 +83,7 @@ Now open a new PowerShell session again and check of the new directory was added
 Once the directory is there, restart the `icingapowershell` service by running
 
 ```powershell
-Restart-IcingaWindowsService;
+Restart-IcingaForWindows;
 ```
 
 Now the error should be resolved the the service should be running.
@@ -119,7 +119,7 @@ Now open a new PowerShell session again and check of the new directory was added
 Once the directory is there, restart the `icingapowershell` service by running
 
 ```powershell
-Restart-IcingaWindowsService;
+Restart-IcingaForWindows;
 ```
 
 Now the error should be resolved the the service should be running.

--- a/doc/knowledgebase/IWKB000014.md
+++ b/doc/knowledgebase/IWKB000014.md
@@ -36,7 +36,7 @@ Import-Module -Name 'icinga-powershell-framework' -Global -Force;
 
 icinga { Write-Host 'Icinga for Windows successfully repaired' };
 
-Restart-IcingaWindowsService;
+Restart-IcingaForWindows;
 ```
 
 Once executed, Icinga for Windows should rebuild the cache and work again as intended. Please keep the `icinga` call within the example, as this will ensure that possible pending migrations of Icinga for Windows will be applied.

--- a/lib/core/framework/Install-IcingaForWindowsService.psm1
+++ b/lib/core/framework/Install-IcingaForWindowsService.psm1
@@ -87,7 +87,7 @@ function Install-IcingaForWindowsService()
     # will not start without this workaround.
     # Todo: Figure out the reason and fix it properly
     Set-IcingaServiceUser -User 'LocalSystem' -Service 'icingapowershell' | Out-Null;
-    Restart-IcingaWindowsService;
+    Restart-IcingaForWindows;
     Start-Sleep -Seconds 1;
     Stop-IcingaWindowsService;
 

--- a/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
+++ b/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
@@ -75,7 +75,7 @@ function Invoke-IcingaForWindowsMigration()
         Set-IcingaForWindowsMigration -MigrationVersion (New-IcingaVersionObject -Version '1.10.0');
 
         if ($ServiceStatus -eq 'Running') {
-            Restart-IcingaWindowsService -Service 'icingapowershell';
+            Restart-IcingaForWindows;
         }
     }
 

--- a/lib/core/icingaagent/misc/Start-IcingaAgentInstallWizard.psm1
+++ b/lib/core/icingaagent/misc/Start-IcingaAgentInstallWizard.psm1
@@ -752,7 +752,7 @@ function Start-IcingaAgentInstallWizard()
             }
             Test-IcingaAgent;
             if ($InstallFrameworkService) {
-                Restart-IcingaWindowsService;
+                Restart-IcingaForWindows;
             }
             Restart-IcingaService 'icinga2';
         }

--- a/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
+++ b/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
@@ -260,7 +260,7 @@ function Start-IcingaForWindowsInstallation()
     }
 
     if ($InstallService) {
-        Restart-IcingaWindowsService;
+        Restart-IcingaForWindows;
     }
 
     switch ($InstallApiChecks) {
@@ -274,7 +274,7 @@ function Start-IcingaForWindowsInstallation()
             Enable-IcingaFrameworkApiChecks;
             $InstallRESTApi = $TRUE;
             if ($InstallService) {
-                Restart-IcingaWindowsService;
+                Restart-IcingaForWindows;
             } else {
                 Write-IcingaConsoleWarning -Message 'You have selected to install the Api-Check feature and all required configurations were made. The Icinga for Windows service is however not marked for installation, which will cause this feature to not work.';
             }
@@ -314,7 +314,7 @@ function Start-IcingaForWindowsInstallation()
 
     # Always install the Icinga for Windows certificate
     Install-IcingaForWindowsCertificate;
-    Restart-IcingaWindowsService;
+    Restart-IcingaForWindows;
 
     # Update configuration and clear swap
     $ConfigSwap = Get-IcingaPowerShellConfig -Path 'Framework.Config.Swap';

--- a/lib/core/installer/menu/manage/framework/ToogleFrameworkApiChecks.psm1
+++ b/lib/core/installer/menu/manage/framework/ToogleFrameworkApiChecks.psm1
@@ -12,5 +12,5 @@ function Invoke-IcingaForWindowsManagementConsoleToggleFrameworkApiChecks()
         Enable-IcingaFrameworkApiChecks;
     }
 
-    Restart-IcingaWindowsService;
+    Restart-IcingaForWindows;
 }

--- a/lib/core/installer/menu/manage/settings/services/ManageServices.psm1
+++ b/lib/core/installer/menu/manage/settings/services/ManageServices.psm1
@@ -94,7 +94,7 @@ function Show-IcingaForWindowsMenuManageIcingaForWindowsServices()
                 'DisabledReason' = 'The Icinga for Windows service is not installed';
                 'AdminMenu'      = $TRUE;
                 'Action'         = @{
-                    'Command' = 'Restart-IcingaWindowsService';
+                    'Command' = 'Restart-IcingaForWindows';
                 }
             },
             @{

--- a/lib/core/logging/Icinga_EventLog_Enums.psm1
+++ b/lib/core/logging/Icinga_EventLog_Enums.psm1
@@ -95,7 +95,7 @@ if ($null -eq $IcingaEventLogEnums -Or $IcingaEventLogEnums.ContainsKey('Framewo
             1503 = @{
                 'EntryType' = 'Error';
                 'Message'   = 'Unable to start Icinga for Windows service';
-                'Details'   = 'Unable to start Icinga for Windows service, as the JEA session created by the service is still active. Run "Restart-IcingaWindowsService" to restart the Icinga for Windows service, while running in JEA context to prevent this issue.';
+                'Details'   = 'Unable to start Icinga for Windows service, as the JEA session created by the service is still active. Run "Restart-IcingaForWindows" to restart the Icinga for Windows service, while running in JEA context to prevent this issue.';
                 'EventId'   = 1503;
             };
             1504 = @{

--- a/lib/core/repository/Update-Icinga.psm1
+++ b/lib/core/repository/Update-Icinga.psm1
@@ -58,6 +58,6 @@ function Update-Icinga()
     # Update JEA profile if JEA is enabled once the update is complete
     if ([string]::IsNullOrEmpty((Get-IcingaJEAContext)) -eq $FALSE -And $UpdateJEA) {
         Update-IcingaJEAProfile;
-        Restart-IcingaWindowsService;
+        Restart-IcingaForWindows;
     }
 }

--- a/lib/core/windows/Install-IcingaSecurity.psm1
+++ b/lib/core/windows/Install-IcingaSecurity.psm1
@@ -29,5 +29,5 @@ function Install-IcingaSecurity()
     Install-IcingaServiceUser -IcingaUser $IcingaUser;
     Install-IcingaJEAProfile -IcingaUser $IcingaUser -RebuildFramework:$RebuildFramework -AllowScriptBlocks:$AllowScriptBlocks -ConstrainedLanguage:$ConstrainedLanguage;
 
-    Restart-IcingaWindowsService;
+    Restart-IcingaForWindows;
 }

--- a/lib/core/windows/Install-IcingaServiceUser.psm1
+++ b/lib/core/windows/Install-IcingaServiceUser.psm1
@@ -25,7 +25,7 @@ function Install-IcingaServiceUser()
     Set-IcingaUserPermissions -IcingaUser $IcingaUser;
 
     Restart-IcingaService 'icinga2';
-    Restart-IcingaWindowsService;
+    Restart-IcingaForWindows;
 
     Clear-IcingaWindowsUserPassword;
 

--- a/lib/core/windows/Restart-IcingaWindowsService.psm1
+++ b/lib/core/windows/Restart-IcingaWindowsService.psm1
@@ -1,4 +1,4 @@
-function Restart-IcingaWindowsService()
+function Restart-IcingaForWindows()
 {
     [string]$JeaPid = Get-IcingaJEAServicePid;
 
@@ -10,3 +10,5 @@ function Restart-IcingaWindowsService()
 
     Restart-IcingaService -Service 'icingapowershell';
 }
+
+Set-Alias -Name 'Restart-IcingaWindowsService' -Value 'Restart-IcingaForWindows';

--- a/lib/core/windows/Uninstall-IcingaServiceUser.psm1
+++ b/lib/core/windows/Uninstall-IcingaServiceUser.psm1
@@ -28,7 +28,7 @@ function Uninstall-IcingaServiceUser()
     }
 
     Restart-IcingaService 'icinga2';
-    Restart-IcingaWindowsService;
+    Restart-IcingaForWindows;
 
     Write-IcingaConsoleNotice 'User "{0}" including permissions was removed from this host' -Objects $IcingaUser;
 }

--- a/lib/core/windows/Update-IcingaServiceUser.psm1
+++ b/lib/core/windows/Update-IcingaServiceUser.psm1
@@ -17,5 +17,5 @@ function Update-IcingaServiceUser()
     Set-IcingaServiceUser -User $IcingaUser -Password $Global:Icinga.ServiceUserPassword -Service 'icingapowershell' | Out-Null;
 
     Restart-IcingaService 'icinga2';
-    Restart-IcingaWindowsService;
+    Restart-IcingaForWindows;
 }

--- a/lib/core/wintasks/Invoke-IcingaWindowsScheduledTask.psm1
+++ b/lib/core/wintasks/Invoke-IcingaWindowsScheduledTask.psm1
@@ -68,7 +68,7 @@ function Invoke-IcingaWindowsScheduledTask()
             }
         };
         'InstallJEA' {
-            $WinAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format('-Command &{{ Use-Icinga -Minimal; Install-IcingaJEAProfile; Restart-IcingaWindowsService; }}', "'", $TmpFile.FullName, $FilePath))
+            $WinAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format('-Command &{{ Use-Icinga -Minimal; Install-IcingaJEAProfile; Restart-IcingaForWindows; }}', "'", $TmpFile.FullName, $FilePath))
             Register-ScheduledTask -TaskName $TaskName -Action $WinAction -RunLevel Highest -TaskPath $TaskPath | Out-Null;
             Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath;
 


### PR DESCRIPTION
Renames `Restart-IcingaWindowsService` to `Restart-IcingaForWindows` and adds alias for backwards compatibility to start unifying the Icinga for Windows cmdlets