### PR TITLE
Fix: Never load user PowerShell profiles

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -11,8 +11,14 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/38)
 
+### Bugfixes
+
 * [#835](https://github.com/Icinga/icinga-powershell-framework/pull/835) Fixes JEA compiler to always enforce a rebuild of the Framework to ensure integrity of JEA profiles
 * [#836](https://github.com/Icinga/icinga-powershell-framework/issues/836) Fixes Metric over Time collector not working on Windows 2012 R2 and older
+
+### Enhancements
+
+* [#838](https://github.com/Icinga/icinga-powershell-framework/pull/838) Enhances Icinga for Windows to never load and user PowerShell profiles
 
 ## 1.13.4 (tbd)
 

--- a/doc/130-JEA/02-Installation.md
+++ b/doc/130-JEA/02-Installation.md
@@ -82,7 +82,7 @@ Update-IcingaJEAProfile -IcingaUser 'MyOwnIcingaUser';
 If you used `TestEnv` to create a test environment for JEA for the current user, you can simply enter the PowerShell JEA session with this command:
 
 ```powershell
-powershell.exe -ConfigurationName 'IcingaForWindowsTest';
+powershell.exe -NoProfile -ConfigurationName 'IcingaForWindowsTest';
 ```
 
 This will open a new `remote` PowerShell session over `WinRM` on the local machine with the provided JEA profile 'IcingaForWindowsTest'.

--- a/icinga-powershell-framework.psm1
+++ b/icinga-powershell-framework.psm1
@@ -340,7 +340,7 @@ function Invoke-IcingaCommand()
     # Ensure we set the path to another folder to prevent locking the Framework Root Folder
     Set-Location (Get-IcingaForWindowsRootPath);
 
-    powershell.exe -NoExit -Command {
+    powershell.exe -NoProfile -NoExit -Command {
         $Script          = $args[0];
         $RootPath        = $args[1];
         $Version         = $args[2];
@@ -427,7 +427,7 @@ function Start-IcingaShellAsUser()
         -Verb RunAs `
         -ArgumentList (
             [string]::Format(
-                "-Command `"Start-Process -FilePath `"powershell.exe`" -WorkingDirectory `"{0}`" -Credential (Get-Credential -UserName '{1}' -Message 'Please enter your credentials to open an Icinga Shell with') -ArgumentList icinga`"",
+                "-NoProfile -Command `"Start-Process -FilePath `"powershell.exe`" -WorkingDirectory `"{0}`" -Credential (Get-Credential -UserName '{1}' -Message 'Please enter your credentials to open an Icinga Shell with') -ArgumentList icinga`"",
                 $PSHOME,
                 $User
             )

--- a/lib/core/framework/Install-IcingaFrameworkComponent.psm1
+++ b/lib/core/framework/Install-IcingaFrameworkComponent.psm1
@@ -112,7 +112,7 @@ function Install-IcingaFrameworkComponent()
 
     if ([string]::IsNullOrEmpty((Get-IcingaJEAContext)) -eq $FALSE) {
         Write-IcingaConsoleNotice 'Updating Icinga JEA profile';
-        & powershell.exe -Command { Use-Icinga -Minimal; Install-IcingaJEAProfile; } | Out-Null;
+        & powershell.exe -NoProfile -Command { Use-Icinga -Minimal; Install-IcingaJEAProfile; } | Out-Null;
     }
 
     # Unload the module if it was loaded before

--- a/lib/core/framework/Install-IcingaFrameworkUpdate.psm1
+++ b/lib/core/framework/Install-IcingaFrameworkUpdate.psm1
@@ -109,7 +109,7 @@ function Install-IcingaFrameworkUpdate()
     if ([string]::IsNullOrEmpty((Get-IcingaJEAContext)) -eq $FALSE) {
         Remove-IcingaFrameworkDependencyFile;
         Write-IcingaConsoleNotice 'Updating Icinga JEA profile';
-        & powershell.exe -Command { Use-Icinga -Minimal; Install-IcingaJEAProfile; } | Out-Null;
+        & powershell.exe -NoProfile -Command { Use-Icinga -Minimal; Install-IcingaJEAProfile; } | Out-Null;
     }
 
     Write-IcingaConsoleNotice 'Framework update has been completed. Please start a new PowerShell instance now to complete the update';

--- a/lib/core/framework/Restart-IcingaService.psm1
+++ b/lib/core/framework/Restart-IcingaService.psm1
@@ -27,7 +27,7 @@ function Restart-IcingaService()
     if (Get-Service "$Service" -ErrorAction SilentlyContinue) {
         Write-IcingaConsoleNotice ([string]::Format('Restarting service "{0}"', $Service));
 
-        & powershell.exe -Command {
+        & powershell.exe -NoProfile -Command {
             Use-Icinga -Minimal;
 
             $Service = $args[0];

--- a/lib/core/framework/Start-IcingaService.psm1
+++ b/lib/core/framework/Start-IcingaService.psm1
@@ -27,7 +27,7 @@ function Start-IcingaService()
     if (Get-Service $Service -ErrorAction SilentlyContinue) {
         Write-IcingaConsoleNotice -Message 'Starting service "{0}"' -Objects $Service;
 
-        & powershell.exe -Command {
+        & powershell.exe -NoProfile -Command {
             Use-Icinga -Minimal;
 
             $Service = $args[0];

--- a/lib/core/framework/Stop-IcingaService.psm1
+++ b/lib/core/framework/Stop-IcingaService.psm1
@@ -27,7 +27,7 @@ function Stop-IcingaService()
     if (Get-Service "$Service" -ErrorAction SilentlyContinue) {
         Write-IcingaConsoleNotice -Message 'Stopping service "{0}"' -Objects $Service;
 
-        & powershell.exe -Command {
+        & powershell.exe -NoProfile -Command {
             Use-Icinga -Minimal;
 
             $Service = $args[0];

--- a/lib/core/icingaagent/installer/Install-IcingaAgent.psm1
+++ b/lib/core/icingaagent/installer/Install-IcingaAgent.psm1
@@ -73,7 +73,7 @@ function Install-IcingaAgent()
         }
     }
 
-    $InstallProcess = & powershell.exe -Command {
+    $InstallProcess = & powershell.exe -NoProfile -Command {
         Use-Icinga -Minimal;
 
         $IcingaInstaller = $args[0];

--- a/lib/core/icingaagent/installer/Uninstall-IcingaAgent.psm1
+++ b/lib/core/icingaagent/installer/Uninstall-IcingaAgent.psm1
@@ -22,7 +22,7 @@ function Uninstall-IcingaAgent()
 
     Stop-IcingaService -Service 'icinga2';
 
-    $Uninstaller = & powershell.exe -Command {
+    $Uninstaller = & powershell.exe -NoProfile -Command {
         Use-Icinga -Minimal;
 
         $IcingaData  = $args[0];

--- a/lib/core/installer/menu/manage/settings/logs/ViewLogs.psm1
+++ b/lib/core/installer/menu/manage/settings/logs/ViewLogs.psm1
@@ -12,7 +12,7 @@ function Show-IcingaForWindowsMenuManageViewLogs()
                 'AdminMenu'      = $TRUE;
                 'Action'         = @{
                     'Command'   = 'Start-Process';
-                    'Arguments' = @{ '-FilePath' = 'powershell.exe'; '-ArgumentList' = "-Command  `"&{ icinga { Read-IcingaAgentLogFile; }; }`"" };
+                    'Arguments' = @{ '-FilePath' = 'powershell.exe'; '-ArgumentList' = "-NoProfile -Command  `"&{ icinga { Read-IcingaAgentLogFile; }; }`"" };
                 }
             },
             @{
@@ -24,7 +24,7 @@ function Show-IcingaForWindowsMenuManageViewLogs()
                 'AdminMenu'      = $TRUE;
                 'Action'         = @{
                     'Command'   = 'Start-Process';
-                    'Arguments' = @{ '-FilePath' = 'powershell.exe'; '-ArgumentList' = "-Command  `"&{ icinga { Read-IcingaAgentDebugLogFile; }; }`"" };
+                    'Arguments' = @{ '-FilePath' = 'powershell.exe'; '-ArgumentList' = "-NoProfile -Command  `"&{ icinga { Read-IcingaAgentDebugLogFile; }; }`"" };
                 }
             },
             @{
@@ -34,7 +34,7 @@ function Show-IcingaForWindowsMenuManageViewLogs()
                 'AdminMenu' = $TRUE;
                 'Action'    = @{
                     'Command'   = 'Start-Process';
-                    'Arguments' = @{ '-FilePath' = 'powershell.exe'; '-ArgumentList' = "-Command  `"&{ icinga { Read-IcingaForWindowsLog; }; }`"" };
+                    'Arguments' = @{ '-FilePath' = 'powershell.exe'; '-ArgumentList' = "-NoProfile -Command  `"&{ icinga { Read-IcingaForWindowsLog; }; }`"" };
                 }
             },
             @{
@@ -44,7 +44,7 @@ function Show-IcingaForWindowsMenuManageViewLogs()
                 'AdminMenu' = $TRUE;
                 'Action'    = @{
                     'Command'   = 'Start-Process';
-                    'Arguments' = @{ '-FilePath' = 'powershell.exe'; '-ArgumentList' = "-Command  `"&{ icinga { Read-IcingaWindowsEventLog -LogName 'Icinga for Windows' -Source 'IfW::Debug'; }; }`"" };
+                    'Arguments' = @{ '-FilePath' = 'powershell.exe'; '-ArgumentList' = "-NoProfile -Command  `"&{ icinga { Read-IcingaWindowsEventLog -LogName 'Icinga for Windows' -Source 'IfW::Debug'; }; }`"" };
                 }
             }
         );

--- a/lib/core/repository/Install-IcingaComponent.psm1
+++ b/lib/core/repository/Install-IcingaComponent.psm1
@@ -358,7 +358,7 @@ function Install-IcingaComponent()
             }
         }
 
-        $MSIData = & powershell.exe -Command {
+        $MSIData = & powershell.exe -NoProfile -Command {
             Use-Icinga -Minimal;
 
             $DownloadDestination = $args[0];
@@ -380,7 +380,7 @@ function Install-IcingaComponent()
             }
         }
 
-        $InstallProcess = & powershell.exe -Command {
+        $InstallProcess = & powershell.exe -NoProfile -Command {
             Use-Icinga -Minimal;
 
             $DownloadDestination = $args[0];

--- a/lib/core/wintasks/Invoke-IcingaWindowsScheduledTask.psm1
+++ b/lib/core/wintasks/Invoke-IcingaWindowsScheduledTask.psm1
@@ -36,7 +36,7 @@ function Invoke-IcingaWindowsScheduledTask()
             $TaskData = Invoke-IcingaWindowsServiceHandlerTask -ScriptPath 'jobs\GetWindowsService.ps1' -ServiceName $ObjectName -TmpFile $TmpFile.FullName -TaskName $TaskName -TaskPath $TaskPath;
         };
         'UninstallAgent' {
-            $WinAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format('-WindowStyle Hidden -Command &{{ Use-Icinga -Minimal; Write-IcingaFileSecure -File {0}{1}{0} -Value (Start-IcingaProcess -Executable {0}MsiExec.exe{0} -Arguments {0}"{2}" /q{0} -FlushNewLines | ConvertTo-Json -Depth 100); }}', "'", $TmpFile.FullName, $FilePath, $TargetPath))
+            $WinAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format('-NoProfile -WindowStyle Hidden -Command &{{ Use-Icinga -Minimal; Write-IcingaFileSecure -File {0}{1}{0} -Value (Start-IcingaProcess -Executable {0}MsiExec.exe{0} -Arguments {0}"{2}" /q{0} -FlushNewLines | ConvertTo-Json -Depth 100); }}', "'", $TmpFile.FullName, $FilePath, $TargetPath))
             Register-ScheduledTask -User 'System' -TaskName $TaskName -Action $WinAction -TaskPath $TaskPath | Out-Null;
 
             Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath;
@@ -54,7 +54,7 @@ function Invoke-IcingaWindowsScheduledTask()
         'ReadMSIPackage' {
             if (Test-Path $FilePath) {
 
-                $WinAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format('-WindowStyle Hidden -Command &{{ Use-Icinga -Minimal; Write-IcingaFileSecure -File {0}{1}{0} -Value (Read-IcingaMSIMetadata -File {0}{2}{0} | ConvertTo-Json -Depth 100); }}', "'", $TmpFile.FullName, $FilePath))
+                $WinAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format('-NoProfile -WindowStyle Hidden -Command &{{ Use-Icinga -Minimal; Write-IcingaFileSecure -File {0}{1}{0} -Value (Read-IcingaMSIMetadata -File {0}{2}{0} | ConvertTo-Json -Depth 100); }}', "'", $TmpFile.FullName, $FilePath))
                 Register-ScheduledTask -TaskName $TaskName -Action $WinAction -RunLevel Highest -TaskPath $TaskPath | Out-Null;
 
                 Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath;
@@ -68,7 +68,7 @@ function Invoke-IcingaWindowsScheduledTask()
             }
         };
         'InstallJEA' {
-            $WinAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format('-Command &{{ Use-Icinga -Minimal; Install-IcingaJEAProfile; Restart-IcingaForWindows; }}', "'", $TmpFile.FullName, $FilePath))
+            $WinAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format('-NoProfile -Command &{{ Use-Icinga -Minimal; Install-IcingaJEAProfile; Restart-IcingaForWindows; }}', "'", $TmpFile.FullName, $FilePath))
             Register-ScheduledTask -User 'System' -TaskName $TaskName -Action $WinAction -TaskPath $TaskPath | Out-Null;
             Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath;
 

--- a/lib/core/wintasks/Invoke-IcingaWindowsServiceHandlerTask.psm1
+++ b/lib/core/wintasks/Invoke-IcingaWindowsServiceHandlerTask.psm1
@@ -19,7 +19,7 @@ function Invoke-IcingaWindowsServiceHandlerTask()
         return $null;
     }
 
-    $WinAction    = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format("-WindowStyle Hidden -Command &{{ & '{0}' -ServiceName '{1}' -TmpFilePath '{2}' }}", $ScriptPath, $ServiceName, $TmpFile));
+    $WinAction    = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument ([string]::Format("-NoProfile -WindowStyle Hidden -Command &{{ & '{0}' -ServiceName '{1}' -TmpFilePath '{2}' }}", $ScriptPath, $ServiceName, $TmpFile));
     $TaskSettings = New-ScheduledTaskSettingsSet -DontStopIfGoingOnBatteries -AllowStartIfOnBatteries -StartWhenAvailable;
     # We need to schedule this task as LocalSystem to ensure we can fetch the information while connected over WinRM/SSH
     # We require high admin privilleges anyway, therefor this shouldn't hurt

--- a/lib/core/wintasks/daemon/Register-TaskIcingaForWindowsProcessPriority.psm1
+++ b/lib/core/wintasks/daemon/Register-TaskIcingaForWindowsProcessPriority.psm1
@@ -15,7 +15,7 @@ function Register-IcingaWindowsScheduledTaskProcessPriority()
     }
 
     $ScriptPath    = Join-Path -Path (Get-IcingaFrameworkRootPath) -ChildPath '\jobs\SetProcessPriority.ps1';
-    $TaskAction    = New-ScheduledTaskAction -Execute 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -Argument ([string]::Format("-WindowStyle Hidden -Command &{{ & '{0}' }}", $ScriptPath));
+    $TaskAction    = New-ScheduledTaskAction -Execute 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -Argument ([string]::Format("-NoProfile -WindowStyle Hidden -Command &{{ & '{0}' }}", $ScriptPath));
     $TaskPrincipal = New-ScheduledTaskPrincipal -UserId 'S-1-5-18' -RunLevel 'Highest' -LogonType ServiceAccount;
     $TaskSettings  = New-ScheduledTaskSettingsSet -DontStopIfGoingOnBatteries -AllowStartIfOnBatteries -StartWhenAvailable;
 

--- a/lib/core/wintasks/daemon/Register-TaskRenewCertificate.psm1
+++ b/lib/core/wintasks/daemon/Register-TaskRenewCertificate.psm1
@@ -16,7 +16,7 @@ function Register-IcingaWindowsScheduledTaskRenewCertificate()
 
     $ScriptPath    = Join-Path -Path (Get-IcingaFrameworkRootPath) -ChildPath '\jobs\RenewCertificate.ps1';
     $TaskTrigger   = New-ScheduledTaskTrigger -Daily -DaysInterval 1 -At '1am';
-    $TaskAction    = New-ScheduledTaskAction -Execute 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -Argument ([string]::Format("-WindowStyle Hidden -Command &{{ & '{0}' }}", $ScriptPath));
+    $TaskAction    = New-ScheduledTaskAction -Execute 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -Argument ([string]::Format("-NoProfile -WindowStyle Hidden -Command &{{ & '{0}' }}", $ScriptPath));
     $TaskPrincipal = New-ScheduledTaskPrincipal -UserId 'S-1-5-18' -RunLevel 'Highest' -LogonType ServiceAccount;
     $TaskSettings  = New-ScheduledTaskSettingsSet -DontStopIfGoingOnBatteries -AllowStartIfOnBatteries -StartWhenAvailable;
 


### PR DESCRIPTION
To enhance compatibility and reduce the overall impact during certain tasks run by Icinga for Windows, ensure we never load any user PowerShell profiles