### PR TITLE
Properly detect OS arch (not current shell arch)

### DIFF
--- a/lib/core/icingaagent/getters/Get-IcingaAgentInstallation.psm1
+++ b/lib/core/icingaagent/getters/Get-IcingaAgentInstallation.psm1
@@ -1,12 +1,12 @@
 function Get-IcingaAgentInstallation()
 {
     [string]$architecture = '';
-    if ([IntPtr]::Size -eq 4) {
-        $architecture = "x86";
-        $regPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*';
-    } else {
+    if (Test-Path 'Env:ProgramFiles(x86)') {
         $architecture = "x86_64";
         $regPath = @('HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*', 'HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*');
+    } else {
+        $architecture = "x86";
+        $regPath = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*';
     }
 
     $RegistryData = Get-ItemProperty $regPath;

--- a/lib/core/repository/Get-IcingaRepositoryPackage.psm1
+++ b/lib/core/repository/Get-IcingaRepositoryPackage.psm1
@@ -33,7 +33,7 @@ function Get-IcingaRepositoryPackage()
     $SourceRepo             = $null;
     $RepoName               = $null;
     [bool]$HasRepo          = $FALSE;
-    [bool]$Isx86            = [bool]([IntPtr]::Size -eq 4);
+    [bool]$Isx86            = [bool](-not (Test-Path 'Env:ProgramFiles(x86)'));
 
     foreach ($entry in $Repositories) {
         $RepoContent        = Read-IcingaRepositoryFile -Name $entry.Name;


### PR DESCRIPTION
[IntPtr]::Size depends on the PS exe arch, but there's also an x86 one on x64. But Env:ProgramFiles(x86) is always defined on an x64 OS.

https://stackoverflow.com/a/61396489

fixes #705