### PR TITLE
Fix: Icinga for Windows API should properly read network streams even for slow clients

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -17,6 +17,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#672](https://github.com/Icinga/icinga-powershell-framework/pull/issues) Fixes Icinga for Windows REST-Api to fully read client data, even when they client is sending the packets on a very slow basis, preventing the API trying to process an incomplete request
 * [#707](https://github.com/Icinga/icinga-powershell-framework/pull/707) Fixes size of the `Icinga for Windows` eventlog by setting it to `20MiB`, allowing to store more events before they are overwritten
 * [#710](https://github.com/Icinga/icinga-powershell-framework/pull/710) Fixes various console errors while running Icinga for Windows outside of an administrative shell
 * [#713](https://github.com/Icinga/icinga-powershell-framework/pull/713) Fixes Icinga for Windows REST-Api which fails during certificate auth handling while running as `NT Authority\NetworkService`

--- a/lib/daemon/Set-IcingaForWindowsThreadAlive.psm1
+++ b/lib/daemon/Set-IcingaForWindowsThreadAlive.psm1
@@ -6,7 +6,8 @@ function Set-IcingaForWindowsThreadAlive()
         $ThreadPool                 = $null,
         [hashtable]$ThreadArgs      = @{ },
         [switch]$Active             = $FALSE,
-        [hashtable]$TerminateAction = @{ }
+        [hashtable]$TerminateAction = @{ },
+        [int]$Timeout               = 300
     );
 
     if ([string]::IsNullOrEmpty($ThreadName)) {
@@ -27,6 +28,7 @@ function Set-IcingaForWindowsThreadAlive()
                 'ThreadPool'      = $ThreadPool;
                 'Active'          = [bool]$Active;
                 'TerminateAction' = $TerminateAction;
+                'Timeout'         = $Timeout;
             }
         );
 
@@ -36,4 +38,5 @@ function Set-IcingaForWindowsThreadAlive()
     $Global:Icinga.Public.ThreadAliveHousekeeping[$ThreadName].LastSeen        = [DateTime]::Now;
     $Global:Icinga.Public.ThreadAliveHousekeeping[$ThreadName].Active          = [bool]$Active;
     $Global:Icinga.Public.ThreadAliveHousekeeping[$ThreadName].TerminateAction = $TerminateAction;
+    $Global:Icinga.Public.ThreadAliveHousekeeping[$ThreadName].Timeout         = $Timeout;
 }

--- a/lib/daemon/Suspend-IcingaForWindowsFrozenThreads.psm1
+++ b/lib/daemon/Suspend-IcingaForWindowsFrozenThreads.psm1
@@ -12,7 +12,7 @@ function Suspend-IcingaForWindowsFrozenThreads()
             }
 
             # Check if the thread is active and not doing something for 5 minutes
