### PR TITLE
Fix: Errors for non-admin shells introduced with v1.12.0

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -16,6 +16,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Bugfixes
 
 * [#707](https://github.com/Icinga/icinga-powershell-framework/pull/707) Fixes size of the `Icinga for Windows` eventlog by setting it to `20MiB`, allowing to store more events before they are overwritten
+* [#710](https://github.com/Icinga/icinga-powershell-framework/pull/710) Fixes various console errors while running Icinga for Windows outside of an administrative shell
 
 ## 1.12.0 (2024-03-26)
 

--- a/lib/core/icingaagent/setters/Set-IcingaServiceEnvironment.psm1
+++ b/lib/core/icingaagent/setters/Set-IcingaServiceEnvironment.psm1
@@ -8,6 +8,11 @@ function Set-IcingaServiceEnvironment()
         return;
     }
 
+    # Don't do anything if we are not inside an administrative shell
+    if ((Test-AdministrativeShell) -eq $FALSE) {
+        return;
+    }
+
     # Use scheduled tasks to fetch our current service configuration for faster load times afterwards
     $IcingaService     = Invoke-IcingaWindowsScheduledTask -JobType GetWindowsService -ObjectName 'icinga2';
     $PowerShellService = Invoke-IcingaWindowsScheduledTask -JobType GetWindowsService -ObjectName 'icingapowershell';

--- a/lib/core/logging/Register-IcingaEventLog.psm1
+++ b/lib/core/logging/Register-IcingaEventLog.psm1
@@ -4,6 +4,10 @@ function Register-IcingaEventLog()
         [string]$LogName = $null
     );
 
+    if ((Test-AdministrativeShell) -eq $FALSE) {
+        return;
+    }
+
     if ([string]::IsNullOrEmpty($LogName)) {
         New-EventLog -LogName 'Icinga for Windows' -Source 'IfW::Framework' -ErrorAction SilentlyContinue;
         New-EventLog -LogName 'Icinga for Windows' -Source 'IfW::Service' -ErrorAction SilentlyContinue;
@@ -15,6 +19,12 @@ function Register-IcingaEventLog()
     }
 
     $IfWEventLog = Get-WinEvent -ListLog 'Icinga for Windows';
+
+    # In case the value is already set, nothing to do
+    if ($IfWEventLog.MaximumSizeInBytes -ge 20971520) {
+        return;
+    }
+
     # Set the size to 20MiB
     $IfWEventLog.MaximumSizeInBytes = 20971520;
     $IfWEventLog.SaveChanges();


### PR DESCRIPTION
Fixes various console errors while running Icinga for Windows outside of an administrative shell