### PR TITLE
Feature: Improves service recover by adjustable restart time interval argument

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -16,6 +16,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Enhancements
 
+* [#766](https://github.com/Icinga/icinga-powershell-framework/issues/766) Adds argument `-IntervalInSeconds` for `Enable-IcingaServiceRecovery` to allow setting a custom time interval for the service to restart, while setting the default to 120 seconds (2 minutes)
 * [#772](https://github.com/Icinga/icinga-powershell-framework/pull/772) Adds new Metric over Time handling
 
 ## 1.13.0 Beta-2 (2024-09-19)

--- a/lib/core/windows/Enable-IcingaServiceRecovery.psm1
+++ b/lib/core/windows/Enable-IcingaServiceRecovery.psm1
@@ -1,7 +1,14 @@
 function Enable-IcingaServiceRecovery()
 {
+    param (
+        [int]$IntervalInSeconds = 120
+    );
+
+    # The interval in milliseconds to restart actions to happen for the service
+    $IntervalInMilliseconds = $IntervalInSeconds * 1000;
+
     if ($null -ne (Get-Service 'icinga2' -ErrorAction SilentlyContinue)) {
-        $ServiceStatus = Start-IcingaProcess -Executable 'sc.exe' -Arguments 'failure icinga2 reset=0 actions=restart/0/restart/0/restart/0';
+        $ServiceStatus = Start-IcingaProcess -Executable 'sc.exe' -Arguments ([string]::Format('failure icinga2 reset=0 actions=restart/{0}/restart/{0}/restart/{0}', $IntervalInMilliseconds));
 
         if ($ServiceStatus.ExitCode -ne 0) {
             Write-IcingaConsoleError -Message 'Failed to enable recover settings for service "icinga2": {0} {1}' -Objects $ServiceStatus.Message, $ServiceStatus.Error;
@@ -11,7 +18,7 @@ function Enable-IcingaServiceRecovery()
     }
 
     if ($null -ne (Get-Service 'icingapowershell' -ErrorAction SilentlyContinue)) {
-        $ServiceStatus = Start-IcingaProcess -Executable 'sc.exe' -Arguments 'failure icingapowershell reset=0 actions=restart/0/restart/0/restart/0';
+        $ServiceStatus = Start-IcingaProcess -Executable 'sc.exe' -Arguments ([string]::Format('failure icingapowershell reset=0 actions=restart/{0}/restart/{0}/restart/{0}', $IntervalInMilliseconds));
 
         if ($ServiceStatus.ExitCode -ne 0) {
             Write-IcingaConsoleError -Message 'Failed to enable recover settings for service "icingapowershell": {0} {1}' -Objects $ServiceStatus.Message, $ServiceStatus.Error;


### PR DESCRIPTION
Adds argument `-IntervalInSeconds` for `Enable-IcingaServiceRecovery` to allow setting a custom time interval for the service to restart, while setting the default to 120 seconds (2 minutes)

Fixes #766