### PR TITLE
Feature: Adds cmdlet `Write-IcingaAgentEventLogConfig` to update eventlog severity and defaults to `warning`during installation and migration

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -19,6 +19,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Enhancements
 
+* [#711](https://github.com/Icinga/icinga-powershell-framework/issues/711) Adds cmdlet `Write-IcingaAgentEventLogConfig` to update eventlog severity and defaults to `warning` during installation and migration
 * [#732](https://github.com/Icinga/icinga-powershell-framework/pull/732) Adds support for TLS 1.3 and improves startup response
 * [#735](https://github.com/Icinga/icinga-powershell-framework/pull/735) Adds support to provide occuring problem event id's for the Eventlog and corresponding acknowledgement id's, providing an indicator if certain issues are resolved or still present
 * [#739](https://github.com/Icinga/icinga-powershell-framework/pull/739) Adds support to check the encoding of files to ensure we can properly load them and throw errors for unsupported encoding

--- a/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
+++ b/lib/core/framework/Invoke-IcingaForWindowsMigration.psm1
@@ -149,6 +149,8 @@ function Invoke-IcingaForWindowsMigration()
 
         # Updates certificate renew task to handle changes made which now stores the Icinga CA inside the cert store
         Start-IcingaWindowsScheduledTaskRenewCertificate;
+        # Ensure the Icinga Agent is not spamming the Application log by default
+        Write-IcingaAgentEventLogConfig -Severity 'warning';
 
         Set-IcingaForWindowsMigration -MigrationVersion (New-IcingaVersionObject -Version '1.13.0');
     }

--- a/lib/core/icingaagent/misc/Start-IcingaAgentInstallWizard.psm1
+++ b/lib/core/icingaagent/misc/Start-IcingaAgentInstallWizard.psm1
@@ -750,6 +750,8 @@ function Start-IcingaAgentInstallWizard()
                 # First cleanup the system by removing all old Firewalls
                 Enable-IcingaFirewall -IcingaPort $CAPort -Force;
             }
+            # Ensure the Icinga Agent is not spamming the Application log by default
+            Write-IcingaAgentEventLogConfig -Severity 'warning';
             Test-IcingaAgent;
             if ($InstallFrameworkService) {
                 Restart-IcingaForWindows;

--- a/lib/core/icingaagent/writers/Write-IcingaAgentEventLogConfig.psm1
+++ b/lib/core/icingaagent/writers/Write-IcingaAgentEventLogConfig.psm1
@@ -1,0 +1,38 @@
+<#
+.SYNOPSIS
+    Writes the Icinga Agent Event Log configuration.
+
+.DESCRIPTION
+    The Write-IcingaAgentEventLogConfig function is used to write the configuration for the Icinga Agent Event Log. It creates a configuration file with the specified severity level for the Windows Event Log Logger.
+
+.PARAMETER Severity
+    Specifies the severity level for the Windows Event Log Logger. Valid values are 'debug', 'notice', 'information', 'warning', and 'critical'. The default value is 'information'.
+
+.EXAMPLE
+    Write-IcingaAgentEventLogConfig -Severity 'warning'
+    This example writes the Icinga Agent Event Log configuration with the severity level set to 'warning'.
+
+.NOTES
+    Please make sure to restart the Icinga Agent after applying any changes to the configuration.
+#>
+
+function Write-IcingaAgentEventLogConfig()
+{
+    param (
+        [ValidateSet('debug', 'notice', 'information', 'warning', 'critical')]
+        [string]$Severity = 'information'
+    );
+
+    $EventLogConf = New-Object System.Text.StringBuilder;
+
+    $EventLogConf.AppendLine('/**') | Out-Null;
+    $EventLogConf.AppendLine(' * The WindowsEventLogLogger type writes log information to the Windows Event Log.') | Out-Null;
+    $EventLogConf.AppendLine(' */') | Out-Null;
+    $EventLogConf.AppendLine('') | Out-Null;
+    $EventLogConf.AppendLine('object WindowsEventLogLogger "windowseventlog" {') | Out-Null;
+    $EventLogConf.AppendLine([string]::Format('    severity = "{0}"', $Severity)) | Out-Null;
+    $EventLogConf.Append('}') | Out-Null;
+
+    Write-IcingaFileSecure -File (Join-Path -Path (Get-IcingaAgentConfigDirectory) -ChildPath 'features-available\windowseventlog.conf') -Value $EventLogConf.ToString();
+    Write-IcingaConsoleNotice 'Windows Eventlog configuration has been written successfully to use severity level: {0} - Please restart the Icinga Agent to apply this change' -Objects $Severity;
+}

--- a/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
+++ b/lib/core/installer/Start-IcingaForWindowsInstallation.psm1
@@ -203,6 +203,8 @@ function Start-IcingaForWindowsInstallation()
         Set-IcingaUserPermissions -IcingaUser $ServiceUser;
         Install-IcingaAgentBaseFeatures;
         Write-IcingaAgentApiConfig -Port $IcingaPort;
+        # Ensure the Icinga Agent is not spamming the Application log by default
+        Write-IcingaAgentEventLogConfig -Severity 'warning';
 
         # Fixes an issue with the local Icinga for Windows listen port and the defined ports for communicating with the Icinga Parent/CA Nodes
         # This will check if we provided a custom port for the endpoints and use this one instead of the configured listen port if Icinga for Windows


### PR DESCRIPTION
Adds cmdlet `Write-IcingaAgentEventLogConfig` to update eventlog severity and defaults to `warning`during installation and migration tasks while updating to Icinga for Windows v1.13.0

Fixes #711