### PR TITLE
Fix: Scheduled task user to use LocalSystem

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#707](https://github.com/Icinga/icinga-powershell-framework/pull/707) Fixes size of the `Icinga for Windows` eventlog by setting it to `20MiB`, allowing to store more events before they are overwritten
 * [#710](https://github.com/Icinga/icinga-powershell-framework/pull/710) Fixes various console errors while running Icinga for Windows outside of an administrative shell
 * [#714](https://github.com/Icinga/icinga-powershell-framework/pull/714) Fixes missing service environment information during initial setup of Icinga for Windows v1.12 on some systems
+* [#715](https://github.com/Icinga/icinga-powershell-framework/pull/715) Fixes internal scheduled task handling and certificate renewal task by setting the user to `LocalSystem` instead of any administrative user or group, ensuring compatibility with all Windows versions as well as managing by using WinRM and SSH
 
 ## 1.12.0 (2024-03-26)
 

--- a/lib/core/framework/Install-IcingaForWindowsService.psm1
+++ b/lib/core/framework/Install-IcingaForWindowsService.psm1
@@ -69,8 +69,9 @@ function Install-IcingaForWindowsService()
 
     if ($IfWService.Present -eq $FALSE) {
         $ServiceCreation = Start-IcingaProcess -Executable 'sc.exe' -Arguments ([string]::Format('create icingapowershell binPath= "{0}" DisplayName= "Icinga PowerShell Service" start= auto', $Path));
-        $Global:Icinga.Protected.Environment.'PowerShell Service'.Present = $TRUE;
-        $Global:Icinga.Protected.Environment.'PowerShell Service'.User    = $User;
+        $Global:Icinga.Protected.Environment.'PowerShell Service'.Present     = $TRUE;
+        $Global:Icinga.Protected.Environment.'PowerShell Service'.User        = $User;
+        $Global:Icinga.Protected.Environment.'PowerShell Service'.ServicePath = $Path;
 
         if ($ServiceCreation.ExitCode -ne 0) {
             throw ([string]::Format('Failed to install Icinga PowerShell Service: {0}{1}', $ServiceCreation.Message, $ServiceCreation.Error));
@@ -81,6 +82,8 @@ function Install-IcingaForWindowsService()
         if ($ServiceUpdate.ExitCode -ne 0) {
             throw ([string]::Format('Failed to update config for Icinga PowerShell Service: {0}{1}', $ServiceUpdate.Message, $ServiceUpdate.Error));
         }
+
+        $Global:Icinga.Protected.Environment.'PowerShell Service'.ServicePath = $Path;
     }
 
     # This is just a hotfix to ensure we setup the service properly before assigning it to

--- a/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
+++ b/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
@@ -108,6 +108,9 @@ function Invoke-IcingaForWindowsMigration()
         # before older ones are faded out
         Register-IcingaEventLog;
 
+        # Fixes user environment which is now set to LocalSystem, allowing configurations over WinRM and SSH
+        Register-IcingaWindowsScheduledTaskRenewCertificate -Force;
+
         Set-IcingaForWindowsMigration -MigrationVersion (New-IcingaVersionObject -Version '1.12.1');
     }
 }

--- a/lib/core/framework/Test-IcingaForWindowsService.psm1
+++ b/lib/core/framework/Test-IcingaForWindowsService.psm1
@@ -4,7 +4,7 @@ function Test-IcingaForWindowsService()
         [switch]$ResolveProblems = $FALSE
     );
 
-    Set-IcingaServiceEnvironment;
+    Set-IcingaServiceEnvironment -Force;
 
     $ServiceData   = Get-IcingaForWindowsServiceData;
     $ServiceConfig = $Global:Icinga.Protected.Environment.'PowerShell Service';

--- a/lib/core/wintasks/Invoke-IcingaWindowsScheduledTask.psm1
+++ b/lib/core/wintasks/Invoke-IcingaWindowsScheduledTask.psm1
@@ -37,7 +37,7 @@ function Invoke-IcingaWindowsScheduledTask()
         };
         'UninstallAgent' {
             $WinAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format('-WindowStyle Hidden -Command &{{ Use-Icinga -Minimal; Write-IcingaFileSecure -File {0}{1}{0} -Value (Start-IcingaProcess -Executable {0}MsiExec.exe{0} -Arguments {0}"{2}" /q{0} -FlushNewLines | ConvertTo-Json -Depth 100); }}', "'", $TmpFile.FullName, $FilePath, $TargetPath))
