### PR TITLE
Fix: Test commands failing because wrong assigned service data

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -11,6 +11,14 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/38)
 
+## 1.13.1 (2025-01-31)
+
+[Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/39)
+
+### Bugfixes
+
+* [#778](https://github.com/Icinga/icinga-powershell-framework/issues/778) Fixes test commands like `Test-IcingaForWindows` failing because of wrong assigned ServiceData information.
+
 ## 1.13.0 (2025-01-30)
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/37)

--- a/jobs/GetWindowsService.ps1
+++ b/jobs/GetWindowsService.ps1
@@ -21,11 +21,11 @@ try {
     if ($null -ne $SvcData) {
         $ServiceConfig           = $SvcData."$ServiceName".configuration;
         $ServiceMeta             = $SvcData."$ServiceName".metadata;
-        $ServiceInfo.Status      = [string]$ServiceConfig.Status.value;
-        $ServiceInfo.User        = [string]$ServiceConfig.ServiceUser;
-        $ServiceInfo.ServicePath = [string]$ServiceConfig.ServicePath;
-        $ServiceInfo.Name        = $ServiceMeta.ServiceName;
-        $ServiceInfo.DisplayName = $ServiceMeta.DisplayName;
+        $ServiceData.Status      = [string]$ServiceConfig.Status.value;
+        $ServiceData.User        = [string]$ServiceConfig.ServiceUser;
+        $ServiceData.ServicePath = [string]$ServiceConfig.ServicePath;
+        $ServiceData.Name        = $ServiceMeta.metadata.ServiceName;
+        $ServiceData.DisplayName = $ServiceMeta.metadata.DisplayName;
         $ServiceData.Present     = $TRUE;
     }
 } catch {


### PR DESCRIPTION
Fixes test commands like `Test-IcingaForWindows` failing because of wrong assigned ServiceData information.

Fixes #778