### PR TITLE
Fix: Returns unknown when no metrics over time data exists

### DIFF
--- a/lib/icinga/plugin/New-IcingaCheck.psm1
+++ b/lib/icinga/plugin/New-IcingaCheck.psm1
@@ -529,9 +529,10 @@ function New-IcingaCheck()
         param ($ThresholdObject, $State);
 
         if ($ThresholdObject.HasError) {
-            $this.SetUnknown() | Out-Null;
-            $this.__ThresholdObject = $ThresholdObject;
-            $this.__FixedState = $TRUE;
+            $this.__HandleAsNoticeObject = $FALSE;
+            $this.__ThresholdObject      = $ThresholdObject;
+            $this.__CheckState           = $IcingaEnums.IcingaExitCode.Unknown;
+            $this.__FixedState           = $TRUE;
             $this.__SetCheckOutput($this.__ThresholdObject.Message);
             $this.__LockState();
             return;


### PR DESCRIPTION
When `-ThresholdInterval` is used but no metrics data has been collected, `Compare-IcingaPluginThresholds` returns `HasError = $true' but the problem is how that error is handled which causes a loop. This proposed fix now returns a graceful `[UNKNOWN]` with `[Failed to parse metrics over time with -ThresholdInterval "<whatever you specified>": No data found...]`