### PR TITLE
Fix #873: ThresholdInterval throws StackOverflowException.

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
+## 1.15.0 (2026-06-30)
+
+[Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/44)
+
+### Bugfixes
+
+* [#873](https://github.com/Icinga/icinga-powershell-framework/issues/873) Fixes `StackOverflowException` while using `-ThresholdInterval` if no Metrics over Time are present [@bewshy]
+
 ## 1.14.2 (2026-03-31)
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/44)

--- a/lib/icinga/plugin/New-IcingaCheck.psm1
+++ b/lib/icinga/plugin/New-IcingaCheck.psm1
@@ -529,10 +529,11 @@ function New-IcingaCheck()
         param ($ThresholdObject, $State);
 
         if ($ThresholdObject.HasError) {
-            $this.SetUnknown() | Out-Null;
-            $this.__ThresholdObject = $ThresholdObject;
-            $this.__FixedState = $TRUE;
-            $this.__SetCheckOutput($this.__ThresholdObject.Message);
+	    $this.__HandleAsNoticeObject = $FALSE;
+            $this.__ThresholdObject      = $ThresholdObject;
+            $this.__CheckState           = $IcingaEnums.IcingaExitCode.Unknown;
+	    $this.__FixedState           = $TRUE;
+	    $this.__SetCheckOutput($this.__ThresholdObject.Message);
             $this.__LockState();
             return;
         }

--- a/lib/icinga/plugin/New-IcingaCheck.psm1
+++ b/lib/icinga/plugin/New-IcingaCheck.psm1
@@ -529,11 +529,11 @@ function New-IcingaCheck()
         param ($ThresholdObject, $State);
 
         if ($ThresholdObject.HasError) {
-	    $this.__HandleAsNoticeObject = $FALSE;
+	        $this.__HandleAsNoticeObject = $FALSE;
             $this.__ThresholdObject      = $ThresholdObject;
             $this.__CheckState           = $IcingaEnums.IcingaExitCode.Unknown;
-	    $this.__FixedState           = $TRUE;
-	    $this.__SetCheckOutput($this.__ThresholdObject.Message);
+	        $this.__FixedState           = $TRUE;
+	        $this.__SetCheckOutput($this.__ThresholdObject.Message);
             $this.__LockState();
             return;
         }


### PR DESCRIPTION
When -ThresholdInterval is used but no metrics data has been collected, Compare-IcingaPluginThresholds returns HasError = $true' but the problem is how that error is handled which causes a loop. This proposed fix now returns a graceful [UNKNOWN]with[Failed to parse metrics over time with -ThresholdInterval "": No data found...]`