### PR TITLE
Fix: Icinga Director Self-Service API is ignoring service user

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -20,6 +20,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#685](https://github.com/Icinga/icinga-powershell-framework/pull/685) Fixes an issue while trying to stop the JEA process in certain cases, which results in an error during installation but has no other effect on the environment
 * [#686](https://github.com/Icinga/icinga-powershell-framework/pull/686) Fixes certutil error handling and message output in case the icingaforwindows.pfx could not be created
 * [#687](https://github.com/Icinga/icinga-powershell-framework/pull/687) Fixes Icinga for Windows port handling on installation, which will now use the proper defined port for communicating with the Icinga CA
+* [#702](https://github.com/Icinga/icinga-powershell-framework/pull/702) Fixes an issue with Icinga Director Self-Service API, which ignored the defined service user
 
 ### Enhancements
 

--- a/lib/core/installer/menu/installation/director/DirectorTemplate.psm1
+++ b/lib/core/installer/menu/installation/director/DirectorTemplate.psm1
@@ -117,6 +117,10 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
     $Ticket                   = '';
     $DirectorHostRegister     = (Get-IcingaForWindowsInstallerStepSelection -InstallerStep 'Show-IcingaForWindowsManagementConsoleInstallationDirectorRegisterHost');
 
+    if ([string]::IsNullOrEmpty($ServiceUserName)) {
+        $ServiceUserName = 'NT Authority\NetworkService';
+    }
+
     if ($null -eq $DirectorHostRegister) {
         $DirectorHostRegister = 0;
     }
@@ -245,6 +249,7 @@ function Resolve-IcingaForWindowsManagementConsoleInstallationDirectorTemplate()
     }
 
     Show-IcingaForWindowsInstallationMenuEnterIcingaCAServer -Automated -Value $MasterAddress;
+    Show-IcingaForWindowsInstallationMenuEnterIcingaAgentUser -Automated -Value $ServiceUserName;
 
     Show-IcingaForWindowsInstallerMenuSelectCertificate -Automated -DefaultInput '1';
     Show-IcingaForWindowsInstallerMenuEnterIcingaTicket -Automated -Value $Ticket;


### PR DESCRIPTION
Fixes an issue with Icinga Director Self-Service API, which ignored the defined service user and didn't apply it to the configuration