### PR TITLE
Fix: Certificate renew-loops if Icinga Agent is not installed

### DIFF
--- a/doc/100-General/10-Changelog.md
+++ b/doc/100-General/10-Changelog.md
@@ -13,6 +13,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ### Bugfixes
 
+* [#871](https://github.com/Icinga/icinga-powershell-framework/issues/871) Fixes endless certificate renew loops in some edge-cases where neither a local certificate is configured and the Icinga Agent is not installed
 * [#873](https://github.com/Icinga/icinga-powershell-framework/issues/873) Fixes `StackOverflowException` while using `-ThresholdInterval` if no Metrics over Time are present [@bewshy]
 * [#874](https://github.com/Icinga/icinga-powershell-framework/pull/874) Fixes Icinga CA importer to only import the CA from our "Icinga CA" into the Windows cert store, leaving custom CA's alone, as they are handled seperately on environments anyway.
 * [#877](https://github.com/Icinga/icinga-powershell-framework/pull/877) Fixes threshold comparison while using `%`-Values, which caused falsely report of `Warning` threshold being larger than `Critical` threshold

--- a/jobs/RenewCertificate.ps1
+++ b/jobs/RenewCertificate.ps1
@@ -22,6 +22,12 @@ if ($RegisteredBackgroundDaemons.ContainsKey('Start-IcingaWindowsRESTApi')) {
     }
 }
 
+# If we do not provide a custom certificate path and the Icinga Agent is not installed on the host, we can skip this entire procedure
+# as we will never be able to create a certificate from nothing
+if ([string]::IsNullOrEmpty($CertificatePath) -And -not $Global:Icinga.Protected.Environment.'Icinga Service'.Present) {
+    exit 0;
+}
+
 # Wait during the initial run as long as the certificate is not available
 while ($TRUE) {
     Install-IcingaForWindowsCertificate -CertFile $CertificatePath;


### PR DESCRIPTION
Fixes endless certificate renew loops in some edge-cases where neither a local certificate is configured and the Icinga Agent is not installed

Fixes #871