### PR TITLE
Fix: Icinga Agent installation lookup on missing registry attributes

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#833](https://github.com/Icinga/icinga-powershell-framework/issues/833) Fixes registry lookup for Icinga Agent installation to check if the required `DisplayName` attribute is defined before checking
 * [#835](https://github.com/Icinga/icinga-powershell-framework/pull/835) Fixes JEA compiler to always enforce a rebuild of the Framework to ensure integrity of JEA profiles
 * [#836](https://github.com/Icinga/icinga-powershell-framework/issues/836) Fixes Metric over Time collector not working on Windows 2012 R2 and older
 

--- a/lib/core/icingaagent/getters/Get-IcingaAgentInstallation.psm1
+++ b/lib/core/icingaagent/getters/Get-IcingaAgentInstallation.psm1
@@ -12,6 +12,10 @@ function Get-IcingaAgentInstallation()
     $RegistryData = Get-ItemProperty $regPath;
     $IcingaData   = $null;
     foreach ($entry in $RegistryData) {
+        if ($null -eq $entry -or $null -eq $entry.DisplayName) {
+            continue;
+        }
+
         if ($entry.DisplayName -eq 'Icinga 2') {
             $IcingaData = $entry;
             break;


### PR DESCRIPTION
Fixes registry lookup for Icinga Agent installation to check if the required `DisplayName` attribute is defined before checking

Fixes #833