### PR TITLE
Fix: AddSummaryHeader not adding any check information to check package

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -25,6 +25,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#787](https://github.com/Icinga/icinga-powershell-framework/pull/787) Fixes the return value in case the `Agent` component could not be installed from `$FALSE` to `null`
 * [#796](https://github.com/Icinga/icinga-powershell-framework/issues/796) [#798](https://github.com/Icinga/icinga-powershell-framework/issues/798) Fixes an issue with the new check handling, which did not properly convert values from checks to the correct performance data values and base values in some cases
 * [#797](https://github.com/Icinga/icinga-powershell-framework/issues/797) Fixes plugins throwing `UNKNOWN` in case `-TresholdInterval` is used for Metrics over Time, when checks are newly registered and checked, before the first MoT is executed and collected
+* [#809](https://github.com/Icinga/icinga-powershell-framework/issues/809) Fixes plugin compiler not handling `AddSummaryHeader` properly for nested check packages, not adding any check information
 
 ### Enhancements
 

--- a/lib/icinga/plugin/New-IcingaCheckPackage.psm1
+++ b/lib/icinga/plugin/New-IcingaCheckPackage.psm1
@@ -101,8 +101,8 @@ function New-IcingaCheckPackage()
         $CheckSummary     = New-Object -TypeName 'System.Text.StringBuilder';
         [bool]$HasContent = $FALSE;
 
-        # Only apply this to the top parent package
-        if ($this.__GetIndention() -eq 0) {
+        # Always apply this to the first package or if we specify AddSummaryHeader
+        if ($this.__GetIndention() -eq 0 -Or $this.AddSummaryHeader) {
             if ($this.__UnknownChecks.Count -ne 0) {
                 $UnknownChecks = [string]::Format(' [UNKNOWN] {0}', ([string]::Join(', ', $this.__UnknownChecks)));
                 $CheckSummary.Append(


### PR DESCRIPTION
Fixes plugin compiler not handling `AddSummaryHeader` properly for nested check packages, not adding any check information

```powershell
[WARNING] CPU Load [WARNING] Socket #0 (All must be [OK])
\_ [OK] Overall Load: 8.283808%
\_ [WARNING] Socket #0: 2 Warning 3 Ok [WARNING] Core 0, Core 2 (All must be [OK])
   \_ [WARNING] Core 0: Value 18.86168% is greater than threshold 9%
   \_ [OK] Core 1: 4.852731%
   \_ [WARNING] Core 2: Value 9.340026% is greater than threshold 9%
   \_ [OK] Core 3: 0.080795%
   \_ [OK] Core Total: 8.283808%
| totalload::ifw_cpu::load=8.283808%;9;;0;100 0_0::ifw_cpu::load=18.86168%;9;;0;100 0_1::ifw_cpu::load=4.852731%;9;;0;100 0_2::ifw_cpu::load=9.340026%;9;;0;100 0_3::ifw_cpu::load=0.080795%;9;;0;100 0_total::ifw_cpu::load=8.283808%;9;;0;100
```

Fixes #809