### PR TITLE
Fix: Update-Icinga to print an error in case a component is not installed

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#729](https://github.com/Icinga/icinga-powershell-framework/issues/729) Fixes `Update-Icinga` to print an error in case a component is not installed, instead of silently continue
 * [#734](https://github.com/Icinga/icinga-powershell-framework/issues/734) Fixes a scenario on which a JEA service could become orphaned while manually stopping the Icinga for Windows service, without gracefully shutting down JEA
 
 ### Enhancements

--- a/lib/core/repository/Update-Icinga.psm1
+++ b/lib/core/repository/Update-Icinga.psm1
@@ -16,6 +16,7 @@ function Update-Icinga()
     $CurrentInstallation   = Get-IcingaInstallation -Release:$Release -Snapshot:$Snapshot;
     [bool]$UpdateJEA       = $FALSE;
     [array]$ComponentsList = @();
+    [bool]$IsInstalled     = $FALSE;
 
     # We need to make sure that the framework is always installed first as component
     # to prevent possible race-conditions during update, in case we update plugins
@@ -43,6 +44,8 @@ function Update-Icinga()
         if ([string]::IsNullOrEmpty($Name) -eq $FALSE -And $Name -ne $entry) {
             continue;
         }
+
+        $IsInstalled = $TRUE;
 
         $NewVersion = $Component.LatestVersion;
 
@@ -74,6 +77,10 @@ function Update-Icinga()
         }
 
         Install-IcingaComponent -Name $entry -Version $NewVersion -Release:$Release -Snapshot:$Snapshot -Confirm:$Confirm -Force:$Force -KeepRepoErrors;
+    }
+
+    if ($IsInstalled -eq $FALSE) {
+        Write-IcingaConsoleError 'Failed to update the component "{0}", as it is not installed' -Objects $Name;
     }
 
     # Update JEA profile if JEA is enabled once the update is complete


### PR DESCRIPTION
Fixes `Update-Icinga` to print an error in case a component is not installed, instead of silently continue

Fixes #729