### PR TITLE
Feature: Changes CPU counter being used for measurement to % Processor Time

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -29,6 +29,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#11](https://github.com/Icinga/icinga-powershell-framework/pull/11) Adds feature to update the cache for performance counter instances to keep track of system changes
 * [#838](https://github.com/Icinga/icinga-powershell-framework/pull/838) Enhances Icinga for Windows to never load and user PowerShell profiles
 * [#841](https://github.com/Icinga/icinga-powershell-framework/pull/841) Adds new [INFO] state for notice and un-checked monitoring objects
+* [#849](https://github.com/Icinga/icinga-powershell-framework/pull/849) Changes CPU provider to use the `\Processor(*)\% Processor Time` counter instead of `\Processor Information(*)\% Processor Utility`
 
 ## 1.13.3 (2025-05-08)
 

--- a/lib/core/framework/New-IcingaEnvironmentVariable.psm1
+++ b/lib/core/framework/New-IcingaEnvironmentVariable.psm1
@@ -103,5 +103,6 @@ function New-IcingaEnvironmentVariable()
                 'FetchedServices'    = $FALSE;
             }
         );
+        $Global:Icinga.Protected.Add('CPUSockets', (Get-IcingaWindowsInformation Win32_Processor).Count);
     }
 }


### PR DESCRIPTION
Changes CPU provider to use the `\Processor(*)\% Processor Time` counter instead of `\Processor Information(*)\% Processor Utility`