### PR TITLE
Fix: Improved security for random character generator

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -15,6 +15,9 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/42)
 
+### Bugfixes
+
+* [#814](https://github.com/Icinga/icinga-powershell-framework/pull/814) Fixes random chars function to truly generate unpredictable character sequences and to replace `Get-Random` which is not entirely secure
 * [#815](https://github.com/Icinga/icinga-powershell-framework/pull/815) Fixes a possible crash for `Test-IcingaAddTypeExist`, causing the Icinga for Windows installation to fail when third party components are checked which are malfunctioning
 
 ## 1.13.3 (2025-05-08)

--- a/lib/core/windows/Get-IcingaRandomChars.psm1
+++ b/lib/core/windows/Get-IcingaRandomChars.psm1
@@ -11,13 +11,28 @@ function Get-IcingaRandomChars()
         return $RandomChars;
     }
 
-    while ($Count -gt 0) {
+    [int]$SymbolLength = $Symbols.Length;
+    $CryptoProvider    = New-Object System.Security.Cryptography.RNGCryptoServiceProvider;
+    $ByteValue         = New-Object Byte[] 4;
+    $maxValid          = [uint32]::MaxValue - ([uint32]::MaxValue % $SymbolLength);
 
-        [int]$SymbolLength = $Symbols.Length;
-        $RandomValue       = Get-Random -Minimum 0 -Maximum ($SymbolLength - 1);
-        $RandomChars       += $Symbols[$RandomValue];
-        $Count             -= 1;
+    for ($index = 0; $index -lt $Count; $index++) {
+        do {
+            # Generate random bytes
+            $CryptoProvider.GetBytes($ByteValue);
+            $RandomNumber = [BitConverter]::ToUInt32($ByteValue, 0);
+            # Ensure the random number is within the valid range to avoid maximum security
+        } while ($RandomNumber -ge $maxValid);
+
+        # Calculate the index for the symbol array
+        $randomIndex  = $RandomNumber % $SymbolLength;
+        $RandomChars += $Symbols[$randomIndex];
     }
+
+    # Clean up
+    $CryptoProvider.Dispose();
+    $CryptoProvider = $null;
+    $ByteValue      = $null;
 
     return $RandomChars;
 }


### PR DESCRIPTION
Fixes random chars function to truly generate unpredictable character sequences and to replace `Get-Random` which is not entirely secure