### PR TITLE
Fix: Exception on Icinga Agent information fetching from registry

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -17,6 +17,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#764](https://github.com/Icinga/icinga-powershell-framework/issues/764) Fixes an issue with the information fetching from the registry for the Icinga Agent, which can throw unhandled exceptions in case of malicious characters in the registry entries
 * [#783](https://github.com/Icinga/icinga-powershell-framework/issues/783) Fixes possible FIPS exception on some Windows machines, caused by `MD5` hash algorithm used to verify the service binary file integrity after download instead of `SHA256`
 * [#814](https://github.com/Icinga/icinga-powershell-framework/pull/814) Fixes random chars function to truly generate unpredictable character sequences and to replace `Get-Random` which is not entirely secure
 * [#815](https://github.com/Icinga/icinga-powershell-framework/pull/815) Fixes a possible crash for `Test-IcingaAddTypeExist`, causing the Icinga for Windows installation to fail when third party components are checked which are malfunctioning

--- a/lib/core/icingaagent/getters/Get-IcingaAgentInstallation.psm1
+++ b/lib/core/icingaagent/getters/Get-IcingaAgentInstallation.psm1
@@ -9,7 +9,7 @@ function Get-IcingaAgentInstallation()
         $regPath = @('HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*', 'HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*');
     }
 
-    $RegistryData = Get-ItemProperty $regPath;
+    $RegistryData = Get-ItemProperty $regPath -ErrorAction SilentlyContinue;
     $IcingaData   = $null;
     foreach ($entry in $RegistryData) {
         if ($null -eq $entry -or $null -eq $entry.DisplayName) {


### PR DESCRIPTION
Fixes an issue with the information fetching from the registry for the Icinga Agent, which can throw unhandled exceptions in case of malicious characters in the registry entries

Fixes #764