### PR TITLE
Fix: Percentage threshold comparison

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-framework/milestones?state=closed).
 
+## 1.15.0 (2026-06-30)
+
+[Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/44)
+
+### Bugfixes
+
+* [#877](https://github.com/Icinga/icinga-powershell-framework/pull/877) Fixes threshold comparison while using `%`-Values, which caused falsely report of `Warning` threshold being larger than `Critical` threshold
+
 ## 1.14.2 (2026-03-31)
 
 [Issues and PRs](https://github.com/Icinga/icinga-powershell-framework/milestone/44)

--- a/lib/core/tools/Convert-IcingaPluginThresholds.psm1
+++ b/lib/core/tools/Convert-IcingaPluginThresholds.psm1
@@ -314,7 +314,11 @@ function Convert-IcingaPluginThresholds()
 
     switch ($RetValue.Mode) {
         $IcingaEnums.IcingaThresholdMethod.Default {
-            $RetValue.Value = $ConvertedValue[0];
+            if (Test-Numeric $ConvertedValue[0]) {
+                $RetValue.Value = [decimal]$ConvertedValue[0];
+            } else {
+                $RetValue.Value = $ConvertedValue[0];
+            }
 
             if ([string]::IsNullOrEmpty($RetValue.Value)) {
                 Exit-IcingaThrowException -CustomMessage ([string]::Format('Could not convert the provided threshold value {0} to a valid Icinga for Windows range', $RetValue.Raw)) -ExceptionType 'Input' -ExceptionThrown $IcingaExceptions.Inputs.InvalidThresholdValue -Force;
@@ -323,7 +327,11 @@ function Convert-IcingaPluginThresholds()
             break;
         };
         $IcingaEnums.IcingaThresholdMethod.Lower {
-            $RetValue.Value = $ConvertedValue[0];
+            if (Test-Numeric $ConvertedValue[0]) {
+                $RetValue.Value = [decimal]$ConvertedValue[0];
+            } else {
+                $RetValue.Value = $ConvertedValue[0];
+            }
 
             if ([string]::IsNullOrEmpty($RetValue.Value)) {
                 Exit-IcingaThrowException -CustomMessage ([string]::Format('Could not convert the provided threshold value {0} to a valid Icinga for Windows range', $RetValue.Raw)) -ExceptionType 'Input' -ExceptionThrown $IcingaExceptions.Inputs.InvalidThresholdValue -Force;
@@ -332,7 +340,11 @@ function Convert-IcingaPluginThresholds()
             break;
         };
         $IcingaEnums.IcingaThresholdMethod.Greater {
-            $RetValue.Value = $ConvertedValue[1];
+            if (Test-Numeric $ConvertedValue[1]) {
+                $RetValue.Value = [decimal]$ConvertedValue[1];
+            } else {
+                $RetValue.Value = $ConvertedValue[1];
+            }
 
             if ([string]::IsNullOrEmpty($RetValue.Value)) {
                 Exit-IcingaThrowException -CustomMessage ([string]::Format('Could not convert the provided threshold value {0} to a valid Icinga for Windows range', $RetValue.Raw)) -ExceptionType 'Input' -ExceptionThrown $IcingaExceptions.Inputs.InvalidThresholdValue -Force;


### PR DESCRIPTION
Fixes threshold comparison while using `%`-Values, which caused falsely report of `Warning` threshold being larger than `Critical` threshold

Fixes #877