### PR TITLE
Fix: Icinga for Windows certificate handling for all Windows environments

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -11,6 +11,14 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/32)
 
+## 1.12.2 (2024-04-10)
+
+[Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/34)
+
+### Bugfixes
+
+* [#719](https://github.com/Icinga/icinga-powershell-framework/pull/719) Fixes certificate handling for renewing certificates with the scheduled task background, which could fail on some Windows Server 2022 environments
+
 ## 1.12.1 (2024-04-09)
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/33)

--- a/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
+++ b/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
@@ -113,4 +113,19 @@ function Invoke-IcingaForWindowsMigration()
 
         Set-IcingaForWindowsMigration -MigrationVersion (New-IcingaVersionObject -Version '1.12.1');
     }
+
+    if (Test-IcingaForWindowsMigration -MigrationVersion (New-IcingaVersionObject -Version '1.12.2')) {
+        Write-IcingaConsoleNotice 'Applying pending migrations required for Icinga for Windows v1.12.2';
+
+        # Revokes certificate handling to run as local Administrators group with highest privileges instead of LocalSystem
+        Register-IcingaWindowsScheduledTaskRenewCertificate -Force;
+        Start-Sleep -Seconds 1;
+        # Enforce the certificate creation to update broken certificates
+        Start-IcingaWindowsScheduledTaskRenewCertificate;
+        # Restart the Icinga for Windows service
+        Start-Sleep -Seconds 2;
+        Restart-IcingaForWindows;
+
+        Set-IcingaForWindowsMigration -MigrationVersion (New-IcingaVersionObject -Version '1.12.2');
+    }
 }

--- a/lib/core/wintasks/daemon/Register-TaskRenewCertificate.psm1
+++ b/lib/core/wintasks/daemon/Register-TaskRenewCertificate.psm1
@@ -17,10 +17,10 @@ function Register-IcingaWindowsScheduledTaskRenewCertificate()
     $ScriptPath    = Join-Path -Path (Get-IcingaFrameworkRootPath) -ChildPath '\jobs\RenewCertificate.ps1';
     $TaskTrigger   = New-ScheduledTaskTrigger -Daily -DaysInterval 1 -At '1am';
     $TaskAction    = New-ScheduledTaskAction -Execute 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -Argument ([string]::Format("-WindowStyle Hidden -Command &{{ & '{0}' }}", $ScriptPath));
+    $TaskPrincipal = New-ScheduledTaskPrincipal -GroupId 'S-1-5-32-544' -RunLevel 'Highest';
     $TaskSettings  = New-ScheduledTaskSettingsSet -DontStopIfGoingOnBatteries -AllowStartIfOnBatteries -StartWhenAvailable;
 
-    # Set our user to execute the renewal script to LocalSystem, ensuring we have enough privilliges to create the certificate file and be able to use WinRM/SSH for service registering
-    Register-ScheduledTask -User 'System' -TaskName $TaskName -TaskPath $TaskPath -Force -Action $TaskAction -Trigger $TaskTrigger -Settings $TaskSettings | Out-Null;
+    Register-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -Force -Principal $TaskPrincipal -Action $TaskAction -Trigger $TaskTrigger -Settings $TaskSettings | Out-Null;
 
     Write-IcingaConsoleNotice -Message 'The task "{0}" has been successfully registered at location "{1}".' -Objects $TaskName, $TaskPath;
 }


### PR DESCRIPTION
Fixes certificate handling for renewing certificates with the scheduled task background, which could fail on some Windows Server 2022 environments