### PR TITLE
Fix: FIPS exception caused by MD5 hash usage

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#783](https://github.com/Icinga/icinga-powershell-framework/issues/783) Fixes possible FIPS exception on some Windows machines, caused by `MD5` hash algorithm used to verify the service binary file integrity after download instead of `SHA256`
 * [#814](https://github.com/Icinga/icinga-powershell-framework/pull/814) Fixes random chars function to truly generate unpredictable character sequences and to replace `Get-Random` which is not entirely secure
 * [#815](https://github.com/Icinga/icinga-powershell-framework/pull/815) Fixes a possible crash for `Test-IcingaAddTypeExist`, causing the Icinga for Windows installation to fail when third party components are checked which are malfunctioning
 * [#816](https://github.com/Icinga/icinga-powershell-framework/issues/816) Fixes plugin execution error while using any `%IfNotMatch`/`%IfNotLike`/`%IfMatch`/`%IfLike` check function for strings containing special characters like `:`

--- a/doc/120-Repository-Manager/07-Create-Own-Repositories.md
+++ b/doc/120-Repository-Manager/07-Create-Own-Repositories.md
@@ -6,7 +6,7 @@ Besides [adding](01-Add-Repositories.md) and/or [syncing](02-Sync-Repositories.m
 
 To prepare your new repository, you will simply require an `empty` folder somewhere on your local Windows machine or accessible network share. For example we can create a new folder directly under `C:`, like `C:\icinga_repositories\custom`.
 
-Now after having an `empty` folder, copy all files you want to add to this repository there. This includes the `.zip` files for Icinga for Windows components, the Icinga Agents `.msi` files and the Icinga for Windows `Service` `.zip` files which include the `.exe` and the `.md5` hash file.
+Now after having an `empty` folder, copy all files you want to add to this repository there. This includes the `.zip` files for Icinga for Windows components, the Icinga Agents `.msi` files and the Icinga for Windows `Service` `.zip` files which include the `.exe` and the `.sha256` hash file.
 
 ## Initialize The Repository
 

--- a/lib/core/framework/Get-IcingaFrameworkServiceBinary.psm1
+++ b/lib/core/framework/Get-IcingaFrameworkServiceBinary.psm1
@@ -80,7 +80,7 @@ function Get-IcingaFrameworkServiceBinary()
     }
 
     if ((Test-IcingaZipBinaryChecksum -Path $TmpServiceBin) -eq $FALSE) {
-        throw 'The checksum of the downloaded file and the required MD5 hash are not matching';
+        throw 'The checksum of the downloaded file and the required SHA256 hash are not matching';
     }
 
     Copy-ItemSecure -Path $TmpServiceBin -Destination $UpdateBin -Force | Out-Null;

--- a/lib/core/framework/Test-IcingaZipBinaryChecksum.psm1
+++ b/lib/core/framework/Test-IcingaZipBinaryChecksum.psm1
@@ -1,18 +1,18 @@
 <#
 .SYNOPSIS
-    Compares a binary within a .zip file to a included .md5 to ensure
+    Compares a binary within a .zip file to a included .sha256 to ensure
     the checksum is matching
 .DESCRIPTION
-    Compares a possible included .md5 checksum file with the provided binary
+    Compares a possible included .sha256 checksum file with the provided binary
     to ensure they are identical
 .FUNCTIONALITY
-    Compares a binary within a .zip file to a included .md5 to ensure
+    Compares a binary within a .zip file to a included .sha256 to ensure
     the checksum is matching.
 .EXAMPLE
     PS>Test-IcingaZipBinaryChecksum -Path 'C:\Program Files\icinga-service\icinga-service.exe';
 .PARAMETER Path
-    Path to the binary to be checked for. A Corresponding .md5 file with the
-    extension added on the file is required, like icinga-service.exe.md5
+    Path to the binary to be checked for. A Corresponding .sha256 file with the
+    extension added on the file is required, like icinga-service.exe.sha256
 .INPUTS
    System.String
 .OUTPUTS
@@ -27,18 +27,18 @@ function Test-IcingaZipBinaryChecksum()
         $Path
     );
 
-    $MD5Path = [string]::Format('{0}.md5', $Path);
+    $SHA256Path = [string]::Format('{0}.sha256', $Path);
 
-    if ((Test-Path $MD5Path) -eq $FALSE) {
-        return $TRUE;
+    if ((Test-Path $SHA256Path) -eq $FALSE) {
+        return $FALSE;
     }
 
-    [string]$MD5Checksum = Get-Content $MD5Path;
-    $MD5Checksum         = ($MD5Checksum.Split(' ')[0]).ToLower();
+    [string]$SHA256Checksum = Get-Content $SHA256Path;
+    $SHA256Checksum         = ($SHA256Checksum.Split(' ')[0]).ToLower();
 
-    $FileHash = ((Get-IcingaFileHash $Path -Algorithm MD5).Hash).ToLower();
+    $FileHash = ((Get-IcingaFileHash $Path -Algorithm SHA256).Hash).ToLower();
 
-    if ($MD5Checksum -ne $FileHash) {
+    if ($SHA256Checksum -ne $FileHash) {
         return $FALSE;
     }
 

--- a/lib/core/framework/Uninstall-IcingaForWindowsService.psm1
+++ b/lib/core/framework/Uninstall-IcingaForWindowsService.psm1
@@ -55,7 +55,7 @@ function Uninstall-IcingaForWindowsService()
     $ServiceFolderContent = Get-ChildItem -Path $ServiceData.Directory;
 
     foreach ($entry in $ServiceFolderContent) {
-        if ($entry.Name -eq 'icinga-service.exe' -Or $entry.Name -eq 'icinga-service.exe.md5' -Or $entry.Name -eq 'icinga-service.exe.update') {
+        if ($entry.Name -eq 'icinga-service.exe' -Or $entry.Name -eq 'icinga-service.exe.md5' -Or $entry.Name -eq 'icinga-service.exe.sha256' -Or $entry.Name -eq 'icinga-service.exe.update') {
             Remove-Item $entry.FullName -Force;
             Write-IcingaConsoleNotice 'Removing file "{0}"' -Objects $entry.FullName;
         }


### PR DESCRIPTION
Fixes possible FIPS exception on some Windows machines, caused by `MD5` hash algorithm used to verify the service binary file integrity after download instead of `SHA256`

Fixes #783