### PR TITLE
Fix: Size of Icinga for Windows eventlog

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -11,6 +11,12 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/32)
 
+## 1.12.1 (tbd)
+
+### Bugfixes
+
+* [#707](https://github.com/Icinga/icinga-powershell-framework/pull/707) Fixes size of the `Icinga for Windows` eventlog by setting it to `20MiB`, allowing to store more events before they are overwritten
+
 ## 1.12.0 (2024-03-26)
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/28)

--- a/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
+++ b/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
@@ -100,4 +100,14 @@ function Invoke-IcingaForWindowsMigration()
 
         Set-IcingaForWindowsMigration -MigrationVersion (New-IcingaVersionObject -Version '1.12.0');
     }
+
+    if (Test-IcingaForWindowsMigration -MigrationVersion (New-IcingaVersionObject -Version '1.12.1')) {
+        Write-IcingaConsoleNotice 'Applying pending migrations required for Icinga for Windows v1.12.1';
+
+        # Fixes the size of the Icinga for Windows Eventlog, allowing more logs to be collected
+        # before older ones are faded out
+        Register-IcingaEventLog;
+
+        Set-IcingaForWindowsMigration -MigrationVersion (New-IcingaVersionObject -Version '1.12.1');
+    }
 }

--- a/lib/core/logging/Register-IcingaEventLog.psm1
+++ b/lib/core/logging/Register-IcingaEventLog.psm1
@@ -13,4 +13,9 @@ function Register-IcingaEventLog()
 
         New-EventLog -LogName 'Icinga for Windows' -Source $LogName -ErrorAction SilentlyContinue;
     }
+
+    $IfWEventLog = Get-WinEvent -ListLog 'Icinga for Windows';
+    # Set the size to 20MiB
+    $IfWEventLog.MaximumSizeInBytes = 20971520;
+    $IfWEventLog.SaveChanges();
 }


### PR DESCRIPTION
Fixes size of the `Icinga for Windows` eventlog by setting it to `20MiB`, allowing to store more events before they are overwritten