### PR TITLE
Set maximum cache duration for service daemons to the right value

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -7,6 +7,12 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
+## 1.13.0 (2025-01-30)
+
+### Bugfixes
+
+* [#759](https://github.com/Icinga/icinga-powershell-framework/pull/759) Fixes maximum cache duration for service daemons to the right value
+
 ## 1.13.0 Beta-2 (2024-09-19)
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/36)

--- a/lib/daemons/ServiceCheckDaemon/tools/New-IcingaServiceCheckDaemonEnvironment.psm1
+++ b/lib/daemons/ServiceCheckDaemon/tools/New-IcingaServiceCheckDaemonEnvironment.psm1
@@ -47,7 +47,7 @@ function New-IcingaServiceCheckDaemonEnvironment()
         }
     }
 
-    $Global:Icinga.Private.Daemons.ServiceCheck.MaxTimeInSeconds = $Global:Icinga.Private.Daemons.ServiceCheck.MaxTime * 60;
+    $Global:Icinga.Private.Daemons.ServiceCheck.MaxTimeInSeconds = $Global:Icinga.Private.Daemons.ServiceCheck.MaxTime;
 
     if ($Global:Icinga.Private.Scheduler.CheckData.ContainsKey($CheckCommand) -eq $FALSE) {
         $Global:Icinga.Private.Scheduler.CheckData.Add(


### PR DESCRIPTION
This commit sets the maximum duration for cached data for service daemons to the proper amount.

Previously it was multiplied by 60, probably a typo from a time when the assigned value was in minutes and not in seconds directly.

Therefore the value was 60 times to high which leads to a massive amount of cached data which drags down the performance significantly.