### PR TITLE
Feature: Adds new [INFO] state for notice and un-checked monitoring objects

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -19,8 +19,9 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Enhancements
 
-* [#838](https://github.com/Icinga/icinga-powershell-framework/pull/838) Enhances Icinga for Windows to never load and user PowerShell profiles
 * [#11](https://github.com/Icinga/icinga-powershell-framework/pull/11) Adds feature to update the cache for performance counter instances to keep track of system changes
+* [#838](https://github.com/Icinga/icinga-powershell-framework/pull/838) Enhances Icinga for Windows to never load and user PowerShell profiles
+* [#841](https://github.com/Icinga/icinga-powershell-framework/pull/841) Adds new [INFO] state for notice and un-checked monitoring objects
 
 ## 1.13.4 (tbd)
 

--- a/lib/icinga/plugin/New-IcingaCheckBaseObject.psm1
+++ b/lib/icinga/plugin/New-IcingaCheckBaseObject.psm1
@@ -2,17 +2,19 @@ function New-IcingaCheckBaseObject()
 {
     $IcingaCheckBaseObject = New-Object -TypeName PSObject;
 
-    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name 'Name'             -Value '';
-    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name 'Verbose'          -Value 0;
-    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__Hidden'         -Value $FALSE;
-    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__SkipSummary'    -Value $FALSE;
-    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__Parent'         -Value $IcingaCheckBaseObject;
-    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__Indention'      -Value 0;
-    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__ErrorMessage'   -Value '';
-    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__CheckState'     -Value $IcingaEnums.IcingaExitCode.Ok;
-    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__CheckCommand'   -Value '';
-    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__CheckOutput'    -Value $null;
-    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__ObjectType'     -Value 'IcingaCheckBaseObject';
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name 'Name'                   -Value '';
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name 'Verbose'                -Value 0;
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__Hidden'               -Value $FALSE;
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__SkipSummary'          -Value $FALSE;
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__Parent'               -Value $IcingaCheckBaseObject;
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__Indention'            -Value 0;
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__ErrorMessage'         -Value '';
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__CheckState'           -Value $IcingaEnums.IcingaExitCode.Ok;
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__CheckCommand'         -Value '';
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__CheckOutput'          -Value $null;
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__IsNoticeObject'       -Value $FALSE;
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__HandleAsNoticeObject' -Value $FALSE;
+    $IcingaCheckBaseObject | Add-Member -MemberType NoteProperty -Name '__ObjectType'           -Value 'IcingaCheckBaseObject';
 
     $IcingaCheckBaseObject | Add-Member -MemberType ScriptMethod -Name '__SetCheckCommand' -Value {
         $CallStack = Get-PSCallStack;
@@ -103,7 +105,7 @@ function New-IcingaCheckBaseObject()
     }
 
     $IcingaCheckBaseObject | Add-Member -MemberType ScriptMethod -Force -Name '__SetCheckOutput' -Value {
-        param ($PluginOutput);
+        param ($PluginOutput, $CheckOverride);
     }
 
     $IcingaCheckBaseObject | Add-Member -MemberType ScriptMethod -Name '__GetCheckOutput' -Value {


### PR DESCRIPTION
Adds new [INFO] state for `New-IcingaCheck` and `New-IcingaCheckPackage`, to allow the printing of simple informational objects as well as telling the user, which objects are currently actively checked by the plugin engine.

```powershell
icinga> Invoke-IcingaCheckCPU -Verbosity 3;

[INFO] CPU Load (All must be [OK])
\_ [INFO] Overall Load: 8.714580%
\_ [INFO] Socket #0 (All must be [OK])
   \_ [INFO] Core 0: 22.63846%
   \_ [INFO] Core 1: 11.04723%
   \_ [INFO] Core 2: 0.672020%
   \_ [INFO] Core 3: 0.500612%
   \_ [INFO] Core Total: 8.714580%
| totalload::ifw_cpu::load=8.714580%;;;0;100 0_0::ifw_cpu::load=22.63846%;;;0;100 0_1::ifw_cpu::load=11.04723%;;;0;100 0_2::ifw_cpu::load=0.672020%;;;0;100 0_3::ifw_cpu::load=0.500612%;;;0;100 0_total::ifw_cpu::load=8.714580%;;;0;100
```


```powershell
icinga> Invoke-IcingaCheckProcess -Verbosity 3 -Process  WmiApSrv -MemoryWarning '1MB' -PageFileWarning '1KiB';

[WARNING] Process Overview: 1 Warning [WARNING] WmiApSrv (All must be [OK])
\_ [WARNING] WmiApSrv (All must be [OK])
   \_ [WARNING] WmiApSrv [16476] (All must be [OK])
      \_ [INFO] CPU Usage: 0%
      \_ [WARNING] Memory Usage: Value 1.67MiB is greater than threshold 976.56KiB
      \_ [INFO] Page File Usage: 2.30KiB
      \_ [INFO] Thread Count: 5c
   \_ [INFO] WmiApSrv Summary (All must be [OK])
      \_ [INFO] CPU Usage: 0%
      \_ [INFO] Memory Usage: 1.67MiB
      \_ [INFO] Page File Usage: 2.30KiB
      \_ [INFO] Process Count: 1c
      \_ [INFO] Thread Count: 5c
| wmiapsrv::ifw_process::cpu=0%;;;0;100 wmiapsrv::ifw_process::memory=1748992B;;;0;8583315000 wmiapsrv::ifw_process::pagefile=2352B;;;0;34359740000 wmiapsrv::ifw_process::count=1c;;;; wmiapsrv::ifw_process::threads=5c;;;;
```