### PR TITLE
Fix: Issue with user updates on domain controllers in case the domain is included in the update

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -27,6 +27,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#835](https://github.com/Icinga/icinga-powershell-framework/pull/835) Fixes JEA compiler to always enforce a rebuild of the Framework to ensure integrity of JEA profiles
 * [#836](https://github.com/Icinga/icinga-powershell-framework/issues/836) Fixes Metric over Time collector not working on Windows 2012 R2 and older
 * [#845](https://github.com/Icinga/icinga-powershell-framework/issues/845) Fixes a bunch of issues present in the New-IcingaCheck component, resulting in non-desired output value
+* [#851](https://github.com/Icinga/icinga-powershell-framework/pull/851) Fixes an issue with user updates on domain controllers, which included the domain besides the user name, causing the user updates to fail
 
 ### Enhancements
 

--- a/lib/core/windows/New-IcingaWindowsUser.psm1
+++ b/lib/core/windows/New-IcingaWindowsUser.psm1
@@ -38,7 +38,7 @@ function New-IcingaWindowsUser()
             [bool]$Success = $FALSE;
 
             while ($Attempts -lt 10) {
-                $Result = Start-IcingaProcess -Executable 'net' -Arguments ([string]::Format('user "{0}" "{1}"', $IcingaUser, (ConvertFrom-IcingaSecureString -SecureString (New-IcingaWindowsUserPassword))));
+                $Result = Start-IcingaProcess -Executable 'net' -Arguments ([string]::Format('user "{0}" "{1}"', $IcingaUserInfo.User, (ConvertFrom-IcingaSecureString -SecureString (New-IcingaWindowsUserPassword))));
 
                 if ($Result.ExitCode -eq 0) {
                     $Success = $TRUE;
@@ -49,7 +49,7 @@ function New-IcingaWindowsUser()
             }
 
             if ($Success -eq $FALSE) {
-                Write-IcingaConsoleError 'Failed to update password for user "{0}": {1}' -Objects $IcingaUser, $Result.Error;
+                Write-IcingaConsoleError 'Failed to update password for user "{0}": {1}' -Objects $IcingaUserInfo.User, $Result.Error;
 
                 return @{
                     'User' = $UserConfig.Caption;
@@ -58,7 +58,7 @@ function New-IcingaWindowsUser()
             }
             Write-IcingaConsoleNotice 'User updated successfully.';
         } else {
-            Write-IcingaConsoleWarning 'User "{0}" is not managed by Icinga for Windows. No changes were made.' -Objects $IcingaUser;
+            Write-IcingaConsoleWarning 'User "{0}" is not managed by Icinga for Windows. No changes were made.' -Objects $IcingaUserInfo.User;
         }
 
         return @{
@@ -69,7 +69,7 @@ function New-IcingaWindowsUser()
 
     # Access our local Account Database
     $AccountDB        = [ADSI]"WinNT://$Env:COMPUTERNAME,Computer";
-    $IcingaUserObject = $AccountDB.Create("User", $IcingaUser);
+    $IcingaUserObject = $AccountDB.Create("User", $IcingaUserInfo.User);
     $IcingaUserObject.SetPassword((ConvertFrom-IcingaSecureString -SecureString (New-IcingaWindowsUserPassword)));
     $IcingaUserObject.SetInfo();
     $IcingaUserObject.FullName    = $UserMetadata.FullName;


### PR DESCRIPTION
Fixes an issue with user updates on domain controllers, which included the domain besides the user name, causing the user updates to fail