### PR TITLE
Feature: Adds caching update for added/removed performance counter instances

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -20,6 +20,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 ### Enhancements
 
 * [#838](https://github.com/Icinga/icinga-powershell-framework/pull/838) Enhances Icinga for Windows to never load and user PowerShell profiles
+* [#11](https://github.com/Icinga/icinga-powershell-framework/pull/11) Adds feature to update the cache for performance counter instances to keep track of system changes
 
 ## 1.13.4 (tbd)
 

--- a/lib/core/perfcounter/New-IcingaPerformanceCounterArray.psm1
+++ b/lib/core/perfcounter/New-IcingaPerformanceCounterArray.psm1
@@ -40,25 +40,12 @@ function New-IcingaPerformanceCounterArray()
         # NumOfCounters * 500 milliseconds for the first runs. This will speed
         # up the general loading of counters and will not require some fancy
         # pre-caching / configuration handler
-        $CachedCounter = Get-IcingaPerformanceCounterCacheItem -Counter $Counter;
-
-        # Remove this for now to ensure our CPU metrics will not be cached
-        # and represent correct values, not exceeding 200% and beyond
-        #if ($null -ne $CachedCounter) {
-        #    $RequireSleep = $FALSE;
-        #}
 
         $obj = New-IcingaPerformanceCounter -Counter $counter -SkipWait $TRUE;
         if ($CounterResult.ContainsKey($obj.Name()) -eq $FALSE) {
             $CounterResult.Add($obj.Name(), $obj.Value());
         }
     }
-
-    # TODO: Add a cache for our Performance Counters to only fetch them once
-    #       for each session to speed up the loading. This cold be something like
-    #       this:
-    #
-    # $Global:Icinga.Private.PerformanceCounter.Cache += $CounterResult;
 
     # Above we initialise ever single counter and we only require a sleep once
     # in case a new, yet unknown counter was added

--- a/lib/core/perfcounter/Show-IcingaPerformanceCounterInstances.psm1
+++ b/lib/core/perfcounter/Show-IcingaPerformanceCounterInstances.psm1
@@ -35,7 +35,7 @@ function Show-IcingaPerformanceCounterInstances()
         return;
     }
 
-    $PerfCounter  = New-IcingaPerformanceCounter -Counter $Counter -SkipWait $TRUE;
+    $PerfCounter  = New-IcingaPerformanceCounter -Counter $Counter -SkipWait $TRUE -NoCache;
 
     foreach ($entry in $PerfCounter.Counters) {
         $Instances.Add(

--- a/lib/core/perfcounter/Update-IcingaPerformanceCounterCache.psm1
+++ b/lib/core/perfcounter/Update-IcingaPerformanceCounterCache.psm1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+    Updates the cached instances of a specified performance counter in the Icinga PowerShell Framework.
+
+.DESCRIPTION
+    The Update-IcingaPerformanceCounterCache function synchronizes the cached instances of a given performance counter.
+    It removes instances that no longer exist and adds new instances that are not yet cached.
+    This ensures that the cache accurately reflects the current state of the performance counter instances.
+
+.PARAMETER Counter
+    The name of the performance counter whose cache should be updated.
+
+.EXAMPLE
+    Update-IcingaPerformanceCounterCache -Counter "\Processor(_Total)\% Processor Time"
+
+    Updates the cache for the specified performance counter.
+
+.NOTES
+    This function is intended for internal use within the Icinga PowerShell Framework.
+    It requires that the global cache variable and related functions are available.
+
+#>
+function Update-IcingaPerformanceCounterCache()
+{
+    param (
+        $Counter
+    );
+
+    if ([string]::IsNullOrEmpty($Counter)) {
+        return;
+    }
+
+    if ($Global:Icinga.Private.PerformanceCounter.Cache.ContainsKey($Counter) -eq $FALSE) {
+        # If there is no cache entry for the provided counter, we don't need to do anything yet
+        return;
+    }
+
+    # First we need to prepare some data by fetching the current instances of the counter
+    # and the cached instances. We will then compare them and update the cache accordingly
+    [array]$CounterInstances    = Show-IcingaPerformanceCounterInstances -Counter $Counter;
+    [array]$CachedInstances     = $Global:Icinga.Private.PerformanceCounter.Cache[$Counter];
+    [array]$UpdatedInstances    = @();
+    [array]$CachedInstanceNames = $CachedInstances.FullName;
+
+    # We will now iterate over the cached instances and check if they are still present in the current
+    # counter instances. If they are not, we will remove them from the cache.
+    # If they are present, we will keep them in the updated instances array.
+    for ($index = 0; $index -lt $CachedInstances.Count; $index++) {
+        $cachedInstance = $CachedInstances[$index];
+        $instanceName   = $cachedInstance.FullName;
+
+        # If the instance is not in the current list, we remove it
+        if ($CounterInstances.Value -contains $instanceName) {
+            $UpdatedInstances += $cachedInstance;
+        }
+    }
+
+    # Now we will iterate over the current counter instances and check if they are already cached.
+    # If they are not, we will add them to the updated instances array.
+    # This ensures that we only add new instances that are not already cached.
+    for ($index = 0; $index -lt $CounterInstances.Count; $index++) {
+        $instanceName = $CounterInstances[$index].Value;
+
+        if ($CachedInstanceNames -notcontains $instanceName) {
+            # If the instance is not cached, we create a new performance counter object
+            # and add it to the updated instances array
+            $UpdatedInstances += (New-IcingaPerformanceCounter -Counter $instanceName -SkipWait $TRUE -NoCache);
+        }
+    }
+
+    # Finally, we update the cache with the new instances
+    # This will ensure that the cache is up-to-date with the current state of the performance
+    # counter instances
+    $Global:Icinga.Private.PerformanceCounter.Cache[$Counter] = $UpdatedInstances;
+}


### PR DESCRIPTION
Adds feature to update the cache for performance counter instances to keep track of system changes.

This will ensure that while we are running as a daemon with Icinga for Windows, newly added or removed information for performance counters will be updated whenever required.

Fixes #11