### PR TITLE
Fix: Return value for "Agent" component installation failure

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -11,6 +11,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/38)
 
+### Bugfixes
+
+* [#787](https://github.com/Icinga/icinga-powershell-framework/pull/787) Fixes the return value in case the `Agent` component could not be installed from `$FALSE` to `null`
+
 ## 1.13.2 (2025-02-03)
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/40)

--- a/lib/core/repository/Install-IcingaComponent.psm1
+++ b/lib/core/repository/Install-IcingaComponent.psm1
@@ -394,7 +394,7 @@ function Install-IcingaComponent()
 
         if ($InstallProcess.ExitCode -ne 0) {
             Write-IcingaConsoleError -Message 'Failed to install component "agent": {0}{1}' -Objects $InstallProcess.Message, $InstallProcess.Error;
-            return $FALSE;
+            return;
         }
 
         $Global:Icinga.Protected.Environment.'Icinga Service'.Present = $TRUE;


### PR DESCRIPTION
Fixes the return value in case the `Agent` component could not be installed from `$FALSE` to `null`