### PR TITLE
Fix: Performance counter results sometimes reporting null instead of 0

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -22,6 +22,7 @@ This beta release has reworked the entire handling on how thresholds and the che
 * [#735](https://github.com/Icinga/icinga-powershell-framework/pull/735) Fixes an issue with filter for EventLog events, which did not properly handle multiple event id includes, causing empty results
 * [#743](https://github.com/Icinga/icinga-powershell-framework/pull/743) In the REST API response header `Server`, tell the software version, not the machine name (RFC 9110)
 * [#745](https://github.com/Icinga/icinga-powershell-framework/pull/745) Fixes an issue for service provider with service names not interpreted correctly in case it contains `[]`
+* [#746](https://github.com/Icinga/icinga-powershell-framework/issues/746) Fixes an issue with performance counters, sometimes reporting empty values instead of at least 0
 
 ### Enhancements
 

--- a/lib/icinga/plugin/New-IcingaCheck.psm1
+++ b/lib/icinga/plugin/New-IcingaCheck.psm1
@@ -198,7 +198,7 @@ function New-IcingaCheck()
 
         [string]$LabelName      = (Format-IcingaPerfDataLabel -PerfData $this.Name);
         [string]$MultiLabelName = (Format-IcingaPerfDataLabel -PerfData $this.Name -MultiOutput);
-        $value                  = ConvertTo-Integer -Value $this.__ThresholdObject.Value -NullAsEmpty;
+        $value                  = ConvertTo-Integer -Value $this.__ThresholdObject.Value;
         $warning                = '';
         $critical               = '';
 


### PR DESCRIPTION
Fixes an issue with performance counters, sometimes reporting empty values instead of at least 0

Fixes #746