### PR TITLE
Fix: icingaforwindows.pfx creation over WinRM and SSH

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -19,6 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#710](https://github.com/Icinga/icinga-powershell-framework/pull/710) Fixes various console errors while running Icinga for Windows outside of an administrative shell
 * [#714](https://github.com/Icinga/icinga-powershell-framework/pull/714) Fixes missing service environment information during initial setup of Icinga for Windows v1.12 on some systems
 * [#715](https://github.com/Icinga/icinga-powershell-framework/pull/715) Fixes internal scheduled task handling and certificate renewal task by setting the user to `LocalSystem` instead of any administrative user or group, ensuring compatibility with all Windows versions as well as managing by using WinRM and SSH
+* [#716](https://github.com/Icinga/icinga-powershell-framework/pull/716) Fixes Icinga for Windows certificate creation while using WinRM or SSH for remote connections
 
 ## 1.12.0 (2024-03-26)
 

--- a/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
+++ b/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
@@ -317,7 +317,8 @@ function Start-IcingaForWindowsInstallation()
     }
 
     # Always install the Icinga for Windows certificate
-    Install-IcingaForWindowsCertificate;
+    # We need to run the task renewal with our scheduled task to fix errors while using WinRM / SSH
+    Start-IcingaWindowsScheduledTaskRenewCertificate;
     Restart-IcingaForWindows;
 
     # Update configuration and clear swap

--- a/lib/core/installer/menu/manage/framework/ToogleFrameworkApiChecks.psm1
+++ b/lib/core/installer/menu/manage/framework/ToogleFrameworkApiChecks.psm1
@@ -8,7 +8,8 @@ function Invoke-IcingaForWindowsManagementConsoleToggleFrameworkApiChecks()
             Add-IcingaRESTApiCommand -Command 'Invoke-IcingaCheck*' -Endpoint 'apichecks';
         }
 
-        Install-IcingaForWindowsCertificate;
+        # We need to run the task renewal with our scheduled task to fix errors while using WinRM / SSH
+        Start-IcingaWindowsScheduledTaskRenewCertificate;
         Enable-IcingaFrameworkApiChecks;
     }
 

--- a/lib/core/installer/menu/manage/settings/troubleshooting/Troubleshooting.psm1
+++ b/lib/core/installer/menu/manage/settings/troubleshooting/Troubleshooting.psm1
@@ -37,7 +37,7 @@ function Show-IcingaForWindowsMenuManageTroubleshooting()
                     'Command'   = 'Show-IcingaWindowsManagementConsoleYesNoDialog';
                     'Arguments' = @{
                         '-Caption' = 'Install Icinga for Windows certificate';
-                        '-Command' = 'Install-IcingaForWindowsCertificate';
+                        '-Command' = 'Start-IcingaWindowsScheduledTaskRenewCertificate';
                     }
                 }
             },

--- a/lib/core/jea/Install-IcingaJeaProfile.psm1
+++ b/lib/core/jea/Install-IcingaJeaProfile.psm1
@@ -22,11 +22,12 @@ function Install-IcingaJEAProfile()
         return;
     }
 
-    Write-IcingaConsoleNotice 'Writing Icinga for Windows environment information as JEA profile'
+    Write-IcingaConsoleNotice 'Writing Icinga for Windows environment information as JEA profile';
     Write-IcingaJEAProfile -RebuildFramework:$RebuildFramework -AllowScriptBlocks:$AllowScriptBlocks;
-    Write-IcingaConsoleNotice 'Registering Icinga for Windows JEA profile'
+    Write-IcingaConsoleNotice 'Registering Icinga for Windows JEA profile';
     Register-IcingaJEAProfile -IcingaUser $IcingaUser -TestEnv:$TestEnv -ConstrainedLanguage:$ConstrainedLanguage;
-    Install-IcingaForWindowsCertificate;
+    # We need to run the task renewal with our scheduled task to fix errors while using WinRM / SSH
+    Start-IcingaWindowsScheduledTaskRenewCertificate;
 }
 
 Set-Alias -Name 'Update-IcingaJEAProfile' -Value 'Install-IcingaJEAProfile';


### PR DESCRIPTION
Fixes Icinga for Windows certificate creation while using WinRM or SSH for remote connections