### PR TITLE
Fix: JEA compiler to always force a framework rebuild on update

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -11,6 +11,8 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/38)
 
+* [#835](https://github.com/Icinga/icinga-powershell-framework/pull/835) Fixes JEA compiler to always enforce a rebuild of the Framework to ensure integrity of JEA profiles
+
 ## 1.13.4 (tbd)
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/42)

--- a/lib/core/jea/Install-IcingaJeaProfile.psm1
+++ b/lib/core/jea/Install-IcingaJeaProfile.psm1
@@ -23,7 +23,8 @@ function Install-IcingaJEAProfile()
     }
 
     Write-IcingaConsoleNotice 'Writing Icinga for Windows environment information as JEA profile';
-    Write-IcingaJEAProfile -RebuildFramework:$RebuildFramework -AllowScriptBlocks:$AllowScriptBlocks;
+    # Always rebuild the framework to ensure we have the latest configuration
+    Write-IcingaJEAProfile -RebuildFramework -AllowScriptBlocks:$AllowScriptBlocks;
     Write-IcingaConsoleNotice 'Registering Icinga for Windows JEA profile';
     Register-IcingaJEAProfile -IcingaUser $IcingaUser -TestEnv:$TestEnv -ConstrainedLanguage:$ConstrainedLanguage;
     # We need to run the task renewal with our scheduled task to fix errors while using WinRM / SSH


### PR DESCRIPTION
Fixes JEA compiler to always enforce a rebuild of the Framework to ensure integrity of JEA profiles