### PR TITLE
Fix: Renew certificate job to properly update permissions for the correct user

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -30,6 +30,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#836](https://github.com/Icinga/icinga-powershell-framework/issues/836) Fixes Metric over Time collector not working on Windows 2012 R2 and older
 * [#845](https://github.com/Icinga/icinga-powershell-framework/issues/845) Fixes a bunch of issues present in the New-IcingaCheck component, resulting in non-desired output value
 * [#851](https://github.com/Icinga/icinga-powershell-framework/pull/851) Fixes an issue with user updates on domain controllers, which included the domain besides the user name, causing the user updates to fail
+* [#854](https://github.com/Icinga/icinga-powershell-framework/pull/854) Fixes an issue with the renew certificate job, which updated file permissions with the wrong user `NT Authority\NetworkService` instead of the correct assigned user
 
 ### Enhancements
 

--- a/jobs/RenewCertificate.ps1
+++ b/jobs/RenewCertificate.ps1
@@ -1,6 +1,6 @@
-Use-Icinga -Minimal;
+Use-Icinga;
 
-# This script will simply install the Icinga for Windows certificate everyime the
+# This script will simply install the Icinga for Windows certificate every time the
 # scheduled task is running. This does not impact our system at all, because we
 # can update the certificate at any time without having to worry about the state
 


### PR DESCRIPTION
Fixes an issue with the renew certificate job, which updated file permissions with the wrong user `NT Authority\NetworkService` instead of the correct assigned user