### PR TITLE
Fix: Icinga CA Importer should not import custom CA's into the cert store

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
+## 1.15.0 (2026-06-30)
+
+[Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/45)
+
+### Bugfixes
+
+* [#874](https://github.com/Icinga/icinga-powershell-framework/pull/874) Fixes Icinga CA importer to only import the CA from our "Icinga CA" into the Windows cert store, leaving custom CA's alone, as they are handled seperately on environments anyway.
+
 ## 1.14.2 (2026-03-31)
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/44)

--- a/lib/webserver/Test-IcingaCAInstalledToAuthRoot.psm1
+++ b/lib/webserver/Test-IcingaCAInstalledToAuthRoot.psm1
@@ -8,6 +8,14 @@ function Test-IcingaCAInstalledToAuthRoot()
 
     $IcingaCACert = New-Object Security.Cryptography.X509Certificates.X509Certificate2 $IcingaCAFile;
 
+    # If the issuer of our CA is not the "Icinga CA", always return true as this is a custom CA then.
+    # Generally speaking, custom CA's are handled properly anyway so this is the correct behavior.
+    if ($IcingaCACert.Issuer -ne 'CN=Icinga CA') {
+        $IcingaCACert = $null;
+
+        return $TRUE;
+    }
+
     [bool]$IcingaCAInstalled = $FALSE;
 
     Get-ChildItem -Recurse -Path 'Cert:\LocalMachine\AuthRoot\' | Where-Object {


### PR DESCRIPTION
Fixes Icinga CA importer to only import the CA from our "Icinga CA" into the Windows cert store, leaving custom CA's alone, as they are handled seperately on environments anyway.