-            if (([DateTime]::Now - $ThreadConfig.LastSeen).TotalSeconds -lt 300) {
+            if (([DateTime]::Now - $ThreadConfig.LastSeen).TotalSeconds -lt $ThreadConfig.Timeout) {
                 continue;
             }
 

--- a/lib/daemons/RestAPI/daemon/New-IcingaForWindowsRESTApi.psm1
+++ b/lib/daemons/RestAPI/daemon/New-IcingaForWindowsRESTApi.psm1
@@ -125,6 +125,8 @@ function New-IcingaForWindowsRESTApi()
         try {
             $NextRESTApiThreadId = (Get-IcingaNextRESTApiThreadId);
 
+            Write-IcingaDebugMessage -Message 'Scheduling Icinga for Windows API request' -Objects 'REST-Thread Id', $NextRESTApiThreadId;
+
             if ($Global:Icinga.Public.Daemons.RESTApi.ApiRequests.ContainsKey($NextRESTApiThreadId) -eq $FALSE) {
                 Close-IcingaTCPConnection -Connection $Connection;
                 $Connection = $null;

--- a/lib/daemons/RestAPI/threads/Get-IcingaNextRESTApiThreadId.psm1
+++ b/lib/daemons/RestAPI/threads/Get-IcingaNextRESTApiThreadId.psm1
@@ -3,6 +3,8 @@ function Get-IcingaNextRESTApiThreadId()
     # Improve our thread management by distributing new REST requests to a non-active thread
     [array]$ConfiguredThreads = $Global:Icinga.Public.ThreadAliveHousekeeping.Keys;
 
+    Write-IcingaDebugMessage -Message 'Distributing Icinga for Windows REST-Api calls to one of those threads' -Objects 'REST-Thread Ids', ($ConfiguredThreads | Out-String);
+
     foreach ($thread in $ConfiguredThreads) {
         if ($thread.ToLower() -NotLike 'Start-IcingaForWindowsRESTThread::New-IcingaForWindowsRESTThread::CheckThread::*') {
             continue;

--- a/lib/daemons/ServiceCheckDaemon/daemon/Add-IcingaServiceCheckDaemon.psm1
+++ b/lib/daemons/ServiceCheckDaemon/daemon/Add-IcingaServiceCheckDaemon.psm1
@@ -17,7 +17,7 @@ function Add-IcingaServiceCheckDaemon()
         $RegisteredServices = Get-IcingaRegisteredServiceChecks;
 
         # Debugging message
-        Write-IcingaDebugMessage 'Found these service checks to load within service check daemon: {0}' -Objects ($RegisteredServices.Keys | Out-String);
+        Write-IcingaDebugMessage 'Found these service checks to load within service check daemon' -Objects ($RegisteredServices.Keys | Out-String);
 
         # Loop all found background services and create a new thread for each check
         foreach ($service in $RegisteredServices.Keys) {

--- a/lib/webserver/Icinga_HTTPResponse_Enums.psm1
+++ b/lib/webserver/Icinga_HTTPResponse_Enums.psm1
@@ -10,6 +10,7 @@
     403 = 'Forbidden';
     404 = 'Not Found'
     500 = 'Internal Server Error';
+    504 = 'Gateway Timeout';
 };
 
 [hashtable]$HTTPResponseType = @{
@@ -19,6 +20,7 @@
     'Forbidden'             = 403;
     'Not Found'             = 404;
     'Internal Server Error' = 500;
+    'Gateway Timeout'       = 504;
 };
 
 <#

--- a/lib/webserver/Read-IcingaTCPStream.psm1
+++ b/lib/webserver/Read-IcingaTCPStream.psm1
@@ -6,19 +6,118 @@ function Read-IcingaTCPStream()
         [int]$ReadLength                       = 0
     );
 
+    [bool]$UnknownMessageSize = $FALSE;
+    [int]$TimeoutInSeconds    = 5;
+
     if ($ReadLength -eq 0) {
-        $ReadLength = $Client.ReceiveBufferSize;
+        $ReadLength         = $Client.ReceiveBufferSize;
+        $UnknownMessageSize = $TRUE;
     }
 
     if ($null -eq $Stream) {
         return $null;
     }
 
+    # Ensure that our stream will timeout after a while to not block
+    # the API permanently
+    $Stream.ReadTimeout    = $TimeoutInSeconds * 1000;
     # Get the maxium size of our buffer
-    [byte[]]$bytes   = New-Object byte[] $ReadLength;
-    # Read the content of our SSL stream
-    $MessageSize     = $Stream.Read($bytes, 0, $ReadLength);
-    # Resize our array to the correct size
+    [int]$MessageSize      = 0;
+    [byte[]]$bytes         = New-Object byte[] $ReadLength;
+    [int]$DebugReadLength  = $ReadLength;
+    [int]$EmptyStreamCount = 0;
+    # Ensure we calculate our own timeouts for the API, in case some malicious actions take place
+    # and we only receive one byte each second for a large message. We should terminate the request
+    # in this case
+    $ReadTimeout           = [DateTime]::Now;
+
+    while ($ReadLength -ne 0) {
+        # Create a buffer element to store our message size into
+        [byte[]]$buffer = New-Object byte[] $ReadLength;
+        # Read the content of our SSL stream
+        $ReadBytes      = $Stream.Read($buffer, 0, $ReadLength);
+        # Now lets copy all read bytes from our buffer to our bytes variable
+        # As we might read multiple times from our stream, we have to read
+        # the entire buffer from index 0 and copy our content to our bytes
+        # variable, while our starting index is always at the last message
+        # sizes end (Message size equals ReadBytes from the previous attempt)
+        # and we need to copy as much bytes to our new array, as we read
+        [array]::Copy($buffer, 0, $bytes, $MessageSize, $ReadBytes);
+
+        $ReadLength  -= $ReadBytes;
+        $MessageSize += $ReadBytes;
+
+        # In case the client terminates the session, we might receive a bunch of invalid
+        # information. Just to make sure there is no other error happening,
+        # we should wait a little to check if the client is still present and
+        # trying to send data
+        if ($ReadBytes -eq 0) {
+            $EmptyStreamCount += 1;
+            Start-Sleep -Milliseconds 100;
+        }
+
+        if ($EmptyStreamCount -gt 20) {
+            # This would mean we waited 2 seconds to receive actual data, the client decide not to do anything
+            # We should terminate this session
+
+            Send-IcingaTCPClientMessage -Message (
+                New-IcingaTCPClientRESTMessage `
+                    -HTTPResponse ($IcingaHTTPEnums.HTTPResponseType.'Internal Server Error') `
+                    -ContentBody @{ 'message' = 'The Icinga for Windows API received no data while reading the TCP stream. The session was terminated to protect the API.' }
+            ) -Stream $Stream;
+
+            Close-IcingaTCPConnection -Connection @{ 'Client' = $Client; 'Stream' = $Stream; };
+
+            Write-IcingaDebugMessage `
+                -Message 'Icinga for Windows API received multiple empty results and attempts from the client. Terminating session.' `
+                -Objects $DebugReadLength, $ReadBytes, $ReadLength, $MessageSize;
+
+            # Return an empty JSON
+            return '{ }';
+        }
+
+        if ((([DateTime]::Now) - $ReadTimeout).TotalSeconds -gt $TimeoutInSeconds -And $ReadLength -ne 0) {
+            # This would mean we waited to long to receive the entire message
+            # We should terminate this session, in case we have't just completed the read
+            # of our message
+
+            Send-IcingaTCPClientMessage -Message (
+                New-IcingaTCPClientRESTMessage `
+                    -HTTPResponse ($IcingaHTTPEnums.HTTPResponseType.'Gateway Timeout') `
+                    -ContentBody @{ 'message' = 'The Icinga for Windows API waited too long to receive the entire message from the client. The session was terminated to protect the API.' }
+            ) -Stream $Stream;
+
+            Close-IcingaTCPConnection -Connection @{ 'Client' = $Client; 'Stream' = $Stream; };
+
+            Write-IcingaDebugMessage `
+                -Message 'Icinga for Windows API waited too long to receive the entire message from the client. Terminating session.' `
+                -Objects $DebugReadLength, $ReadBytes, $ReadLength, $MessageSize;
+
+            # Return an empty JSON
+            return '{ }';
+        }
+
+        # In case our client did not set a defined message size, we just take the default from the Client
+        # In most cases, the client will default to 65536 as network buffer for this and we should just
+        # pretend the message was send properly. In most cases, the important request will go through
+        # as this will only happen to the first message. Afterwards we can use the HTTP headers to read
+        # the actual content size of the message
+        if ($UnknownMessageSize) {
+            Write-IcingaDebugMessage `
+                -Message 'Message buffer for incoming network stream was 65536. Assuming we read all data' `
+                -Objects $DebugReadLength, $ReadBytes, $ReadLength, $MessageSize;
+
+            break;
+        }
+
+        # Just some debug context, allowing us to check what is going on with the API
+        Write-IcingaDebugMessage `
+            -Message 'Network stream output while parsing request. Request Size / Read Bytes / Remaining Size / Message Size' `
+            -Objects $DebugReadLength, $ReadBytes, $ReadLength, $MessageSize;
+    }
+
+    # Resize our array to the correct size, as we might have read
+    # 65536 bytes because of our client not sending the correct length
     [byte[]]$resized = New-Object byte[] $MessageSize;
     [array]::Copy($bytes, 0, $resized, 0, $MessageSize);
 


### PR DESCRIPTION
Fixes Icinga for Windows REST-Api to fully read client data, even when they client is sending the packets on a very slow basis, preventing the API trying to process an incomplete request

Fixes #672