-            Register-ScheduledTask -TaskName $TaskName -Action $WinAction -RunLevel Highest -TaskPath $TaskPath | Out-Null;
+            Register-ScheduledTask -User 'System' -TaskName $TaskName -Action $WinAction -TaskPath $TaskPath | Out-Null;
 
             Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath;
 
@@ -69,7 +69,7 @@ function Invoke-IcingaWindowsScheduledTask()
         };
         'InstallJEA' {
             $WinAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format('-Command &{{ Use-Icinga -Minimal; Install-IcingaJEAProfile; Restart-IcingaForWindows; }}', "'", $TmpFile.FullName, $FilePath))
-            Register-ScheduledTask -TaskName $TaskName -Action $WinAction -RunLevel Highest -TaskPath $TaskPath | Out-Null;
+            Register-ScheduledTask -User 'System' -TaskName $TaskName -Action $WinAction -TaskPath $TaskPath | Out-Null;
             Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath;
 
             Wait-IcingaWindowsScheduledTask;

--- a/lib/core/wintasks/Invoke-IcingaWindowsServiceHandlerTask.psm1
+++ b/lib/core/wintasks/Invoke-IcingaWindowsServiceHandlerTask.psm1
@@ -21,7 +21,9 @@ function Invoke-IcingaWindowsServiceHandlerTask()
 
     $WinAction    = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format("-WindowStyle Hidden -Command &{{ & '{0}' -ServiceName '{1}' -TmpFilePath '{2}' }}", $ScriptPath, $ServiceName, $TmpFile));
     $TaskSettings = New-ScheduledTaskSettingsSet -DontStopIfGoingOnBatteries -AllowStartIfOnBatteries -StartWhenAvailable;
-    Register-ScheduledTask -TaskName $TaskName -Action $WinAction -RunLevel Highest -TaskPath $TaskPath -Settings $TaskSettings -Force | Out-Null;
+    # We need to schedule this task as LocalSystem to ensure we can fetch the information while connected over WinRM/SSH
+    # We require high admin privilleges anyway, therefor this shouldn't hurt
+    Register-ScheduledTask -User 'System' -TaskName $TaskName -Action $WinAction -TaskPath $TaskPath -Settings $TaskSettings -Force | Out-Null;
 
     Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath;
 

--- a/lib/core/wintasks/daemon/Register-TaskRenewCertificate.psm1
+++ b/lib/core/wintasks/daemon/Register-TaskRenewCertificate.psm1
@@ -17,10 +17,10 @@ function Register-IcingaWindowsScheduledTaskRenewCertificate()
     $ScriptPath    = Join-Path -Path (Get-IcingaFrameworkRootPath) -ChildPath '\jobs\RenewCertificate.ps1';
     $TaskTrigger   = New-ScheduledTaskTrigger -Daily -DaysInterval 1 -At '1am';
     $TaskAction    = New-ScheduledTaskAction -Execute 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -Argument ([string]::Format("-WindowStyle Hidden -Command &{{ & '{0}' }}", $ScriptPath));
-    $TaskPrincipal = New-ScheduledTaskPrincipal -GroupId 'S-1-5-32-544' -RunLevel 'Highest';
     $TaskSettings  = New-ScheduledTaskSettingsSet -DontStopIfGoingOnBatteries -AllowStartIfOnBatteries -StartWhenAvailable;
 
-    Register-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -Force -Principal $TaskPrincipal -Action $TaskAction -Trigger $TaskTrigger -Settings $TaskSettings | Out-Null;
+    # Set our user to execute the renewal script to LocalSystem, ensuring we have enough privilliges to create the certificate file and be able to use WinRM/SSH for service registering
+    Register-ScheduledTask -User 'System' -TaskName $TaskName -TaskPath $TaskPath -Force -Action $TaskAction -Trigger $TaskTrigger -Settings $TaskSettings | Out-Null;
 
     Write-IcingaConsoleNotice -Message 'The task "{0}" has been successfully registered at location "{1}".' -Objects $TaskName, $TaskPath;
 }


### PR DESCRIPTION
Fixes internal scheduled task handling and certificate renewal task by setting the user to `LocalSystem` instead of any administrative user or group, ensuring compatibility with all Windows versions as well as managing by using WinRM and SSH