### PR TITLE
Fix: ACL handling on non-english Windows versions

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -31,6 +31,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#845](https://github.com/Icinga/icinga-powershell-framework/issues/845) Fixes a bunch of issues present in the New-IcingaCheck component, resulting in non-desired output value
 * [#851](https://github.com/Icinga/icinga-powershell-framework/pull/851) Fixes an issue with user updates on domain controllers, which included the domain besides the user name, causing the user updates to fail
 * [#854](https://github.com/Icinga/icinga-powershell-framework/pull/854) Fixes an issue with the renew certificate job, which updated file permissions with the wrong user `NT Authority\NetworkService` instead of the correct assigned user
+* [#855](https://github.com/Icinga/icinga-powershell-framework/issues/855) Fixes an issue with ACL permission handling on non-english Windows versions by looking up the correct names by their underlying SID
 
 ### Enhancements
 


### PR DESCRIPTION
Fixes an issue with ACL permission handling on non-english Windows versions by looking up the correct names by their underlying SID

Fixes #855