### PR TITLE
Feature: Allow JEA-Session to update IfW process priority

### DIFF
--- a/lib/daemon/Start-IcingaPowerShellDaemon.psm1
+++ b/lib/daemon/Start-IcingaPowerShellDaemon.psm1
@@ -52,6 +52,9 @@ function Start-IcingaForWindowsDaemon()
 
                     Write-IcingaFileSecure -File ($args[0]) -Value $PID;
 
+                    # Make sure a new JEA session is always updated with the correct process priority
+                    Start-IcingaWindowsScheduledTaskProcessPriority;
+
                     $Global:Icinga.Protected.JEAContext  = $TRUE;
                     $Global:Icinga.Protected.RunAsDaemon = $TRUE;
                     # Todo: Add config for active background tasks. Set it to 20 for the moment


### PR DESCRIPTION
Improves JEA-Sessions by allowing the daemon to update the IfW process priority, as with v1.13.0 we want to ensure that we always run as "Below Normal"