### PR TITLE
Fix: Possible crash on assembly fetching for third party assemblies

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -11,6 +11,12 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/38)
 
+## 1.13.4 (tbd)
+
+[Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/42)
+
+* [#815](https://github.com/Icinga/icinga-powershell-framework/pull/815) Fixes a possible crash for `Test-IcingaAddTypeExist`, causing the Icinga for Windows installation to fail when third party components are checked which are malfunctioning
+
 ## 1.13.3 (2025-05-08)
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/39)

--- a/lib/core/tools/Test-IcingaAddTypeExist.psm1
+++ b/lib/core/tools/Test-IcingaAddTypeExist.psm1
@@ -31,12 +31,15 @@ function Test-IcingaAddTypeExist()
     }
 
     foreach ($entry in [System.AppDomain]::CurrentDomain.GetAssemblies()) {
-        if ($entry.GetTypes() -Match $Type) {
-            $LoadedTypes.Add($Type, $TRUE);
+        try {
+            if ($entry.GetTypes() -Match $Type) {
+                $LoadedTypes.Add($Type, $TRUE);
 
-            Set-IcingaPrivateEnvironmentVariable -Name 'AddTypeFunctions' -Value $LoadedTypes;
+                Set-IcingaPrivateEnvironmentVariable -Name 'AddTypeFunctions' -Value $LoadedTypes;
 
-            return $TRUE;
+                return $TRUE;
+            }
+        } catch {
         }
     }
 


### PR DESCRIPTION
Fixes a possible crash for `Test-IcingaAddTypeExist`, causing the Icinga for Windows installation to fail when third party components are checked which are malfunctioning