### PR TITLE
REST API: in the Server header, identify the software, not the machine

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -16,6 +16,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#729](https://github.com/Icinga/icinga-powershell-framework/issues/729) Fixes `Update-Icinga` to print an error in case a component is not installed, instead of silently continue
 * [#734](https://github.com/Icinga/icinga-powershell-framework/issues/734) Fixes a scenario on which a JEA service could become orphaned while manually stopping the Icinga for Windows service, without gracefully shutting down JEA
 * [#735](https://github.com/Icinga/icinga-powershell-framework/pull/735) Fixes an issue with filter for EventLog events, which did not properly handle multiple event id includes, causing empty results
+* [#743](https://github.com/Icinga/icinga-powershell-framework/pull/743) In the REST API response header `Server`, tell the software version, not the machine name (RFC 9110)
 * [#745](https://github.com/Icinga/icinga-powershell-framework/pull/745) Fixes an issue for service provider with service names not interpreted correctly in case it contains `[]`
 
 ### Enhancements

--- a/lib/webserver/New-IcingaTCPClientRESTMessage.psm1
+++ b/lib/webserver/New-IcingaTCPClientRESTMessage.psm1
@@ -39,8 +39,8 @@ function New-IcingaTCPClientRESTMessage()
             (New-IcingaNewLine)
         ),
         [string]::Format(
-            'Server: {0}{1}',
-            (Get-IcingaHostname -LowerCase $TRUE -AutoUseFQDN $TRUE),
+            'Server: IcingaForWindows/{0}{1}',
+            (Get-Module -Name icinga-powershell-framework).Version,
             (New-IcingaNewLine)
         ),
         [string]::Format(


### PR DESCRIPTION
Rationale: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server

## Test

```
> GET /v1/checker?command=cpu HTTP/1.1
> Host: 10.27.0.147:5668
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 Ok
< Server: IcingaForWindows/1.12.3
< Content-Type: application/json
< Content-Length: 427
<
```